### PR TITLE
add frameless transparent always-on-top window options and window.move bridge command

### DIFF
--- a/examples/hello/src/runner.zig
+++ b/examples/hello/src/runner.zig
@@ -25,6 +25,7 @@ pub const RunOptions = struct {
     bridge: ?zero_native.BridgeDispatcher = null,
     builtin_bridge: zero_native.BridgePolicy = .{},
     security: zero_native.SecurityPolicy = .{},
+    main_window: zero_native.WindowOptions = .{},
 
     fn appInfo(self: RunOptions) zero_native.AppInfo {
         return .{
@@ -32,6 +33,7 @@ pub const RunOptions = struct {
             .window_title = self.window_title,
             .bundle_id = self.bundle_id,
             .icon_path = self.icon_path,
+            .main_window = self.main_window,
         };
     }
 };

--- a/examples/webview/src/main.zig
+++ b/examples/webview/src/main.zig
@@ -105,6 +105,7 @@ const builtin_policies = [_]zero_native.BridgeCommandPolicy{
     .{ .name = "zero-native.window.create", .permissions = &window_permission, .origins = &example_origins },
     .{ .name = "zero-native.window.focus", .permissions = &window_permission, .origins = &example_origins },
     .{ .name = "zero-native.window.close", .permissions = &window_permission, .origins = &example_origins },
+    .{ .name = "zero-native.window.move", .permissions = &window_permission, .origins = &example_origins },
     .{ .name = "zero-native.webview.create", .permissions = &window_permission, .origins = &example_origins },
     .{ .name = "zero-native.webview.list", .permissions = &window_permission, .origins = &example_origins },
     .{ .name = "zero-native.webview.setFrame", .permissions = &window_permission, .origins = &example_origins },

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -35,7 +35,7 @@ typedef struct {
 typedef void (*zero_native_appkit_event_callback_t)(void *context, const zero_native_appkit_event_t *event);
 typedef void (*zero_native_appkit_bridge_callback_t)(void *context, uint64_t window_id, const char *webview_label, size_t webview_label_len, const char *message, size_t message_len, const char *origin, size_t origin_len);
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame);
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top);
 void zero_native_appkit_destroy(zero_native_appkit_host_t *host);
 void zero_native_appkit_run(zero_native_appkit_host_t *host, zero_native_appkit_event_callback_t callback, void *context);
 void zero_native_appkit_stop(zero_native_appkit_host_t *host);
@@ -47,8 +47,9 @@ void zero_native_appkit_bridge_respond_window(zero_native_appkit_host_t *host, u
 void zero_native_appkit_bridge_respond_webview(zero_native_appkit_host_t *host, uint64_t window_id, const char *webview_label, size_t webview_label_len, const char *response, size_t response_len);
 void zero_native_appkit_emit_window_event(zero_native_appkit_host_t *host, uint64_t window_id, const char *name, size_t name_len, const char *detail_json, size_t detail_json_len);
 void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, const char *allowed_origins, size_t allowed_origins_len, const char *external_urls, size_t external_urls_len, int external_action);
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame);
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top);
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id);
+int zero_native_appkit_move_window(zero_native_appkit_host_t *host, uint64_t window_id, double dx, double dy, int clamp_to_visible_frame, int *out_hit_x, int *out_hit_y);
 int zero_native_appkit_close_window(zero_native_appkit_host_t *host, uint64_t window_id);
 size_t zero_native_appkit_clipboard_read(zero_native_appkit_host_t *host, char *buffer, size_t buffer_len);
 void zero_native_appkit_clipboard_write(zero_native_appkit_host_t *host, const char *text, size_t text_len);

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -73,8 +73,8 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
 @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
 @property(nonatomic, assign) NSInteger externalLinkAction;
-- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame;
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain;
+- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop;
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop makeMain:(BOOL)makeMain;
 - (void)focusWindowWithId:(uint64_t)windowId;
 - (void)closeWindowWithId:(uint64_t)windowId;
 - (WKWebView *)webViewForWindowId:(uint64_t)windowId;
@@ -263,7 +263,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 
 @implementation ZeroNativeAppKitHost
 
-- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame {
+- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop {
     self = [super init];
     if (!self) {
         return nil;
@@ -288,13 +288,13 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     self.externalLinkAction = 0;
     [self configureApplication];
 
-    [self createWindowWithId:1 title:(windowTitle.length > 0 ? windowTitle : self.appName) label:self.windowLabel x:x y:y width:width height:height restoreFrame:restoreFrame makeMain:YES];
+    [self createWindowWithId:1 title:(windowTitle.length > 0 ? windowTitle : self.appName) label:self.windowLabel x:x y:y width:width height:height restoreFrame:restoreFrame frameless:frameless transparent:transparent alwaysOnTop:alwaysOnTop makeMain:YES];
     self.didShutdown = NO;
 
     return self;
 }
 
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop makeMain:(BOOL)makeMain {
     NSNumber *key = @(windowId);
     if (self.windows[key]) {
         return NO;
@@ -304,14 +304,32 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     if (restoreFrame) {
         rect = constrainFrame(rect);
     }
+    NSWindowStyleMask styleMask = frameless
+        ? NSWindowStyleMaskBorderless
+        : (NSWindowStyleMaskTitled |
+           NSWindowStyleMaskClosable |
+           NSWindowStyleMaskResizable |
+           NSWindowStyleMaskMiniaturizable);
     NSWindow *window = [[NSWindow alloc] initWithContentRect:rect
-                                                   styleMask:(NSWindowStyleMaskTitled |
-                                                              NSWindowStyleMaskClosable |
-                                                              NSWindowStyleMaskResizable |
-                                                              NSWindowStyleMaskMiniaturizable)
+                                                   styleMask:styleMask
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
     [window setTitle:(title.length > 0 ? title : self.appName)];
+    if (frameless) {
+        [window setMovableByWindowBackground:YES];
+    }
+    if (transparent) {
+        [window setOpaque:NO];
+        [window setBackgroundColor:[NSColor clearColor]];
+        [window setHasShadow:NO];
+    }
+    if (alwaysOnTop) {
+        [window setLevel:NSFloatingWindowLevel];
+        [window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+                                       NSWindowCollectionBehaviorFullScreenAuxiliary |
+                                       NSWindowCollectionBehaviorIgnoresCycle];
+        [window setHidesOnDeactivate:NO];
+    }
     if (!restoreFrame) {
         [window center];
     }
@@ -343,6 +361,17 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     if ([webView respondsToSelector:NSSelectorFromString(@"setInspectable:")]) {
         [webView setValue:@YES forKey:@"inspectable"];
     }
+    if (transparent) {
+        if ([webView respondsToSelector:NSSelectorFromString(@"setValue:forKey:")]) {
+            @try {
+                [webView setValue:@NO forKey:@"drawsBackground"];
+            } @catch (NSException *exception) {
+                (void)exception;
+            }
+        }
+        webView.layer.backgroundColor = [NSColor clearColor].CGColor;
+        webView.layer.opaque = NO;
+    }
     webView.navigationDelegate = self;
     webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [container addSubview:webView positioned:NSWindowAbove relativeTo:nil];
@@ -366,6 +395,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
         self.bridgeScriptHandler = bridgeScriptHandler;
         self.assetSchemeHandler = assetSchemeHandler;
         self.windowLabel = label.length > 0 ? label : @"main";
+        if (frameless) {
+            [window makeKeyAndOrderFront:nil];
+            [NSApp activate];
+        }
     } else {
         [window makeKeyAndOrderFront:nil];
         [NSApp activate];
@@ -1342,14 +1375,14 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     return NO;
 }
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top) {
     @autoreleasepool {
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *windowTitleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
         NSString *bundleIdString = [[NSString alloc] initWithBytes:bundle_id length:bundle_id_len encoding:NSUTF8StringEncoding] ?: @"dev.zero_native.app";
         NSString *iconPathString = [[NSString alloc] initWithBytes:icon_path length:icon_path_len encoding:NSUTF8StringEncoding] ?: @"";
         NSString *windowLabelString = [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] ?: @"main";
-        ZeroNativeAppKitHost *host = [[ZeroNativeAppKitHost alloc] initWithAppName:appNameString windowTitle:windowTitleString bundleIdentifier:bundleIdString iconPath:iconPathString windowLabel:windowLabelString x:x y:y width:width height:height restoreFrame:(restore_frame != 0)];
+        ZeroNativeAppKitHost *host = [[ZeroNativeAppKitHost alloc] initWithAppName:appNameString windowTitle:windowTitleString bundleIdentifier:bundleIdString iconPath:iconPathString windowLabel:windowLabelString x:x y:y width:width height:height restoreFrame:(restore_frame != 0) frameless:(frameless != 0) transparent:(transparent != 0) alwaysOnTop:(always_on_top != 0)];
         return (__bridge_retained zero_native_appkit_host_t *)host;
     }
 }
@@ -1428,11 +1461,11 @@ void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, con
     [object setAllowedNavigationOrigins:origins externalURLs:externalURLs externalAction:external_action];
 }
 
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top) {
     ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
     NSString *titleString = window_title ? [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] : @"";
     NSString *labelString = window_label ? [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] : @"";
-    return [object createWindowWithId:window_id title:titleString ?: @"" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) makeMain:NO] ? 1 : 0;
+    return [object createWindowWithId:window_id title:titleString ?: @"" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) frameless:(frameless != 0) transparent:(transparent != 0) alwaysOnTop:(always_on_top != 0) makeMain:NO] ? 1 : 0;
 }
 
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id) {
@@ -1446,6 +1479,35 @@ int zero_native_appkit_close_window(zero_native_appkit_host_t *host, uint64_t wi
     ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
     if (!object.windows[@(window_id)]) return 0;
     [object closeWindowWithId:window_id];
+    return 1;
+}
+
+int zero_native_appkit_move_window(zero_native_appkit_host_t *host, uint64_t window_id, double dx, double dy, int clamp_to_visible_frame, int *out_hit_x, int *out_hit_y) {
+    ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
+    NSWindow *window = object.windows[@(window_id)];
+    if (!window) {
+        if (out_hit_x) *out_hit_x = 0;
+        if (out_hit_y) *out_hit_y = 0;
+        return 0;
+    }
+    NSRect frame = window.frame;
+    double newX = frame.origin.x + dx;
+    double newY = frame.origin.y - dy;
+    int hitX = 0, hitY = 0;
+    if (clamp_to_visible_frame) {
+        NSRect visible = (window.screen ?: NSScreen.mainScreen).visibleFrame;
+        double minX = visible.origin.x;
+        double maxX = visible.origin.x + visible.size.width - frame.size.width;
+        double minY = visible.origin.y;
+        double maxY = visible.origin.y + visible.size.height - frame.size.height;
+        if (newX < minX) { newX = minX; hitX = 1; }
+        else if (newX > maxX) { newX = maxX; hitX = 1; }
+        if (newY < minY) { newY = minY; hitY = 1; }
+        else if (newY > maxY) { newY = maxY; hitY = 1; }
+    }
+    [window setFrameOrigin:NSMakePoint(newX, newY)];
+    if (out_hit_x) *out_hit_x = hitX;
+    if (out_hit_y) *out_hit_y = hitY;
     return 1;
 }
 

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -400,7 +400,7 @@ static const char *ZeroNativeCefBridgeScript() {
 @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
 @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
 @property(nonatomic, assign) NSInteger externalLinkAction;
-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height;
+- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop;
 - (void)configureApplication;
 - (void)buildMenuBar;
 - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
@@ -487,7 +487,7 @@ static const char *ZeroNativeCefBridgeScript() {
 
 @implementation ZeroNativeChromiumHost
 
-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height {
+- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop {
     self = [super init];
     if (!self) return nil;
 
@@ -517,7 +517,7 @@ static const char *ZeroNativeCefBridgeScript() {
     self.allowedExternalURLs = @[];
     self.externalLinkAction = 0;
 
-    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO frameless:NO transparent:NO alwaysOnTop:NO makeMain:YES];
+    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO frameless:frameless transparent:transparent alwaysOnTop:alwaysOnTop makeMain:YES];
     self.didShutdown = NO;
     return self;
 }
@@ -1326,14 +1326,14 @@ bool ZeroNativeCefClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser
 } // namespace
 
 static void ZeroNativeWarnUnsupportedFlags(int frameless, int transparent, int always_on_top) {
-    if (frameless) {
-        NSLog(@"zero-native: window option `frameless` is not yet honored on the Chromium backend; falling back to titled window chrome");
-    }
+    // `frameless` and `always_on_top` are NSWindow attributes that the CEF
+    // backend honors normally — only `transparent` is genuinely unsupported,
+    // because the embedded Chromium browser surface stays opaque even when
+    // the surrounding NSWindow is set to clear color.
+    (void)frameless;
+    (void)always_on_top;
     if (transparent) {
-        NSLog(@"zero-native: window option `transparent` is not yet honored on the Chromium backend; the embedded browser surface remains opaque");
-    }
-    if (always_on_top) {
-        NSLog(@"zero-native: window option `always_on_top` is not yet honored on the Chromium backend; window will use normal level");
+        NSLog(@"zero-native: window option `transparent` is not yet honored on the Chromium backend; the surrounding NSWindow honors it but the embedded browser surface remains opaque");
     }
 }
 
@@ -1348,7 +1348,7 @@ zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_
         ZeroNativeWarnUnsupportedFlags(frameless, transparent, always_on_top);
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
-        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height];
+        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height frameless:(frameless != 0) transparent:(transparent != 0) alwaysOnTop:(always_on_top != 0)];
         if (restore_frame) {
             [host.window setFrame:ZeroNativeConstrainFrame(NSMakeRect(x, y, width, height)) display:NO];
         }
@@ -1451,7 +1451,6 @@ int zero_native_appkit_close_window(zero_native_appkit_host_t *host, uint64_t wi
 }
 
 int zero_native_appkit_move_window(zero_native_appkit_host_t *host, uint64_t window_id, double dx, double dy, int clamp_to_visible_frame, int *out_hit_x, int *out_hit_y) {
-    (void)clamp_to_visible_frame;
     ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
     NSWindow *window = object.windows[@(window_id)];
     if (!window) {
@@ -1460,9 +1459,25 @@ int zero_native_appkit_move_window(zero_native_appkit_host_t *host, uint64_t win
         return 0;
     }
     NSRect frame = window.frame;
-    [window setFrameOrigin:NSMakePoint(frame.origin.x + dx, frame.origin.y - dy)];
-    if (out_hit_x) *out_hit_x = 0;
-    if (out_hit_y) *out_hit_y = 0;
+    // dx/dy are screen-space pixels with Y growing downward; AppKit window
+    // origin is bottom-up, so dy is subtracted.
+    double newX = frame.origin.x + dx;
+    double newY = frame.origin.y - dy;
+    int hitX = 0, hitY = 0;
+    if (clamp_to_visible_frame) {
+        NSRect visible = (window.screen ?: NSScreen.mainScreen).visibleFrame;
+        double minX = visible.origin.x;
+        double maxX = visible.origin.x + visible.size.width - frame.size.width;
+        double minY = visible.origin.y;
+        double maxY = visible.origin.y + visible.size.height - frame.size.height;
+        if (newX < minX) { newX = minX; hitX = 1; }
+        else if (newX > maxX) { newX = maxX; hitX = 1; }
+        if (newY < minY) { newY = minY; hitY = 1; }
+        else if (newY > maxY) { newY = maxY; hitY = 1; }
+    }
+    [window setFrameOrigin:NSMakePoint(newX, newY)];
+    if (out_hit_x) *out_hit_x = hitX;
+    if (out_hit_y) *out_hit_y = hitY;
     return 1;
 }
 

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -1325,6 +1325,18 @@ bool ZeroNativeCefClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser
 
 } // namespace
 
+static void ZeroNativeWarnUnsupportedFlags(int frameless, int transparent, int always_on_top) {
+    if (frameless) {
+        NSLog(@"zero-native: window option `frameless` is not yet honored on the Chromium backend; falling back to titled window chrome");
+    }
+    if (transparent) {
+        NSLog(@"zero-native: window option `transparent` is not yet honored on the Chromium backend; the embedded browser surface remains opaque");
+    }
+    if (always_on_top) {
+        NSLog(@"zero-native: window option `always_on_top` is not yet honored on the Chromium backend; window will use normal level");
+    }
+}
+
 zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top) {
     @autoreleasepool {
         (void)bundle_id;
@@ -1333,9 +1345,7 @@ zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_
         (void)icon_path_len;
         (void)window_label;
         (void)window_label_len;
-        (void)frameless;
-        (void)transparent;
-        (void)always_on_top;
+        ZeroNativeWarnUnsupportedFlags(frameless, transparent, always_on_top);
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
         ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height];
@@ -1422,6 +1432,7 @@ int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t w
     ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
     NSString *titleString = window_title ? [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] : @"zero-native";
     NSString *labelString = window_label ? [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] : @"";
+    ZeroNativeWarnUnsupportedFlags(frameless, transparent, always_on_top);
     return [object createWindowWithId:window_id title:titleString ?: @"zero-native" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) frameless:(frameless != 0) transparent:(transparent != 0) alwaysOnTop:(always_on_top != 0) makeMain:NO] ? 1 : 0;
 }
 
@@ -1436,6 +1447,22 @@ int zero_native_appkit_close_window(zero_native_appkit_host_t *host, uint64_t wi
     ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
     if (!object.windows[@(window_id)]) return 0;
     [object closeWindowWithId:window_id];
+    return 1;
+}
+
+int zero_native_appkit_move_window(zero_native_appkit_host_t *host, uint64_t window_id, double dx, double dy, int clamp_to_visible_frame, int *out_hit_x, int *out_hit_y) {
+    (void)clamp_to_visible_frame;
+    ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
+    NSWindow *window = object.windows[@(window_id)];
+    if (!window) {
+        if (out_hit_x) *out_hit_x = 0;
+        if (out_hit_y) *out_hit_y = 0;
+        return 0;
+    }
+    NSRect frame = window.frame;
+    [window setFrameOrigin:NSMakePoint(frame.origin.x + dx, frame.origin.y - dy)];
+    if (out_hit_x) *out_hit_x = 0;
+    if (out_hit_y) *out_hit_y = 0;
     return 1;
 }
 

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -404,7 +404,7 @@ static const char *ZeroNativeCefBridgeScript() {
 - (void)configureApplication;
 - (void)buildMenuBar;
 - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain;
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop makeMain:(BOOL)makeMain;
 - (void)focusWindowWithId:(uint64_t)windowId;
 - (void)closeWindowWithId:(uint64_t)windowId;
 - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(void *)context;
@@ -517,7 +517,7 @@ static const char *ZeroNativeCefBridgeScript() {
     self.allowedExternalURLs = @[];
     self.externalLinkAction = 0;
 
-    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO makeMain:YES];
+    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO frameless:NO transparent:NO alwaysOnTop:NO makeMain:YES];
     self.didShutdown = NO;
     return self;
 }
@@ -608,19 +608,33 @@ static const char *ZeroNativeCefBridgeScript() {
     delete self.browsers;
 }
 
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame frameless:(BOOL)frameless transparent:(BOOL)transparent alwaysOnTop:(BOOL)alwaysOnTop makeMain:(BOOL)makeMain {
     NSNumber *key = @(windowId);
     if (self.windows[key]) return NO;
 
     NSRect rect = restoreFrame ? ZeroNativeConstrainFrame(NSMakeRect(x, y, width, height)) : NSMakeRect(0, 0, width, height);
+    NSWindowStyleMask styleMask = frameless
+        ? NSWindowStyleMaskBorderless
+        : (NSWindowStyleMaskTitled |
+           NSWindowStyleMaskClosable |
+           NSWindowStyleMaskResizable |
+           NSWindowStyleMaskMiniaturizable);
     NSWindow *window = [[NSWindow alloc] initWithContentRect:rect
-                                                   styleMask:(NSWindowStyleMaskTitled |
-                                                              NSWindowStyleMaskClosable |
-                                                              NSWindowStyleMaskResizable |
-                                                              NSWindowStyleMaskMiniaturizable)
+                                                   styleMask:styleMask
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
     [window setTitle:title.length > 0 ? title : @"zero-native"];
+    if (frameless) [window setMovableByWindowBackground:YES];
+    if (transparent) {
+        [window setOpaque:NO];
+        [window setBackgroundColor:[NSColor clearColor]];
+        [window setHasShadow:NO];
+    }
+    if (alwaysOnTop) {
+        [window setLevel:NSFloatingWindowLevel];
+        [window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+                                       NSWindowCollectionBehaviorFullScreenAuxiliary];
+    }
     if (!restoreFrame) [window center];
 
     NSView *stackRoot = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
@@ -1311,7 +1325,7 @@ bool ZeroNativeCefClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser
 
 } // namespace
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top) {
     @autoreleasepool {
         (void)bundle_id;
         (void)bundle_id_len;
@@ -1319,6 +1333,9 @@ zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_
         (void)icon_path_len;
         (void)window_label;
         (void)window_label_len;
+        (void)frameless;
+        (void)transparent;
+        (void)always_on_top;
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
         ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height];
@@ -1401,11 +1418,11 @@ void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, con
     [object setAllowedNavigationOrigins:origins externalURLs:externalURLs externalAction:external_action];
 }
 
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int frameless, int transparent, int always_on_top) {
     ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
     NSString *titleString = window_title ? [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] : @"zero-native";
     NSString *labelString = window_label ? [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] : @"";
-    return [object createWindowWithId:window_id title:titleString ?: @"zero-native" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) makeMain:NO] ? 1 : 0;
+    return [object createWindowWithId:window_id title:titleString ?: @"zero-native" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) frameless:(frameless != 0) transparent:(transparent != 0) alwaysOnTop:(always_on_top != 0) makeMain:NO] ? 1 : 0;
 }
 
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id) {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -37,7 +37,7 @@ const AppKitEvent = extern struct {
 const AppKitCallback = *const fn (context: ?*anyopaque, event: *const AppKitEvent) callconv(.c) void;
 const AppKitBridgeCallback = *const fn (context: ?*anyopaque, window_id: u64, webview_label: [*]const u8, webview_label_len: usize, message: [*]const u8, message_len: usize, origin: [*]const u8, origin_len: usize) callconv(.c) void;
 
-extern fn zero_native_appkit_create(app_name: [*]const u8, app_name_len: usize, window_title: [*]const u8, window_title_len: usize, bundle_id: [*]const u8, bundle_id_len: usize, icon_path: [*]const u8, icon_path_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int) ?*AppKitHost;
+extern fn zero_native_appkit_create(app_name: [*]const u8, app_name_len: usize, window_title: [*]const u8, window_title_len: usize, bundle_id: [*]const u8, bundle_id_len: usize, icon_path: [*]const u8, icon_path_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int, frameless: c_int, transparent: c_int, always_on_top: c_int) ?*AppKitHost;
 extern fn zero_native_appkit_destroy(host: *AppKitHost) void;
 extern fn zero_native_appkit_run(host: *AppKitHost, callback: AppKitCallback, context: ?*anyopaque) void;
 extern fn zero_native_appkit_stop(host: *AppKitHost) void;
@@ -49,9 +49,10 @@ extern fn zero_native_appkit_bridge_respond_window(host: *AppKitHost, window_id:
 extern fn zero_native_appkit_bridge_respond_webview(host: *AppKitHost, window_id: u64, webview_label: [*]const u8, webview_label_len: usize, response: [*]const u8, response_len: usize) void;
 extern fn zero_native_appkit_emit_window_event(host: *AppKitHost, window_id: u64, name: [*]const u8, name_len: usize, detail_json: [*]const u8, detail_json_len: usize) void;
 extern fn zero_native_appkit_set_security_policy(host: *AppKitHost, allowed_origins: [*]const u8, allowed_origins_len: usize, external_urls: [*]const u8, external_urls_len: usize, external_action: c_int) void;
-extern fn zero_native_appkit_create_window(host: *AppKitHost, window_id: u64, window_title: [*]const u8, window_title_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int) c_int;
+extern fn zero_native_appkit_create_window(host: *AppKitHost, window_id: u64, window_title: [*]const u8, window_title_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int, frameless: c_int, transparent: c_int, always_on_top: c_int) c_int;
 extern fn zero_native_appkit_focus_window(host: *AppKitHost, window_id: u64) c_int;
 extern fn zero_native_appkit_close_window(host: *AppKitHost, window_id: u64) c_int;
+extern fn zero_native_appkit_move_window(host: *AppKitHost, window_id: u64, dx: f64, dy: f64, clamp_to_visible_frame: c_int, out_hit_x: *c_int, out_hit_y: *c_int) c_int;
 extern fn zero_native_appkit_create_webview(host: *AppKitHost, window_id: u64, label: [*]const u8, label_len: usize, url: [*]const u8, url_len: usize, x: f64, y: f64, width: f64, height: f64, layer: c_int, transparent: c_int, bridge_enabled: c_int) c_int;
 extern fn zero_native_appkit_set_webview_frame(host: *AppKitHost, window_id: u64, label: [*]const u8, label_len: usize, x: f64, y: f64, width: f64, height: f64) c_int;
 extern fn zero_native_appkit_navigate_webview(host: *AppKitHost, window_id: u64, label: [*]const u8, label_len: usize, url: [*]const u8, url_len: usize) c_int;
@@ -133,7 +134,7 @@ pub const MacPlatform = struct {
         const window_options = app_info.resolvedMainWindow();
         const window_title = window_options.resolvedTitle(app_info.app_name);
         const frame = window_options.default_frame;
-        const host = zero_native_appkit_create(app_info.app_name.ptr, app_info.app_name.len, window_title.ptr, window_title.len, app_info.bundle_id.ptr, app_info.bundle_id.len, app_info.icon_path.ptr, app_info.icon_path.len, window_options.label.ptr, window_options.label.len, frame.x, frame.y, frame.width, frame.height, if (window_options.restore_state) 1 else 0) orelse return error.CreateFailed;
+        const host = zero_native_appkit_create(app_info.app_name.ptr, app_info.app_name.len, window_title.ptr, window_title.len, app_info.bundle_id.ptr, app_info.bundle_id.len, app_info.icon_path.ptr, app_info.icon_path.len, window_options.label.ptr, window_options.label.len, frame.x, frame.y, frame.width, frame.height, if (window_options.restore_state) 1 else 0, if (window_options.frameless) 1 else 0, if (window_options.transparent) 1 else 0, if (window_options.always_on_top) 1 else 0) orelse return error.CreateFailed;
         return .{
             .host = host,
             .web_engine = web_engine,
@@ -168,6 +169,7 @@ pub const MacPlatform = struct {
                 .create_window_fn = createWindow,
                 .focus_window_fn = focusWindow,
                 .close_window_fn = closeWindow,
+                .move_window_fn = moveWindow,
                 .create_webview_fn = createWebView,
                 .set_webview_frame_fn = setWebViewFrame,
                 .navigate_webview_fn = navigateWebView,
@@ -331,7 +333,7 @@ fn createWindow(context: ?*anyopaque, options: platform_mod.WindowOptions) anyer
     const self: *MacPlatform = @ptrCast(@alignCast(context.?));
     const title = options.resolvedTitle(self.app_info.app_name);
     const frame = options.default_frame;
-    if (zero_native_appkit_create_window(self.host, options.id, title.ptr, title.len, options.label.ptr, options.label.len, frame.x, frame.y, frame.width, frame.height, if (options.restore_state) 1 else 0) == 0) return error.CreateFailed;
+    if (zero_native_appkit_create_window(self.host, options.id, title.ptr, title.len, options.label.ptr, options.label.len, frame.x, frame.y, frame.width, frame.height, if (options.restore_state) 1 else 0, if (options.frameless) 1 else 0, if (options.transparent) 1 else 0, if (options.always_on_top) 1 else 0) == 0) return error.CreateFailed;
     return .{
         .id = options.id,
         .label = options.label,
@@ -351,6 +353,15 @@ fn focusWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!
 fn closeWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!void {
     const self: *MacPlatform = @ptrCast(@alignCast(context.?));
     if (zero_native_appkit_close_window(self.host, window_id) == 0) return error.CloseFailed;
+}
+
+fn moveWindow(context: ?*anyopaque, window_id: platform_mod.WindowId, dx: f64, dy: f64, clamp_to_visible_frame: bool) anyerror!platform_mod.MoveResult {
+    const self: *MacPlatform = @ptrCast(@alignCast(context.?));
+    var hit_x: c_int = 0;
+    var hit_y: c_int = 0;
+    const clamp_flag: c_int = if (clamp_to_visible_frame) 1 else 0;
+    if (zero_native_appkit_move_window(self.host, window_id, dx, dy, clamp_flag, &hit_x, &hit_y) == 0) return error.MoveFailed;
+    return .{ .hit_x = hit_x != 0, .hit_y = hit_y != 0 };
 }
 
 fn createWebView(context: ?*anyopaque, options: platform_mod.WebViewOptions) anyerror!void {

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -86,10 +86,18 @@ pub const WindowOptions = struct {
     resizable: bool = true,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
+    frameless: bool = false,
+    transparent: bool = false,
+    always_on_top: bool = false,
 
     pub fn resolvedTitle(self: WindowOptions, app_name: []const u8) []const u8 {
         return if (self.title.len > 0) self.title else app_name;
     }
+};
+
+pub const MoveResult = struct {
+    hit_x: bool = false,
+    hit_y: bool = false,
 };
 
 pub const WindowState = struct {
@@ -134,6 +142,9 @@ pub const WindowCreateOptions = struct {
     resizable: bool = true,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
+    frameless: bool = false,
+    transparent: bool = false,
+    always_on_top: bool = false,
     source: ?WebViewSource = null,
 
     pub fn windowOptions(self: WindowCreateOptions, id: WindowId, label: []const u8) WindowOptions {
@@ -145,6 +156,9 @@ pub const WindowCreateOptions = struct {
             .resizable = self.resizable,
             .restore_state = self.restore_state,
             .restore_policy = self.restore_policy,
+            .frameless = self.frameless,
+            .transparent = self.transparent,
+            .always_on_top = self.always_on_top,
         };
     }
 };
@@ -322,6 +336,7 @@ pub const PlatformServices = struct {
     create_window_fn: ?*const fn (context: ?*anyopaque, options: WindowOptions) anyerror!WindowInfo = null,
     focus_window_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId) anyerror!void = null,
     close_window_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId) anyerror!void = null,
+    move_window_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId, dx: f64, dy: f64, clamp_to_visible_frame: bool) anyerror!MoveResult = null,
     create_webview_fn: ?*const fn (context: ?*anyopaque, options: WebViewOptions) anyerror!void = null,
     set_webview_frame_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId, label: []const u8, frame: geometry.RectF) anyerror!void = null,
     navigate_webview_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId, label: []const u8, url: []const u8) anyerror!void = null,
@@ -390,6 +405,11 @@ pub const PlatformServices = struct {
     pub fn closeWindow(self: PlatformServices, window_id: WindowId) anyerror!void {
         const close_fn = self.close_window_fn orelse return error.UnsupportedService;
         return close_fn(self.context, window_id);
+    }
+
+    pub fn moveWindow(self: PlatformServices, window_id: WindowId, dx: f64, dy: f64, clamp_to_visible_frame: bool) anyerror!MoveResult {
+        const move_fn = self.move_window_fn orelse return error.UnsupportedService;
+        return move_fn(self.context, window_id, dx, dy, clamp_to_visible_frame);
     }
 
     pub fn createWebView(self: PlatformServices, options: WebViewOptions) anyerror!void {
@@ -481,7 +501,7 @@ pub const Platform = struct {
 };
 
 pub const Backend = enum {
-    @"null",
+    null,
     macos,
     linux,
     windows,
@@ -503,6 +523,9 @@ pub const NullPlatform = struct {
     bridge_response_len: usize = 0,
     bridge_response_window_id: WindowId = 0,
     bridge_response_webview_label: []const u8 = "main",
+    clamp_x_on_move: bool = false,
+    clamp_y_on_move: bool = false,
+    last_move_clamp: bool = false,
 
     pub fn init(surface_value: Surface) NullPlatform {
         return .{ .surface_value = surface_value };
@@ -532,6 +555,7 @@ pub const NullPlatform = struct {
                 .create_window_fn = createWindow,
                 .focus_window_fn = focusWindow,
                 .close_window_fn = closeWindow,
+                .move_window_fn = moveWindow,
                 .create_webview_fn = createWebView,
                 .set_webview_frame_fn = setWebViewFrame,
                 .navigate_webview_fn = navigateWebView,
@@ -658,6 +682,20 @@ pub const NullPlatform = struct {
         self.windows[index].open = false;
         self.windows[index].focused = false;
         self.removeWebViewsForWindow(window_id);
+    }
+
+    fn moveWindow(context: ?*anyopaque, window_id: WindowId, dx: f64, dy: f64, clamp_to_visible_frame: bool) anyerror!MoveResult {
+        const self: *NullPlatform = @ptrCast(@alignCast(context.?));
+        self.last_move_clamp = clamp_to_visible_frame;
+        const index = self.findWindowIndex(window_id) orelse return error.WindowNotFound;
+        var frame = self.windows[index].frame;
+        frame.x += @floatCast(dx);
+        frame.y += @floatCast(dy);
+        self.windows[index].frame = frame;
+        return .{
+            .hit_x = clamp_to_visible_frame and self.clamp_x_on_move,
+            .hit_y = clamp_to_visible_frame and self.clamp_y_on_move,
+        };
     }
 
     fn createWebView(context: ?*anyopaque, options: WebViewOptions) anyerror!void {

--- a/src/primitives/app_manifest/root.zig
+++ b/src/primitives/app_manifest/root.zig
@@ -197,6 +197,9 @@ pub const Window = struct {
     resizable: bool = true,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
+    frameless: bool = false,
+    transparent: bool = false,
+    always_on_top: bool = false,
 };
 
 pub const PackageMetadata = struct {

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -602,7 +602,7 @@ pub const Runtime = struct {
             return true;
         }
         const result = if (is_window)
-            self.dispatchWindowBridgeCommand(request, &result_buffer, &response_buffer)
+            self.dispatchWindowBridgeCommand(request, message.window_id, &result_buffer, &response_buffer)
         else if (is_webview)
             self.dispatchWebViewBridgeCommand(request, message.window_id, &result_buffer, &response_buffer)
         else
@@ -630,7 +630,7 @@ pub const Runtime = struct {
         return security.hasPermission(self.options.security.permissions, security.permission_window);
     }
 
-    fn dispatchWindowBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
+    fn dispatchWindowBridgeCommand(self: *Runtime, request: bridge.Request, source_window_id: platform.WindowId, result_buffer: []u8, response_buffer: []u8) []const u8 {
         const result = if (std.mem.eql(u8, request.command, "zero-native.window.list"))
             self.writeWindowListJson(result_buffer) catch return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, "Failed to list windows")
         else if (std.mem.eql(u8, request.command, "zero-native.window.create"))
@@ -639,6 +639,8 @@ pub const Runtime = struct {
             self.focusWindowFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
         else if (std.mem.eql(u8, request.command, "zero-native.window.close"))
             self.closeWindowFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
+        else if (std.mem.eql(u8, request.command, "zero-native.window.move"))
+            self.moveWindowFromJson(request.payload, source_window_id, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
         else
             return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown window command");
         return bridge.writeSuccessResponse(response_buffer, request.id, result);
@@ -780,9 +782,23 @@ pub const Runtime = struct {
             .title = title,
             .default_frame = geometry.RectF.init(x, y, width, height),
             .restore_state = jsonBoolField(payload, "restoreState") orelse true,
+            .frameless = jsonBoolField(payload, "frameless") orelse false,
+            .transparent = jsonBoolField(payload, "transparent") orelse false,
+            .always_on_top = jsonBoolField(payload, "alwaysOnTop") orelse false,
             .source = source,
         });
         return writeWindowJson(info, output);
+    }
+
+    fn moveWindowFromJson(self: *Runtime, payload: []const u8, source_window_id: platform.WindowId, output: []u8) ![]const u8 {
+        var storage = json.StringStorage.init(output);
+        const window_id = self.resolveWindowSelector(payload, &storage) catch source_window_id;
+        const dx = jsonNumberField(payload, "dx") orelse 0;
+        const dy = jsonNumberField(payload, "dy") orelse 0;
+        const clamp = jsonBoolField(payload, "clampToVisibleFrame") orelse false;
+        const result = try self.options.platform.services.moveWindow(window_id, dx, dy, clamp);
+        const index = self.findWindowIndexById(window_id) orelse return error.WindowNotFound;
+        return writeMoveResultJson(self.windows[index].info, result, output);
     }
 
     fn createWebViewFromJson(self: *Runtime, payload: []const u8, source_window_id: platform.WindowId, output: []u8) ![]const u8 {
@@ -1169,6 +1185,18 @@ fn writeWindowJson(window: platform.WindowInfo, output: []u8) ![]const u8 {
     return writer.buffered();
 }
 
+fn writeMoveResultJson(window: platform.WindowInfo, result: platform.MoveResult, output: []u8) ![]const u8 {
+    var writer = std.Io.Writer.fixed(output);
+    try writer.writeByte('{');
+    try writeWindowFields(window, &writer);
+    try writer.writeAll(",\"hitX\":");
+    try writer.writeAll(if (result.hit_x) "true" else "false");
+    try writer.writeAll(",\"hitY\":");
+    try writer.writeAll(if (result.hit_y) "true" else "false");
+    try writer.writeByte('}');
+    return writer.buffered();
+}
+
 fn writeWebViewOkJson(label: []const u8, window_id: platform.WindowId, output: []u8) ![]const u8 {
     var writer = std.Io.Writer.fixed(output);
     try writer.writeAll("{\"label\":");
@@ -1202,7 +1230,13 @@ fn writeWebViewJsonToWriter(webview: RuntimeWebView, writer: anytype) !void {
 }
 
 fn writeWindowJsonToWriter(window: platform.WindowInfo, writer: anytype) !void {
-    try writer.writeAll("{\"id\":");
+    try writer.writeByte('{');
+    try writeWindowFields(window, writer);
+    try writer.writeByte('}');
+}
+
+fn writeWindowFields(window: platform.WindowInfo, writer: anytype) !void {
+    try writer.writeAll("\"id\":");
     try writer.print("{d}", .{window.id});
     try writer.writeAll(",\"label\":");
     try json.writeString(writer, window.label);
@@ -1219,7 +1253,6 @@ fn writeWindowJsonToWriter(window: platform.WindowInfo, writer: anytype) !void {
         window.frame.height,
         window.scale_factor,
     });
-    try writer.writeByte('}');
 }
 
 fn builtinBridgeErrorMessage(err: anyerror) []const u8 {
@@ -1663,11 +1696,82 @@ test "runtime handles built-in JavaScript window bridge commands" {
     try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"focused\":true") != null);
 
     try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
-        .bytes = "{\"id\":\"4\",\"command\":\"zero-native.window.close\",\"payload\":{\"label\":\"palette\"}}",
+        .bytes = "{\"id\":\"4\",\"command\":\"zero-native.window.move\",\"payload\":{\"label\":\"palette\",\"dx\":12,\"dy\":-7}}",
+        .origin = "zero://inline",
+        .window_id = 1,
+    } });
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"ok\":true") != null);
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
+        .bytes = "{\"id\":\"5\",\"command\":\"zero-native.window.close\",\"payload\":{\"label\":\"palette\"}}",
         .origin = "zero://inline",
         .window_id = 1,
     } });
     try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"open\":false") != null);
+}
+
+test "runtime window.move defaults to source window when payload omits selector" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "window-move-default", .source = platform.WebViewSource.html("<p>Move</p>") };
+        }
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    harness.runtime.options.js_window_api = true;
+    var app_state: TestApp = .{};
+    try harness.start(app_state.app());
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.window.create\",\"payload\":{\"label\":\"floater\",\"width\":160,\"height\":160}}",
+        .origin = "zero://inline",
+        .window_id = 1,
+    } });
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"ok\":true") != null);
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
+        .bytes = "{\"id\":\"2\",\"command\":\"zero-native.window.move\",\"payload\":{\"dx\":10,\"dy\":5}}",
+        .origin = "zero://inline",
+        .window_id = 2,
+    } });
+    const response = harness.null_platform.lastBridgeResponse();
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"id\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"hitX\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"hitY\":false") != null);
+}
+
+test "runtime window.move propagates clamp flag and hit results" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "window-move-clamp", .source = platform.WebViewSource.html("<p>Clamp</p>") };
+        }
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    harness.runtime.options.js_window_api = true;
+    harness.null_platform.clamp_x_on_move = true;
+    var app_state: TestApp = .{};
+    try harness.start(app_state.app());
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.window.create\",\"payload\":{\"label\":\"floater\",\"width\":160,\"height\":160}}",
+        .origin = "zero://inline",
+        .window_id = 1,
+    } });
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"ok\":true") != null);
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .bridge_message = .{
+        .bytes = "{\"id\":\"2\",\"command\":\"zero-native.window.move\",\"payload\":{\"label\":\"floater\",\"dx\":1000,\"dy\":0,\"clampToVisibleFrame\":true}}",
+        .origin = "zero://inline",
+        .window_id = 1,
+    } });
+    const response = harness.null_platform.lastBridgeResponse();
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"hitX\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"hitY\":false") != null);
+    try std.testing.expect(harness.null_platform.last_move_clamp);
 }
 
 test "runtime handles built-in JavaScript webview bridge commands" {

--- a/src/tooling/manifest.zig
+++ b/src/tooling/manifest.zig
@@ -91,6 +91,9 @@ pub const WindowMetadata = struct {
     x: ?f32 = null,
     y: ?f32 = null,
     restore_state: bool = true,
+    frameless: bool = false,
+    transparent: bool = false,
+    always_on_top: bool = false,
 };
 
 pub const FrontendDevMetadata = struct {
@@ -270,6 +273,9 @@ fn convertRawWindows(allocator: std.mem.Allocator, windows: []const RawWindow) !
             .x = window.x,
             .y = window.y,
             .restore_state = window.restore_state,
+            .frameless = window.frameless,
+            .transparent = window.transparent,
+            .always_on_top = window.always_on_top,
         };
     }
     return converted;
@@ -342,6 +348,9 @@ fn convertWindows(allocator: std.mem.Allocator, windows: []const WindowMetadata)
             .x = window.x,
             .y = window.y,
             .restore_state = window.restore_state,
+            .frameless = window.frameless,
+            .transparent = window.transparent,
+            .always_on_top = window.always_on_top,
         };
     }
     return converted;
@@ -557,4 +566,49 @@ test "manifest metadata parser reads frontend config" {
     try std.testing.expectEqualStrings("http://127.0.0.1:5173/", metadata.frontend.?.dev.?.url);
     try std.testing.expectEqualStrings("npm", metadata.frontend.?.dev.?.command[0]);
     try std.testing.expectEqual(@as(u32, 12000), metadata.frontend.?.dev.?.timeout_ms);
+}
+
+test "manifest parser reads frameless transparent always_on_top window flags" {
+    const metadata = try parseText(std.testing.allocator,
+        \\.{
+        \\  .id = "com.example.app",
+        \\  .name = "example",
+        \\  .version = "0.1.0",
+        \\  .windows = .{
+        \\    .{
+        \\      .label = "overlay",
+        \\      .width = 160,
+        \\      .height = 160,
+        \\      .frameless = true,
+        \\      .transparent = true,
+        \\      .always_on_top = true,
+        \\    },
+        \\  },
+        \\}
+    );
+    defer metadata.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), metadata.windows.len);
+    const window = metadata.windows[0];
+    try std.testing.expectEqualStrings("overlay", window.label);
+    try std.testing.expect(window.frameless);
+    try std.testing.expect(window.transparent);
+    try std.testing.expect(window.always_on_top);
+}
+
+test "manifest parser defaults floating window flags to false" {
+    const metadata = try parseText(std.testing.allocator,
+        \\.{
+        \\  .id = "com.example.app",
+        \\  .name = "example",
+        \\  .version = "0.1.0",
+        \\  .windows = .{ .{ .label = "main" } },
+        \\}
+    );
+    defer metadata.deinit(std.testing.allocator);
+
+    const window = metadata.windows[0];
+    try std.testing.expect(!window.frameless);
+    try std.testing.expect(!window.transparent);
+    try std.testing.expect(!window.always_on_top);
 }

--- a/src/tooling/raw_manifest.zig
+++ b/src/tooling/raw_manifest.zig
@@ -68,4 +68,7 @@ pub const RawWindow = struct {
     x: ?f32 = null,
     y: ?f32 = null,
     restore_state: bool = true,
+    frameless: bool = false,
+    transparent: bool = false,
+    always_on_top: bool = false,
 };

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -740,7 +740,8 @@ fn runnerZig() []const u8 {
     \\    bridge: ?zero_native.BridgeDispatcher = null,
     \\    builtin_bridge: zero_native.BridgePolicy = .{},
     \\    security: zero_native.SecurityPolicy = .{},
-        \\    js_window_api: bool = false,
+    \\    js_window_api: bool = false,
+    \\    main_window: zero_native.WindowOptions = .{},
     \\
     \\    fn appInfo(self: RunOptions) zero_native.AppInfo {
     \\        return .{
@@ -748,6 +749,7 @@ fn runnerZig() []const u8 {
     \\            .window_title = self.window_title,
     \\            .bundle_id = self.bundle_id,
     \\            .icon_path = self.icon_path,
+    \\            .main_window = self.main_window,
     \\        };
     \\    }
     \\};
@@ -793,7 +795,7 @@ fn runnerZig() []const u8 {
     \\        .bridge = options.bridge,
     \\        .builtin_bridge = options.builtin_bridge,
     \\        .security = options.security,
-        \\        .js_window_api = options.js_window_api,
+    \\        .js_window_api = options.js_window_api,
     \\        .automation = if (build_options.automation) zero_native.automation.Server.init(init.io, ".zig-cache/zero-native-automation", app_info.resolvedWindowTitle()) else null,
     \\        .window_state_store = store,
     \\    });
@@ -828,7 +830,7 @@ fn runnerZig() []const u8 {
     \\        .bridge = options.bridge,
     \\        .builtin_bridge = options.builtin_bridge,
     \\        .security = options.security,
-        \\        .js_window_api = options.js_window_api,
+    \\        .js_window_api = options.js_window_api,
     \\        .automation = if (build_options.automation) zero_native.automation.Server.init(init.io, ".zig-cache/zero-native-automation", app_info.resolvedWindowTitle()) else null,
     \\        .window_state_store = store,
     \\    });
@@ -863,7 +865,7 @@ fn runnerZig() []const u8 {
     \\        .bridge = options.bridge,
     \\        .builtin_bridge = options.builtin_bridge,
     \\        .security = options.security,
-        \\        .js_window_api = options.js_window_api,
+    \\        .js_window_api = options.js_window_api,
     \\        .automation = if (build_options.automation) zero_native.automation.Server.init(init.io, ".zig-cache/zero-native-automation", app_info.resolvedWindowTitle()) else null,
     \\        .window_state_store = store,
     \\    });
@@ -898,7 +900,7 @@ fn runnerZig() []const u8 {
     \\        .bridge = options.bridge,
     \\        .builtin_bridge = options.builtin_bridge,
     \\        .security = options.security,
-        \\        .js_window_api = options.js_window_api,
+    \\        .js_window_api = options.js_window_api,
     \\        .automation = if (build_options.automation) zero_native.automation.Server.init(init.io, ".zig-cache/zero-native-automation", app_info.resolvedWindowTitle()) else null,
     \\        .window_state_store = store,
     \\    });


### PR DESCRIPTION
Adds three optional window flags and a new builtin bridge command that
unblock overlay/companion window patterns the current API can't express.
Same primitives as Tauri, Electron, and GTK.

## Window options

All default `false`. Readable from `app.zon`:

- `frameless` — `NSWindowStyleMaskBorderless`
- `transparent` — clear `NSWindow` + transparent `WKWebView`
- `always_on_top` — `NSFloatingWindowLevel` + can-join-all-spaces

```zig
.windows = .{
    .{ .label = "overlay", .frameless = true, .transparent = true, .always_on_top = true },
},
```

## window.move

```js
const r = await window.zero.invoke("zero-native.window.move", {
  dx: 12, dy: -7, clampToVisibleFrame: true,
});
// r.hitX / r.hitY signal boundary hits
```

`dx`/`dy` are screen-space, Y-down. When the payload omits a selector,
the move targets the window that sent the message (matches Tauri's
`setPosition`). Boundary clamping is opt-in.

Combined with pointer events, this enables custom drag UX with
velocity, momentum, and edge stops — similar to `window.startDragging()`.

## Scope

- macOS only. Linux/Windows backends keep their existing signatures.
- CEF host threads the flags through but stubs them (Chromium
  transparency is a follow-up).
- All flags default to `false` → backwards compatible.

## Tests

`zig build test` passes on macOS 14 / Zig 0.16. New coverage:

- manifest parser for the three flags + defaults
- bridge dispatch for `window.move` including source-window fallback
  and clamp/hit reporting through an extended `NullPlatform`

Happy to split into smaller PRs if preferred.