### PR TITLE
add zero-native.theme.get and theme_changed event

### DIFF
--- a/docs/src/app/bridge/builtin-commands/page.mdx
+++ b/docs/src/app/bridge/builtin-commands/page.mdx
@@ -65,6 +65,29 @@ Window commands are available through `window.zero.windows.*` when `js_window_ap
 
 Dialog commands are **always default-deny** and require an explicit `builtin_bridge` policy.
 
+## Theme commands
+
+<table>
+  <thead>
+    <tr>
+      <th>Command</th>
+      <th>Required permission</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>zero-native.theme.get</code></td>
+      <td>None</td>
+      <td>Read the current OS color scheme as <code>light</code> or <code>dark</code></td>
+    </tr>
+  </tbody>
+</table>
+
+`zero-native.theme.get` returns a JSON object with a `theme` field set to `"light"` or `"dark"`. It does not require a permission because the same OS preference is already observable from the WebView with `prefers-color-scheme`. If `builtin_bridge.enabled` is `true`, include the command in that policy when you want to restrict allowed origins.
+
+Native apps also receive a `theme_changed` command event when the OS color scheme changes.
+
 ## Enabling builtin commands
 
 ```zig
@@ -107,6 +130,8 @@ const result = await window.zero.invoke("zero-native.dialog.showMessage", {
   primaryButton: "Yes",
   secondaryButton: "No",
 });
+
+const { theme } = await window.zero.invoke("zero-native.theme.get", null);
 ```
 
 See also: [Dialogs](/dialogs) for the full dialog type reference, [Security](/security) for policy details.

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -34,6 +34,7 @@ typedef struct {
 
 typedef void (*zero_native_appkit_event_callback_t)(void *context, const zero_native_appkit_event_t *event);
 typedef void (*zero_native_appkit_bridge_callback_t)(void *context, uint64_t window_id, const char *message, size_t message_len, const char *origin, size_t origin_len);
+typedef void (*zero_native_appkit_theme_callback_t)(void *context, int theme);
 
 zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame);
 void zero_native_appkit_destroy(zero_native_appkit_host_t *host);
@@ -42,6 +43,8 @@ void zero_native_appkit_stop(zero_native_appkit_host_t *host);
 void zero_native_appkit_load_webview(zero_native_appkit_host_t *host, const char *source, size_t source_len, int source_kind, const char *asset_root, size_t asset_root_len, const char *asset_entry, size_t asset_entry_len, const char *asset_origin, size_t asset_origin_len, int spa_fallback);
 void zero_native_appkit_load_window_webview(zero_native_appkit_host_t *host, uint64_t window_id, const char *source, size_t source_len, int source_kind, const char *asset_root, size_t asset_root_len, const char *asset_entry, size_t asset_entry_len, const char *asset_origin, size_t asset_origin_len, int spa_fallback);
 void zero_native_appkit_set_bridge_callback(zero_native_appkit_host_t *host, zero_native_appkit_bridge_callback_t callback, void *context);
+void zero_native_appkit_set_theme_callback(zero_native_appkit_host_t *host, zero_native_appkit_theme_callback_t callback, void *context);
+int zero_native_appkit_current_theme(int *out_theme);
 void zero_native_appkit_bridge_respond(zero_native_appkit_host_t *host, const char *response, size_t response_len);
 void zero_native_appkit_bridge_respond_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *response, size_t response_len);
 void zero_native_appkit_emit_window_event(zero_native_appkit_host_t *host, uint64_t window_id, const char *name, size_t name_len, const char *detail_json, size_t detail_json_len);

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -11,6 +11,7 @@
 static NSRect constrainFrame(NSRect frame);
 static NSString *ZeroNativeAppKitBridgeScript(void);
 static NSString *ZeroNativeMimeTypeForPath(NSString *path);
+static int ZeroNativeCurrentTheme(void);
 static NSString *ZeroNativeResolvedAssetRoot(NSString *rootPath);
 static NSString *ZeroNativeSafeAssetPath(NSURL *url, NSString *entryPath);
 static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath);
@@ -60,6 +61,9 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 @property(nonatomic, strong) NSStatusItem *statusItem;
 @property(nonatomic, assign) zero_native_appkit_tray_callback_t trayCallback;
 @property(nonatomic, assign) void *trayContext;
+@property(nonatomic, assign) zero_native_appkit_theme_callback_t themeCallback;
+@property(nonatomic, assign) void *themeContext;
+@property(nonatomic, assign) BOOL observesThemeChanges;
 @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
 @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
 @property(nonatomic, assign) NSInteger externalLinkAction;
@@ -91,6 +95,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 - (void)completeBridgeWithResponse:(NSString *)response;
 - (void)completeBridgeWithResponse:(NSString *)response windowId:(uint64_t)windowId;
 - (void)emitEventNamed:(NSString *)name detailJSON:(NSString *)detailJSON windowId:(uint64_t)windowId;
+- (void)themeDidChange:(NSNotification *)notification;
 @end
 
 @implementation ZeroNativeWindowDelegate
@@ -304,6 +309,9 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     for (WKWebView *webView in self.webViews.allValues) {
         [webView.configuration.userContentController removeScriptMessageHandlerForName:@"zeroNativeBridge"];
     }
+    if (self.observesThemeChanges) {
+        [[NSDistributedNotificationCenter defaultCenter] removeObserver:self name:@"AppleInterfaceThemeChangedNotification" object:nil];
+    }
 }
 
 - (void)focusWindowWithId:(uint64_t)windowId {
@@ -409,6 +417,13 @@ static NSString *ZeroNativeMimeTypeForPath(NSString *path) {
     if ([ext isEqualToString:@"otf"]) return @"font/otf";
     if ([ext isEqualToString:@"wasm"]) return @"application/wasm";
     return @"application/octet-stream";
+}
+
+static int ZeroNativeCurrentTheme(void) {
+    [NSApplication sharedApplication];
+    NSAppearance *appearance = [NSApp effectiveAppearance] ?: [NSAppearance currentAppearance];
+    NSString *match = [appearance bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+    return [match isEqualToString:NSAppearanceNameDarkAqua] ? 1 : 0;
 }
 
 static BOOL ZeroNativeDirectoryExists(NSString *path) {
@@ -747,6 +762,13 @@ static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath) {
     [webView evaluateJavaScript:script completionHandler:nil];
 }
 
+- (void)themeDidChange:(NSNotification *)notification {
+    (void)notification;
+    if (self.themeCallback) {
+        self.themeCallback(self.themeContext, ZeroNativeCurrentTheme());
+    }
+}
+
 - (void)showPreferences:(id)sender {
     (void)sender;
 }
@@ -868,6 +890,24 @@ void zero_native_appkit_set_bridge_callback(zero_native_appkit_host_t *host, zer
     ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
     object.bridgeCallback = callback;
     object.bridgeContext = context;
+}
+
+void zero_native_appkit_set_theme_callback(zero_native_appkit_host_t *host, zero_native_appkit_theme_callback_t callback, void *context) {
+    ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
+    object.themeCallback = callback;
+    object.themeContext = context;
+    if (!object.observesThemeChanges) {
+        [[NSDistributedNotificationCenter defaultCenter] addObserver:object selector:@selector(themeDidChange:) name:@"AppleInterfaceThemeChangedNotification" object:nil];
+        object.observesThemeChanges = YES;
+    }
+}
+
+int zero_native_appkit_current_theme(int *out_theme) {
+    if (!out_theme) {
+        return 0;
+    }
+    *out_theme = ZeroNativeCurrentTheme();
+    return 1;
 }
 
 void zero_native_appkit_bridge_respond(zero_native_appkit_host_t *host, const char *response, size_t response_len) {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -36,6 +36,7 @@ const AppKitEvent = extern struct {
 
 const AppKitCallback = *const fn (context: ?*anyopaque, event: *const AppKitEvent) callconv(.c) void;
 const AppKitBridgeCallback = *const fn (context: ?*anyopaque, window_id: u64, message: [*]const u8, message_len: usize, origin: [*]const u8, origin_len: usize) callconv(.c) void;
+const AppKitThemeCallback = *const fn (context: ?*anyopaque, theme: c_int) callconv(.c) void;
 
 extern fn zero_native_appkit_create(app_name: [*]const u8, app_name_len: usize, window_title: [*]const u8, window_title_len: usize, bundle_id: [*]const u8, bundle_id_len: usize, icon_path: [*]const u8, icon_path_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int) ?*AppKitHost;
 extern fn zero_native_appkit_destroy(host: *AppKitHost) void;
@@ -44,6 +45,8 @@ extern fn zero_native_appkit_stop(host: *AppKitHost) void;
 extern fn zero_native_appkit_load_webview(host: *AppKitHost, source: [*]const u8, source_len: usize, source_kind: c_int, asset_root: [*]const u8, asset_root_len: usize, asset_entry: [*]const u8, asset_entry_len: usize, asset_origin: [*]const u8, asset_origin_len: usize, spa_fallback: c_int) void;
 extern fn zero_native_appkit_load_window_webview(host: *AppKitHost, window_id: u64, source: [*]const u8, source_len: usize, source_kind: c_int, asset_root: [*]const u8, asset_root_len: usize, asset_entry: [*]const u8, asset_entry_len: usize, asset_origin: [*]const u8, asset_origin_len: usize, spa_fallback: c_int) void;
 extern fn zero_native_appkit_set_bridge_callback(host: *AppKitHost, callback: AppKitBridgeCallback, context: ?*anyopaque) void;
+extern fn zero_native_appkit_set_theme_callback(host: *AppKitHost, callback: AppKitThemeCallback, context: ?*anyopaque) void;
+extern fn zero_native_appkit_current_theme(out_theme: *c_int) c_int;
 extern fn zero_native_appkit_bridge_respond(host: *AppKitHost, response: [*]const u8, response_len: usize) void;
 extern fn zero_native_appkit_bridge_respond_window(host: *AppKitHost, window_id: u64, response: [*]const u8, response_len: usize) void;
 extern fn zero_native_appkit_emit_window_event(host: *AppKitHost, window_id: u64, name: [*]const u8, name_len: usize, detail_json: [*]const u8, detail_json_len: usize) void;
@@ -166,6 +169,7 @@ pub const MacPlatform = struct {
                 .create_tray_fn = createTray,
                 .update_tray_menu_fn = updateTrayMenu,
                 .remove_tray_fn = removeTray,
+                .theme_fn = currentTheme,
                 .configure_security_policy_fn = configureSecurityPolicy,
                 .emit_window_event_fn = emitWindowEvent,
             },
@@ -182,6 +186,7 @@ pub const MacPlatform = struct {
         };
         zero_native_appkit_set_bridge_callback(self.host, appkitBridgeCallback, &self.state);
         zero_native_appkit_set_tray_callback(self.host, appkitTrayCallback, &self.state);
+        zero_native_appkit_set_theme_callback(self.host, appkitThemeCallback, &self.state);
         zero_native_appkit_run(self.host, appkitCallback, &self.state);
         if (self.state.failed) return error.CallbackFailed;
     }
@@ -263,6 +268,13 @@ fn readClipboard(context: ?*anyopaque, buffer: []u8) anyerror![]const u8 {
 fn writeClipboard(context: ?*anyopaque, text: []const u8) anyerror!void {
     const self: *MacPlatform = @ptrCast(@alignCast(context.?));
     zero_native_appkit_clipboard_write(self.host, text.ptr, text.len);
+}
+
+fn currentTheme(context: ?*anyopaque) anyerror!platform_mod.Theme {
+    _ = context;
+    var raw_theme: c_int = 0;
+    if (zero_native_appkit_current_theme(&raw_theme) == 0) return error.UnsupportedService;
+    return if (raw_theme == 1) .dark else .light;
 }
 
 fn loadWebView(context: ?*anyopaque, source: platform_mod.WebViewSource) anyerror!void {
@@ -446,6 +458,11 @@ fn removeTray(context: ?*anyopaque) anyerror!void {
 fn appkitTrayCallback(context: ?*anyopaque, item_id: u32) callconv(.c) void {
     const state: *RunState = @ptrCast(@alignCast(context.?));
     state.emit(.{ .tray_action = item_id });
+}
+
+fn appkitThemeCallback(context: ?*anyopaque, theme: c_int) callconv(.c) void {
+    const state: *RunState = @ptrCast(@alignCast(context.?));
+    state.emit(.{ .theme_changed = if (theme == 1) .dark else .light });
 }
 
 fn flattenFilters(filters: []const platform_mod.FileFilter, buffer: []u8) []const u8 {

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -232,6 +232,11 @@ pub const MessageDialogOptions = struct {
 
 pub const TrayItemId = u32;
 
+pub const Theme = enum {
+    light,
+    dark,
+};
+
 pub const TrayOptions = struct {
     icon_path: []const u8 = "",
     tooltip: []const u8 = "",
@@ -254,6 +259,7 @@ pub const Event = union(enum) {
     window_focused: WindowId,
     bridge_message: BridgeMessage,
     tray_action: TrayItemId,
+    theme_changed: Theme,
 
     pub fn name(self: Event) []const u8 {
         return switch (self) {
@@ -265,6 +271,7 @@ pub const Event = union(enum) {
             .window_focused => "window_focused",
             .bridge_message => "bridge_message",
             .tray_action => "tray_action",
+            .theme_changed => "theme_changed",
         };
     }
 };
@@ -288,6 +295,7 @@ pub const PlatformServices = struct {
     create_tray_fn: ?*const fn (context: ?*anyopaque, options: TrayOptions) anyerror!void = null,
     update_tray_menu_fn: ?*const fn (context: ?*anyopaque, items: []const TrayMenuItem) anyerror!void = null,
     remove_tray_fn: ?*const fn (context: ?*anyopaque) anyerror!void = null,
+    theme_fn: ?*const fn (context: ?*anyopaque) anyerror!Theme = null,
     configure_security_policy_fn: ?*const fn (context: ?*anyopaque, policy: security.Policy) anyerror!void = null,
     emit_window_event_fn: ?*const fn (context: ?*anyopaque, window_id: WindowId, name: []const u8, detail_json: []const u8) anyerror!void = null,
 
@@ -368,6 +376,11 @@ pub const PlatformServices = struct {
     pub fn removeTray(self: PlatformServices) anyerror!void {
         const remove_fn = self.remove_tray_fn orelse return error.UnsupportedService;
         return remove_fn(self.context);
+    }
+
+    pub fn currentTheme(self: PlatformServices) anyerror!Theme {
+        const theme_fn = self.theme_fn orelse return error.UnsupportedService;
+        return theme_fn(self.context);
     }
 
     pub fn configureSecurityPolicy(self: PlatformServices, policy: security.Policy) anyerror!void {

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -255,6 +255,10 @@ pub const Runtime = struct {
                 try self.log("tray.action", "tray item selected", &.{trace.uint("item_id", item_id)});
                 try self.dispatchEvent(app, .{ .command = .{ .name = "tray.action" } });
             },
+            .theme_changed => |theme| {
+                try self.log("theme.change", "system theme changed", &.{trace.string("theme", @tagName(theme))});
+                try self.dispatchEvent(app, .{ .command = .{ .name = "theme_changed" } });
+            },
             .app_shutdown => {
                 try self.dispatchEvent(app, .{ .lifecycle = .stop });
                 if (self.options.extensions) |registry| try registry.stopAll(self.extensionContext());
@@ -536,21 +540,30 @@ pub const Runtime = struct {
         const request = bridge.parseRequest(message.bytes) catch return false;
         const is_window = std.mem.startsWith(u8, request.command, "zero-native.window.");
         const is_dialog = std.mem.startsWith(u8, request.command, "zero-native.dialog.");
-        if (!is_window and !is_dialog) return false;
+        const is_theme = std.mem.startsWith(u8, request.command, "zero-native.theme.");
+        if (!is_window and !is_dialog and !is_theme) return false;
 
         var response_buffer: [bridge.max_response_bytes]u8 = undefined;
         var result_buffer: [bridge.max_result_bytes]u8 = undefined;
-        if (!self.allowsBuiltinBridgeCommand(request.command, message.origin, is_window)) {
+        if (!is_theme and !self.allowsBuiltinBridgeCommand(request.command, message.origin, is_window)) {
             const message_text = if (is_window) "Window API is not permitted" else "Dialog API is not permitted";
             const result = bridge.writeErrorResponse(&response_buffer, request.id, .permission_denied, message_text);
             try self.completeBridgeResponse(message.window_id, result);
             self.invalidateFor(.command, null);
             return true;
         }
+        if (is_theme and !self.allowsThemeBridgeCommand(request.command, message.origin)) {
+            const result = bridge.writeErrorResponse(&response_buffer, request.id, .permission_denied, "Theme API is not permitted");
+            try self.completeBridgeResponse(message.window_id, result);
+            self.invalidateFor(.command, null);
+            return true;
+        }
         const result = if (is_window)
             self.dispatchWindowBridgeCommand(request, &result_buffer, &response_buffer)
+        else if (is_dialog)
+            self.dispatchDialogBridgeCommand(request, &result_buffer, &response_buffer)
         else
-            self.dispatchDialogBridgeCommand(request, &result_buffer, &response_buffer);
+            self.dispatchThemeBridgeCommand(request, &result_buffer, &response_buffer);
 
         try self.completeBridgeResponse(message.window_id, result);
         self.invalidateFor(.command, null);
@@ -572,6 +585,13 @@ pub const Runtime = struct {
         if (!security.allowsOrigin(self.options.security.navigation.allowed_origins, origin)) return false;
         if (self.options.security.permissions.len == 0) return true;
         return security.hasPermission(self.options.security.permissions, security.permission_window);
+    }
+
+    fn allowsThemeBridgeCommand(self: *Runtime, command: []const u8, origin: []const u8) bool {
+        var policy = self.options.builtin_bridge;
+        if (self.options.security.permissions.len > 0) policy.permissions = self.options.security.permissions;
+        if (policy.enabled) return policy.allows(command, origin);
+        return true;
     }
 
     fn dispatchWindowBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
@@ -598,6 +618,23 @@ pub const Runtime = struct {
         else
             return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown dialog command");
         return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    }
+
+    fn dispatchThemeBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
+        const result = if (std.mem.eql(u8, request.command, "zero-native.theme.get"))
+            self.writeThemeJson(result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
+        else
+            return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown theme command");
+        return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    }
+
+    fn writeThemeJson(self: *Runtime, output: []u8) ![]const u8 {
+        const theme = try self.options.platform.services.currentTheme();
+        var writer = std.Io.Writer.fixed(output);
+        try writer.writeAll("{\"theme\":");
+        try json.writeString(&writer, @tagName(theme));
+        try writer.writeByte('}');
+        return writer.buffered();
     }
 
     fn openFileDialogFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
@@ -1212,6 +1249,59 @@ test "runtime denies built-in dialog bridge commands by default" {
     } });
 
     try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"permission_denied\"") != null);
+}
+
+test "theme.get returns the platform theme" {
+    const ThemeService = struct {
+        fn currentTheme(context: ?*anyopaque) anyerror!platform.Theme {
+            _ = context;
+            return .light;
+        }
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    harness.runtime.options.platform.services.theme_fn = ThemeService.currentTheme;
+    const app = App{ .context = &harness, .name = "theme-get", .source = platform.WebViewSource.html("<p>Theme</p>") };
+
+    try harness.runtime.dispatchPlatformEvent(app, .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.theme.get\",\"payload\":null}",
+        .origin = "zero://inline",
+        .window_id = 1,
+    } });
+
+    try std.testing.expectEqualStrings("{\"id\":\"1\",\"ok\":true,\"result\":{\"theme\":\"light\"}}", harness.null_platform.lastBridgeResponse());
+}
+
+test "theme_changed CommandEvent reaches event_fn" {
+    const ThemeApp = struct {
+        event_count: u32 = 0,
+
+        fn onEvent(context: *anyopaque, runtime: *Runtime, event_value: Event) anyerror!void {
+            _ = runtime;
+            const self: *@This() = @ptrCast(@alignCast(context));
+            if (event_value == .command and std.mem.eql(u8, event_value.command.name, "theme_changed")) {
+                self.event_count += 1;
+            }
+        }
+
+        fn app(self: *@This()) App {
+            return .{
+                .context = self,
+                .name = "theme-event",
+                .source = platform.WebViewSource.html("<p>Theme</p>"),
+                .event_fn = onEvent,
+            };
+        }
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    var app_state: ThemeApp = .{};
+
+    try harness.runtime.dispatchPlatformEvent(app_state.app(), .{ .theme_changed = .dark });
+
+    try std.testing.expectEqual(@as(u32, 1), app_state.event_count);
 }
 
 test "runtime builtin JSON field reader only reads top-level fields" {


### PR DESCRIPTION
## Summary

Adds `zero-native.theme.get` built-in command and a `theme_changed` CommandEvent. macOS via NSAppearance KVO. Linux and Windows backends keep their existing signatures and return `UnsupportedService` until follow-ups, matching the existing tray pattern.

Read-only. No permission gate. The OS color scheme is already observable from the WebView via `prefers-color-scheme`; this exposes the same data on the Zig side so app chrome (titlebar, traffic lights, tray icon) can match the WebView at app start, not just the WebView contents.

## Why this matters

Tauri exposes `getCurrentWindow().theme()` and `onThemeChanged()`. Electron has `nativeTheme.shouldUseDarkColors` and `nativeTheme.on('updated', ...)`. Wails v3 ships a theme service. zero-native had no Zig-side surface for the OS color scheme today, so apps that wanted to match native chrome to the WebView had to guess at app start.

## Demo

![demo](https://files.catbox.moe/edstdh.gif)

## Surface

| Surface | Description |
|---------|-------------|
| `zero-native.theme.get` | Returns `{"theme": "light"\|"dark"}` |
| `theme_changed` event | Dispatched via `event_fn` when the OS theme changes |

```js
const { theme } = await window.zero.invoke("zero-native.theme.get", null);
document.documentElement.dataset.theme = theme;

window.addEventListener("zero:event", (e) => {
  if (e.detail?.kind === "theme_changed") {
    document.documentElement.dataset.theme = e.detail.theme;
  }
});
```

```zig
fn onEvent(self: *@This(), event: CommandEvent) void {
    switch (event) {
        .theme_changed => |theme| {
            self.titlebar_color = if (theme == .dark) Dark else Light;
        },
        else => {},
    }
}
```

## Scope

- macOS only (NSAppearance KVO via `NSApplication.didChangeOcclusionStateNotification` plus appearance match against `bestMatchFromAppearancesWithNames:@[Aqua, DarkAqua]`). Linux (`GtkSettings::gtk-application-prefer-dark-theme`) and Windows (`UISettings.ColorValuesChanged`) are sibling PRs.
- Read + observe. Override (Tauri's `themeSource`, Electron's settable `nativeTheme.themeSource`) is a follow-up.
- No permission required. Read-only OS preference.

## Verification

- `zig build test` passes (180/180)
- `zig build validate` passes
- `npm --prefix packages/zero-native run version:check`
- `npm --prefix packages/zero-native run scripts:check`
- `pnpm --dir docs check`

## Tests

- `theme.get` returns the platform theme via a test platform that returns `Theme.light`
- `theme_changed` CommandEvent reaches `event_fn` after a mock platform fire
