### PR TITLE
fix broken svelte example

### DIFF
--- a/examples/svelte/frontend/src/main.js
+++ b/examples/svelte/frontend/src/main.js
@@ -1,6 +1,7 @@
+import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
 
-const app = new App({ target: document.getElementById("app") });
+const app = mount(App, { target: document.getElementById("app") });
 
 export default app;


### PR DESCRIPTION
## Summary
Fixes the Svelte example so it renders correctly.

## Problem
Running `zig build run` showed a blank page despite a non-empty `App.svelte`.

## Changes
- Updates the Svelte example to match Svelte 5 behavior

## Before
<img width="729" height="516" alt="Blank Svelte example before fix"
src="https://github.com/user-attachments/assets/58e8d1df-c41a-4597-8dc2-33f1307b5d03" />

## After
<img width="727" height="580" alt="Svelte example rendering after fix"
src="https://github.com/user-attachments/assets/2e249d9d-1634-4ccd-a3a5-f6e319124c11" />

## Testing
- [x] Ran `zig build run` successfully
- [x] Confirmed the Svelte example renders correctly