### PR TITLE
add zero-native.clipboard.readText and writeText built-in commands

### DIFF
--- a/docs/src/app/bridge/builtin-commands/page.mdx
+++ b/docs/src/app/bridge/builtin-commands/page.mdx
@@ -1,6 +1,6 @@
 # Builtin Commands
 
-zero-native provides built-in bridge commands for window management and native dialogs. These are controlled by the `builtin_bridge` policy in `RuntimeOptions`, separate from app-defined commands.
+zero-native provides built-in bridge commands for window management, native dialogs, and clipboard text. These are controlled by the `builtin_bridge` policy in `RuntimeOptions`, separate from app-defined commands.
 
 ## Window commands
 
@@ -65,10 +65,22 @@ Window commands are available through `window.zero.windows.*` when `js_window_ap
 
 Dialog commands are **always default-deny** and require an explicit `builtin_bridge` policy.
 
+## Clipboard commands
+
+| Command | Required permission | Description |
+| --- | --- | --- |
+| `zero-native.clipboard.readText` | `clipboard` | Read text from the system clipboard and return `{"text": string}` |
+| `zero-native.clipboard.writeText` | `clipboard` | Write `{"text": string}` to the system clipboard |
+
+Clipboard commands are **always default-deny**. They require the app-level `clipboard` permission and an explicit `builtin_bridge.commands` policy entry for each command.
+
 ## Enabling builtin commands
 
 ```zig
-const app_permissions = [_][]const u8{zero_native.security.permission_window};
+const app_permissions = [_][]const u8{
+    zero_native.security.permission_window,
+    zero_native.security.permission_clipboard,
+};
 
 .security = .{
     .permissions = &app_permissions,
@@ -81,6 +93,8 @@ const app_permissions = [_][]const u8{zero_native.security.permission_window};
         .{ .name = "zero-native.window.create", .permissions = .{ "window" }, .origins = .{ "zero://app" } },
         .{ .name = "zero-native.dialog.openFile", .origins = .{ "zero://app" } },
         .{ .name = "zero-native.dialog.showMessage", .origins = .{ "zero://app" } },
+        .{ .name = "zero-native.clipboard.readText", .permissions = .{ "clipboard" }, .origins = .{ "zero://app" } },
+        .{ .name = "zero-native.clipboard.writeText", .permissions = .{ "clipboard" }, .origins = .{ "zero://app" } },
     },
 },
 ```
@@ -107,6 +121,9 @@ const result = await window.zero.invoke("zero-native.dialog.showMessage", {
   primaryButton: "Yes",
   secondaryButton: "No",
 });
+
+await window.zero.invoke("zero-native.clipboard.writeText", { text: "Hello" });
+const { text } = await window.zero.invoke("zero-native.clipboard.readText", null);
 ```
 
 See also: [Dialogs](/dialogs) for the full dialog type reference, [Security](/security) for policy details.

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -536,12 +536,18 @@ pub const Runtime = struct {
         const request = bridge.parseRequest(message.bytes) catch return false;
         const is_window = std.mem.startsWith(u8, request.command, "zero-native.window.");
         const is_dialog = std.mem.startsWith(u8, request.command, "zero-native.dialog.");
-        if (!is_window and !is_dialog) return false;
+        const is_clipboard = std.mem.startsWith(u8, request.command, "zero-native.clipboard.");
+        if (!is_window and !is_dialog and !is_clipboard) return false;
 
         var response_buffer: [bridge.max_response_bytes]u8 = undefined;
         var result_buffer: [bridge.max_result_bytes]u8 = undefined;
-        if (!self.allowsBuiltinBridgeCommand(request.command, message.origin, is_window)) {
-            const message_text = if (is_window) "Window API is not permitted" else "Dialog API is not permitted";
+        if (!self.allowsBuiltinBridgeCommand(request.command, message.origin, is_window, is_clipboard)) {
+            const message_text = if (is_window)
+                "Window API is not permitted"
+            else if (is_dialog)
+                "Dialog API is not permitted"
+            else
+                "Clipboard API is not permitted";
             const result = bridge.writeErrorResponse(&response_buffer, request.id, .permission_denied, message_text);
             try self.completeBridgeResponse(message.window_id, result);
             self.invalidateFor(.command, null);
@@ -549,6 +555,8 @@ pub const Runtime = struct {
         }
         const result = if (is_window)
             self.dispatchWindowBridgeCommand(request, &result_buffer, &response_buffer)
+        else if (is_clipboard)
+            self.dispatchClipboardBridgeCommand(request, &result_buffer, &response_buffer)
         else
             self.dispatchDialogBridgeCommand(request, &result_buffer, &response_buffer);
 
@@ -564,10 +572,13 @@ pub const Runtime = struct {
         }
     }
 
-    fn allowsBuiltinBridgeCommand(self: *Runtime, command: []const u8, origin: []const u8, is_window: bool) bool {
+    fn allowsBuiltinBridgeCommand(self: *Runtime, command: []const u8, origin: []const u8, is_window: bool, is_clipboard: bool) bool {
         var policy = self.options.builtin_bridge;
         if (self.options.security.permissions.len > 0) policy.permissions = self.options.security.permissions;
-        if (policy.enabled) return policy.allows(command, origin);
+        if (policy.enabled) {
+            if (is_clipboard and !security.hasPermission(self.options.security.permissions, security.permission_clipboard)) return false;
+            return policy.allows(command, origin);
+        }
         if (!is_window or !self.options.js_window_api) return false;
         if (!security.allowsOrigin(self.options.security.navigation.allowed_origins, origin)) return false;
         if (self.options.security.permissions.len == 0) return true;
@@ -597,6 +608,16 @@ pub const Runtime = struct {
             self.showMessageDialogFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
         else
             return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown dialog command");
+        return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    }
+
+    fn dispatchClipboardBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
+        const result = if (std.mem.eql(u8, request.command, "zero-native.clipboard.readText"))
+            self.readClipboardTextJson(result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
+        else if (std.mem.eql(u8, request.command, "zero-native.clipboard.writeText"))
+            self.writeClipboardTextFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
+        else
+            return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown clipboard command");
         return bridge.writeSuccessResponse(response_buffer, request.id, result);
     }
 
@@ -688,6 +709,23 @@ pub const Runtime = struct {
         var writer = std.Io.Writer.fixed(output);
         try json.writeString(&writer, @tagName(result));
         return writer.buffered();
+    }
+
+    fn readClipboardTextJson(self: *Runtime, output: []u8) ![]const u8 {
+        var clipboard_buffer: [16 * 1024]u8 = undefined;
+        const text = try self.options.platform.services.readClipboard(&clipboard_buffer);
+        var writer = std.Io.Writer.fixed(output);
+        try writer.writeAll("{\"text\":");
+        try json.writeString(&writer, text);
+        try writer.writeByte('}');
+        return writer.buffered();
+    }
+
+    fn writeClipboardTextFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
+        var storage = json.StringStorage.init(output);
+        const text = jsonStringField(payload, "text", &storage) orelse "";
+        try self.options.platform.services.writeClipboard(text);
+        return "{}";
     }
 
     fn createWindowFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
@@ -1212,6 +1250,87 @@ test "runtime denies built-in dialog bridge commands by default" {
     } });
 
     try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"permission_denied\"") != null);
+}
+
+test "clipboard.readText returns the platform value" {
+    const Clipboard = struct {
+        fn read(context: ?*anyopaque, buffer: []u8) anyerror![]const u8 {
+            _ = context;
+            return copyInto(buffer, "hello");
+        }
+    };
+
+    const clipboard_permissions = [_][]const u8{security.permission_clipboard};
+    const policies = [_]bridge.CommandPolicy{
+        .{ .name = "zero-native.clipboard.readText", .permissions = &clipboard_permissions, .origins = &.{"zero://inline"} },
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    harness.runtime.options.platform.services.read_clipboard_fn = Clipboard.read;
+    harness.runtime.options.security.permissions = &clipboard_permissions;
+    harness.runtime.options.builtin_bridge = .{ .enabled = true, .commands = &policies };
+    const app = App{ .context = &harness, .name = "clipboard-read", .source = platform.WebViewSource.html("<p>Clipboard</p>") };
+    try harness.runtime.dispatchPlatformEvent(app, .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.clipboard.readText\",\"payload\":null}",
+        .origin = "zero://inline",
+    } });
+
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"text\":\"hello\"") != null);
+}
+
+test "clipboard.writeText round-trips through the platform" {
+    const Clipboard = struct {
+        var written: [64]u8 = undefined;
+        var written_len: usize = 0;
+
+        fn write(context: ?*anyopaque, text: []const u8) anyerror!void {
+            _ = context;
+            if (text.len > written.len) return error.NoSpaceLeft;
+            @memcpy(written[0..text.len], text);
+            written_len = text.len;
+        }
+    };
+
+    const clipboard_permissions = [_][]const u8{security.permission_clipboard};
+    const policies = [_]bridge.CommandPolicy{
+        .{ .name = "zero-native.clipboard.writeText", .permissions = &clipboard_permissions, .origins = &.{"zero://inline"} },
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    Clipboard.written_len = 0;
+    harness.runtime.options.platform.services.write_clipboard_fn = Clipboard.write;
+    harness.runtime.options.security.permissions = &clipboard_permissions;
+    harness.runtime.options.builtin_bridge = .{ .enabled = true, .commands = &policies };
+    const app = App{ .context = &harness, .name = "clipboard-write", .source = platform.WebViewSource.html("<p>Clipboard</p>") };
+    try harness.runtime.dispatchPlatformEvent(app, .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.clipboard.writeText\",\"payload\":{\"text\":\"world\"}}",
+        .origin = "zero://inline",
+    } });
+
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"ok\":true") != null);
+    try std.testing.expectEqualStrings("world", Clipboard.written[0..Clipboard.written_len]);
+}
+
+test "clipboard requires the clipboard permission" {
+    const clipboard_permissions = [_][]const u8{security.permission_clipboard};
+    const policies = [_]bridge.CommandPolicy{
+        .{ .name = "zero-native.clipboard.readText", .permissions = &clipboard_permissions, .origins = &.{"zero://inline"} },
+    };
+
+    var harness: TestHarness() = undefined;
+    harness.init(.{});
+    harness.runtime.options.builtin_bridge = .{ .enabled = true, .commands = &policies };
+    const app = App{ .context = &harness, .name = "clipboard-denied", .source = platform.WebViewSource.html("<p>Clipboard</p>") };
+    try harness.runtime.dispatchPlatformEvent(app, .{ .bridge_message = .{
+        .bytes = "{\"id\":\"1\",\"command\":\"zero-native.clipboard.readText\",\"payload\":null}",
+        .origin = "zero://inline",
+    } });
+
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "\"permission_denied\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, harness.null_platform.lastBridgeResponse(), "Clipboard API is not permitted") != null);
 }
 
 test "runtime builtin JSON field reader only reads top-level fields" {


### PR DESCRIPTION
## Summary

Adds two built-in bridge commands that expose the existing clipboard `PlatformServices` to JS: `zero-native.clipboard.readText` and `zero-native.clipboard.writeText`. Default-deny via `builtin_bridge.commands` policy and the `clipboard` permission.

## What was already there

The clipboard platform layer was already wired upstream across all three backends. This PR adds only the runtime bridge dispatch glue that exposes it to JS. Specifically:

| Layer | Existing location |
|-------|-------------------|
| `permission_clipboard` constant | `src/security/root.zig:5` |
| `clipboard` enum entry | `src/primitives/app_manifest/root.zig` (`PermissionKind`, `Permission`, `BridgePermissionKind`, `BridgePermission`) |
| `read_clipboard_fn` / `write_clipboard_fn` on `PlatformServices` | `src/platform/root.zig:276-277` |
| macOS NSPasteboard | `src/platform/macos/appkit_host.{h,m}` |
| Linux GTK clipboard | `src/platform/linux/...gtk_host.c` |
| Windows clipboard | `src/platform/windows/...windows_host.cpp` |
| Manifest string parser | `src/tooling/manifest.zig:384,395` |

If you had a different JS API shape in mind, happy to close this and let you ship the dispatch yourself, or rework to match.

## Demo

![demo](https://files.catbox.moe/20j98d.gif)

## Commands

| Command | Permission | Behavior |
|---------|------------|----------|
| `zero-native.clipboard.readText` | `clipboard` | Returns `{"text": "..."}` |
| `zero-native.clipboard.writeText` | `clipboard` | Accepts `{"text": "..."}`, returns `{}` |

```js
await window.zero.invoke("zero-native.clipboard.writeText", { text: "Hello" });
const { text } = await window.zero.invoke("zero-native.clipboard.readText", null);
```

## Scope

- Two text commands. `clear`, `readImage`, `writeImage` are deferred (no existing C ABI for clear; image surface needs separate review).
- Default-deny. Caller must declare the `clipboard` permission and a per-command `builtin_bridge` policy entry. `allowsBuiltinBridgeCommand` checks the permission explicitly when policy is enabled (slightly stricter than `dialog.*`, since clipboard is sensitive surface).
- 16 KB stack buffer for read. Covers typical NSPasteboard text payloads without heap allocation. Open to changing this if you have a different ceiling in mind.

## Verification

- `zig build test` passes (181/181)
- `zig build validate` passes
- `npm --prefix packages/zero-native run version:check`
- `npm --prefix packages/zero-native run scripts:check`
- `pnpm --dir docs check`

## Tests

- `clipboard.readText returns the platform value` (test platform returns a fixed string, dispatch verifies the JSON response)
- `clipboard.writeText round-trips through the platform` (test platform captures writes, dispatch invokes with payload, captured value matches)
- `clipboard requires the clipboard permission` (dispatch without policy enablement returns `permission_denied` with `"Clipboard API is not permitted"`)
