### PR TITLE
Add missing React example type dependencies

### DIFF
--- a/examples/react/frontend/package.json
+++ b/examples/react/frontend/package.json
@@ -13,6 +13,8 @@
     "react-dom": "^19.2.6"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "vite": "^8.0.11"
   }

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -1343,6 +1343,8 @@ fn reactPackageJson(allocator: std.mem.Allocator, names: TemplateNames) ![]const
         \\    "react-dom": "^19.2.6"
         \\  },
         \\  "devDependencies": {
+        \\    "@types/react": "^19.2.14",
+        \\    "@types/react-dom": "^19.2.3",
         \\    "@vitejs/plugin-react": "^6.0.1",
         \\    "vite": "^8.0.11"
         \\  }


### PR DESCRIPTION
## Summary
- add missing React type packages to the checked-in React example frontend
- update the React scaffold template so generated React frontends include the same types packages

## Why
The React example uses .tsx files but does not include React's type packages in devDependencies, leaving editors and type-aware tooling without type definitions for JSX, react, and react-dom/client.
