### PR TITLE
fix(macos): prevent use-after-free when closing a window via JS bridge

### DIFF
--- a/examples/webview/src/main.zig
+++ b/examples/webview/src/main.zig
@@ -64,7 +64,17 @@ const html =
     \\      if (jsWindow) show(await window.zero.windows.focus(jsWindow.id));
     \\    });
     \\    document.querySelector("#close-window").addEventListener("click", async () => {
-    \\      if (jsWindow) show(await window.zero.windows.close(jsWindow.id));
+    \\      try {
+    \\        const list = await window.zero.windows.list();
+    \\        const target = list.find((w) => w.open && w.focused)
+    \\          || list.find((w) => w.open && w.label.startsWith("js-tools-"));
+    \\        if (!target) { show("No window to close"); return; }
+    \\        const result = await window.zero.windows.close(target.id);
+    \\        if (jsWindow && jsWindow.id === target.id) jsWindow = null;
+    \\        show(result);
+    \\      } catch (error) {
+    \\        output.textContent = `${error.code || "error"}: ${error.message}`;
+    \\      }
     \\    });
     \\  </script>
     \\</body>

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -117,20 +117,38 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 - (void)windowWillClose:(NSNotification *)notification {
     (void)notification;
     [self.host emitWindowFrameForWindowId:self.windowId open:NO];
+
     NSNumber *key = @(self.windowId);
     ZeroNativeAppKitHost *host = self.host;
-    BOOL last = (host.windows.count <= 1);
+
+    NSWindow *window = host.windows[key];
+    WKWebView *webView = host.webViews[key];
+    ZeroNativeWindowDelegate *delegate = host.delegates[key];
+    ZeroNativeBridgeScriptHandler *bridgeHandler = host.bridgeScriptHandlers[key];
+    ZeroNativeAssetSchemeHandler *assetHandler = host.assetSchemeHandlers[key];
+    NSString *label = host.windowLabels[key];
+
+    [host.windows removeObjectForKey:key];
+    [host.webViews removeObjectForKey:key];
+    [host.delegates removeObjectForKey:key];
+    [host.bridgeScriptHandlers removeObjectForKey:key];
+    [host.assetSchemeHandlers removeObjectForKey:key];
+    [host.windowLabels removeObjectForKey:key];
+
+    BOOL last = (host.windows.count == 0);
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        [host.windows removeObjectForKey:key];
-        [host.webViews removeObjectForKey:key];
-        [host.delegates removeObjectForKey:key];
-        [host.bridgeScriptHandlers removeObjectForKey:key];
-        [host.assetSchemeHandlers removeObjectForKey:key];
-        [host.windowLabels removeObjectForKey:key];
+        (void)window;
+        (void)webView;
+        (void)delegate;
+        (void)bridgeHandler;
+        (void)assetHandler;
+        (void)label;
     });
+
     if (last) {
-        [self.host emitShutdown];
-        [self.host stop];
+        [host emitShutdown];
+        [host stop];
     }
 }
 

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -118,13 +118,17 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     (void)notification;
     [self.host emitWindowFrameForWindowId:self.windowId open:NO];
     NSNumber *key = @(self.windowId);
-    [self.host.windows removeObjectForKey:key];
-    [self.host.webViews removeObjectForKey:key];
-    [self.host.delegates removeObjectForKey:key];
-    [self.host.bridgeScriptHandlers removeObjectForKey:key];
-    [self.host.assetSchemeHandlers removeObjectForKey:key];
-    [self.host.windowLabels removeObjectForKey:key];
-    if (self.host.windows.count == 0) {
+    ZeroNativeAppKitHost *host = self.host;
+    BOOL last = (host.windows.count <= 1);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [host.windows removeObjectForKey:key];
+        [host.webViews removeObjectForKey:key];
+        [host.delegates removeObjectForKey:key];
+        [host.bridgeScriptHandlers removeObjectForKey:key];
+        [host.assetSchemeHandlers removeObjectForKey:key];
+        [host.windowLabels removeObjectForKey:key];
+    });
+    if (last) {
         [self.host emitShutdown];
         [self.host stop];
     }
@@ -246,6 +250,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
                                                               NSWindowStyleMaskMiniaturizable)
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
+    [window setReleasedWhenClosed:NO];
     [window setTitle:(title.length > 0 ? title : self.appName)];
     if (!restoreFrame) {
         [window center];


### PR DESCRIPTION
### Description:

Closing a window from JS (e.g. `examples/webview` → “Close JS window”, or anything that hits `zero_native_appkit_close_window`) could segfault on macOS. Previously it was tearing down the `WKWebView` and related objects inside `-[ZeroNativeWindowDelegate windowWillClose:]` while AppKit was still finishing its own close work, and `NSWindow` was also left at the default `releasedWhenClosed` (`YES`).

**Fix:** `[window setReleasedWhenClosed:NO]` in `createWindowWithId:`, and move the dictionary cleanup (`removeObjectForKey:` on `windows`, `webViews`, `delegates`, etc.) to the next main-queue turn via `dispatch_async(dispatch_get_main_queue(), ^{ ... })` so AppKit finishes first. `emitShutdown` / `stop` when the last window closes stays synchronous.

**Example:** The close button now uses `window.zero.windows.list()` and closes the focused window (each `WKWebView` has its own JS context, so the old `jsWindow` variable was wrong when you clicked from the child window).

**Tested:** `zig build run` or `zig build run-webview` with the webview example — open/close the JS window a bunch, no crash.

### Files
- `src/platform/macos/appkit_host.m`
- `examples/webview/src/main.zig`