### PR TITLE
Fix duplicate contributor lists in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Extract changelog entry
         run: |
           VERSION="${{ needs.check-release.outputs.version }}"
-          awk '/<!-- release:start -->/{found=1; next} /<!-- release:end -->/{found=0} found{print}' CHANGELOG.md > /tmp/release-notes.md
+          awk '/<!-- release:start -->/{found=1; next} /<!-- release:end -->/{exit} found{print}' CHANGELOG.md > /tmp/release-notes.md
 
           LINES=$(wc -l < /tmp/release-notes.md | tr -d ' ')
           if [ "$LINES" -lt 2 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ All notable changes to zero-native will be documented in this file.
 
 ## 0.1.8
 
-<!-- release:start -->
-
 ### Bug Fixes
 
 - **Install completion delay** - Drain redirected GitHub responses during postinstall so npm exits immediately after the native binary is installed.
@@ -26,11 +24,8 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.7
-
-<!-- release:start -->
 
 ### Improvements
 
@@ -39,11 +34,8 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.6
-
-<!-- release:start -->
 
 ### Improvements
 
@@ -52,11 +44,8 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.5
-
-<!-- release:start -->
 
 ### Bug Fixes
 
@@ -65,11 +54,8 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.4
-
-<!-- release:start -->
 
 ### Bug Fixes
 
@@ -82,11 +68,8 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.3
-
-<!-- release:start -->
 
 ### Bug Fixes
 
@@ -97,7 +80,6 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.2
 


### PR DESCRIPTION
## Summary

- Remove stale `<!-- release:start -->` / `<!-- release:end -->` markers from old changelog entries (0.1.3–0.1.8) so only the latest release is marked
- Change the `awk` extraction in the release workflow to `exit` after the first block instead of resetting, preventing duplicate content if old markers are accidentally left behind