### PR TITLE
fix: resolve CEF Runtime workflow failures across platforms

### DIFF
--- a/.github/workflows/cef-runtime.yml
+++ b/.github/workflows/cef-runtime.yml
@@ -33,8 +33,6 @@ jobs:
         include:
           - platform: macosarm64
             runner: macos-14
-          - platform: macosx64
-            runner: macos-13
           - platform: linux64
             runner: ubuntu-latest
           - platform: linuxarm64
@@ -64,7 +62,13 @@ jobs:
           curl --fail --location --output "zig-out/cef-download/${archive}" "${base}/${archive}"
           curl --fail --location --output "zig-out/cef-download/${archive}.sha256" "${base}/${archive}.sha256"
           expected="$(tr -d '[:space:]' < "zig-out/cef-download/${archive}.sha256")"
-          actual="$(shasum -a 256 "zig-out/cef-download/${archive}" | awk '{print $1}')"
+          if command -v sha256sum &>/dev/null; then
+            actual="$(sha256sum "zig-out/cef-download/${archive}" | awk '{print $1}')"
+          elif command -v shasum &>/dev/null; then
+            actual="$(shasum -a 256 "zig-out/cef-download/${archive}" | awk '{print $1}')"
+          else
+            echo "::error::No SHA-256 hashing utility found"; exit 1
+          fi
           test "$expected" = "$actual"
           tar -xjf "zig-out/cef-download/${archive}" -C zig-out/cef-download
           echo "CEF_ROOT=zig-out/cef-download/${archive%.tar.bz2}" >> "$GITHUB_ENV"
@@ -74,7 +78,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cmake -S "$CEF_ROOT" -B "$CEF_ROOT/build/libcef_dll_wrapper"
+          cmake_args=(-S "$CEF_ROOT" -B "$CEF_ROOT/build/libcef_dll_wrapper")
+          case "${{ matrix.platform }}" in
+            *arm64) cmake_args+=(-DPROJECT_ARCH=arm64) ;;
+          esac
+          cmake "${cmake_args[@]}"
           cmake --build "$CEF_ROOT/build/libcef_dll_wrapper" --target libcef_dll_wrapper --config Release
           mkdir -p "$CEF_ROOT/libcef_dll_wrapper"
           case "${{ matrix.platform }}" in

--- a/.github/workflows/cef-runtime.yml
+++ b/.github/workflows/cef-runtime.yml
@@ -33,6 +33,8 @@ jobs:
         include:
           - platform: macosarm64
             runner: macos-14
+          - platform: macosx64
+            runner: macos-15
           - platform: linux64
             runner: ubuntu-latest
           - platform: linuxarm64
@@ -81,6 +83,7 @@ jobs:
           cmake_args=(-S "$CEF_ROOT" -B "$CEF_ROOT/build/libcef_dll_wrapper")
           case "${{ matrix.platform }}" in
             *arm64) cmake_args+=(-DPROJECT_ARCH=arm64) ;;
+            macosx64) cmake_args+=(-DCMAKE_OSX_ARCHITECTURES=x86_64 -DPROJECT_ARCH=x86_64) ;;
           esac
           cmake "${cmake_args[@]}"
           cmake --build "$CEF_ROOT/build/libcef_dll_wrapper" --target libcef_dll_wrapper --config Release


### PR DESCRIPTION
## Summary

- **Windows** (`windows64`, `windowsarm64`): `shasum` is not available in Git Bash — use `sha256sum` with `shasum` fallback
- **Linux ARM64**: CEF CMake defaults to x86_64 arch flags (`-m64`, `-march=x86-64`) on ARM runners — pass `-DPROJECT_ARCH=arm64` for `*arm64` platforms
- **macOS x64**: `macos-13` Intel runners are no longer reliably available — switch to `macos-15` (ARM64) and cross-compile via `CMAKE_OSX_ARCHITECTURES=x86_64`