### PR TITLE
fix: Windows CEF runtime build failures

### DIFF
--- a/.github/workflows/cef-runtime.yml
+++ b/.github/workflows/cef-runtime.yml
@@ -41,8 +41,10 @@ jobs:
             runner: ubuntu-24.04-arm
           - platform: windows64
             runner: windows-2022
-          - platform: windowsarm64
-            runner: windows-11-arm
+          # windowsarm64 disabled: Zig 0.16.0 aarch64-windows binary is broken
+          # https://codeberg.org/ziglang/zig/issues/31865
+          # - platform: windowsarm64
+          #   runner: windows-11-arm
 
     steps:
       - uses: actions/checkout@v4

--- a/src/tooling/cef.zig
+++ b/src/tooling/cef.zig
@@ -11,6 +11,11 @@ pub const default_windows_dir = "third_party/cef/windows";
 pub const default_dir = "";
 pub const default_release_output_dir = "zig-out/cef";
 
+const sha256_shell_snippet = if (builtin.target.os.tag == .windows)
+    "sha256sum"
+else
+    "shasum -a 256";
+
 pub const Error = error{
     InvalidArguments,
     UnsupportedPlatform,
@@ -436,7 +441,7 @@ fn verifyArchiveChecksum(allocator: std.mem.Allocator, io: std.Io, cache_path: [
     defer allocator.free(quoted_archive);
     const command = try std.fmt.allocPrint(
         allocator,
-        "cd {s} && expected=$(tr -d '[:space:]' < {s}.sha256) && actual=$(shasum -a 256 {s} | awk '{{print $1}}') && if [ \"$expected\" != \"$actual\" ]; then echo \"CEF archive checksum mismatch\" >&2; exit 1; fi",
+        "cd {s} && expected=$(tr -d '[:space:]' < {s}.sha256) && actual=$(" ++ sha256_shell_snippet ++ " {s} | awk '{{print $1}}') && if [ \"$expected\" != \"$actual\" ]; then echo \"CEF archive checksum mismatch\" >&2; exit 1; fi",
         .{ quoted_cache, quoted_archive, quoted_archive },
     );
     defer allocator.free(command);
@@ -460,9 +465,10 @@ pub fn prepareRelease(allocator: std.mem.Allocator, io: std.Io, options: Prepare
     defer allocator.free(quoted_output);
     const quoted_name = try shellQuote(allocator, name);
     defer allocator.free(quoted_name);
+    const force_local = if (builtin.target.os.tag == .windows) " --force-local" else "";
     const command = try std.fmt.allocPrint(
         allocator,
-        "output_dir=$(cd {s} && pwd) && cd {s} && tar -czf \"$output_dir\"/{s} include Release libcef_dll_wrapper $(test -d Resources && echo Resources) $(test -d locales && echo locales)",
+        "output_dir=$(cd {s} && pwd) && cd {s} && tar -czf" ++ force_local ++ " \"$output_dir\"/{s} include Release libcef_dll_wrapper $(test -d Resources && echo Resources) $(test -d locales && echo locales)",
         .{ quoted_output, quoted_dir, quoted_name },
     );
     defer allocator.free(command);
@@ -470,7 +476,7 @@ pub fn prepareRelease(allocator: std.mem.Allocator, io: std.Io, options: Prepare
 
     const sha_command = try std.fmt.allocPrint(
         allocator,
-        "cd {s} && shasum -a 256 {s} | awk '{{print $1}}' > {s}.sha256",
+        "cd {s} && " ++ sha256_shell_snippet ++ " {s} | awk '{{print $1}}' > {s}.sha256",
         .{ quoted_output, quoted_name, quoted_name },
     );
     defer allocator.free(sha_command);


### PR DESCRIPTION
## Summary

- **windows64**: `tar` misinterprets `D:/...` drive letter paths as `host:path` remote syntax — add `--force-local` flag (comptime, only on Windows targets)
- **windows64**: `shasum` unavailable in the Zig tooling code — use `sha256sum` on Windows via comptime `sha256_shell_snippet` constant
- **windowsarm64**: `zig build` segfaults — Zig 0.16.0 `aarch64-windows` binary is broken ([ziglang/zig#31865](https://codeberg.org/ziglang/zig/issues/31865)). Disabled in CI until upstream fix.