### PR TITLE
Add macOS title bar overlay style

### DIFF
--- a/docs/src/app/app-zon/page.mdx
+++ b/docs/src/app/app-zon/page.mdx
@@ -29,7 +29,7 @@ The `app.zon` manifest declares app metadata, permissions, bridge policies, secu
     .web_engine = "system",
     .cef = .{ .dir = "third_party/cef/macos", .auto_install = false },
     .windows = .{
-        .{ .label = "main", .title = "zero-native", .width = 720, .height = 480, .restore_state = true },
+        .{ .label = "main", .title = "zero-native", .title_bar_style = "standard", .width = 720, .height = 480, .restore_state = true },
     },
 }
 ```

--- a/docs/src/app/windows/page.mdx
+++ b/docs/src/app/windows/page.mdx
@@ -8,6 +8,7 @@ zero-native supports multiple windows. The main window is created automatically;
 const info = try runtime.createWindow(.{
     .label = "tools",
     .title = "Tools",
+    .title_bar_style = .overlay,
     .default_frame = zero_native.geometry.RectF.init(80, 80, 420, 320),
 });
 try runtime.focusWindow(info.id);
@@ -33,6 +34,7 @@ Then JavaScript can call the helper from an allowed origin:
 const win = await window.zero.windows.create({
   label: "tools",
   title: "Tools",
+  titleBarStyle: "overlay",
   width: 420,
   height: 320,
 });
@@ -58,7 +60,7 @@ await window.zero.windows.close(win.id);
     </tr>
     <tr>
       <td><code>WindowCreateOptions</code></td>
-      <td>Options for <code>runtime.createWindow()</code>: label, title, frame</td>
+      <td>Options for <code>runtime.createWindow()</code>: label, title, frame, title bar style</td>
     </tr>
     <tr>
       <td><code>WindowInfo</code></td>
@@ -74,6 +76,10 @@ await window.zero.windows.close(win.id);
     </tr>
   </tbody>
 </table>
+
+## macOS title bar style
+
+Use `title_bar_style = .overlay` from Zig, `title_bar_style = "overlay"` in `app.zon`, or `titleBarStyle: "overlay"` from JavaScript to extend the WebView into the native macOS title bar while keeping native window controls. The default `standard` style keeps the normal macOS title bar. Other platforms currently ignore this option.
 
 ## Platform limits
 
@@ -145,6 +151,6 @@ When `saveWindow` is called, the store merges by matching on `label` or `id`, so
 
 ```zig
 .windows = .{
-    .{ .label = "main", .title = "zero-native", .width = 720, .height = 480, .restore_state = true },
+    .{ .label = "main", .title = "zero-native", .title_bar_style = "overlay", .width = 720, .height = 480, .restore_state = true },
 },
 ```

--- a/packages/zero-native/zero-native.d.ts
+++ b/packages/zero-native/zero-native.d.ts
@@ -30,6 +30,7 @@ export interface ZeroNativeCreateWindowOptions {
   height?: number;
   x?: number;
   y?: number;
+  titleBarStyle?: "standard" | "overlay";
   restoreState?: boolean;
   url?: string;
 }

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -35,7 +35,7 @@ typedef struct {
 typedef void (*zero_native_appkit_event_callback_t)(void *context, const zero_native_appkit_event_t *event);
 typedef void (*zero_native_appkit_bridge_callback_t)(void *context, uint64_t window_id, const char *message, size_t message_len, const char *origin, size_t origin_len);
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame);
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style);
 void zero_native_appkit_destroy(zero_native_appkit_host_t *host);
 void zero_native_appkit_run(zero_native_appkit_host_t *host, zero_native_appkit_event_callback_t callback, void *context);
 void zero_native_appkit_stop(zero_native_appkit_host_t *host);
@@ -46,7 +46,7 @@ void zero_native_appkit_bridge_respond(zero_native_appkit_host_t *host, const ch
 void zero_native_appkit_bridge_respond_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *response, size_t response_len);
 void zero_native_appkit_emit_window_event(zero_native_appkit_host_t *host, uint64_t window_id, const char *name, size_t name_len, const char *detail_json, size_t detail_json_len);
 void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, const char *allowed_origins, size_t allowed_origins_len, const char *external_urls, size_t external_urls_len, int external_action);
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame);
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style);
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id);
 int zero_native_appkit_close_window(zero_native_appkit_host_t *host, uint64_t window_id);
 size_t zero_native_appkit_clipboard_read(zero_native_appkit_host_t *host, char *buffer, size_t buffer_len);

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -17,6 +17,7 @@ static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath);
 static NSArray<NSString *> *ZeroNativePolicyListFromBytes(const char *bytes, size_t len, NSArray<NSString *> *fallback);
 static NSString *ZeroNativeOriginForURL(NSURL *url);
 static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
+static void ZeroNativeApplyTitleBarStyle(NSWindow *window, NSInteger style);
 
 @interface ZeroNativeWindowDelegate : NSObject <NSWindowDelegate>
 @property(nonatomic, assign) ZeroNativeAppKitHost *host;
@@ -63,8 +64,8 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
 @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
 @property(nonatomic, assign) NSInteger externalLinkAction;
-- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame;
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain;
+- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle;
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle makeMain:(BOOL)makeMain;
 - (void)focusWindowWithId:(uint64_t)windowId;
 - (void)closeWindowWithId:(uint64_t)windowId;
 - (WKWebView *)webViewForWindowId:(uint64_t)windowId;
@@ -200,7 +201,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 
 @implementation ZeroNativeAppKitHost
 
-- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame {
+- (instancetype)initWithAppName:(NSString *)appName windowTitle:(NSString *)windowTitle bundleIdentifier:(NSString *)bundleIdentifier iconPath:(NSString *)iconPath windowLabel:(NSString *)windowLabel x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle {
     self = [super init];
     if (!self) {
         return nil;
@@ -223,13 +224,13 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     self.externalLinkAction = 0;
     [self configureApplication];
 
-    [self createWindowWithId:1 title:(windowTitle.length > 0 ? windowTitle : self.appName) label:self.windowLabel x:x y:y width:width height:height restoreFrame:restoreFrame makeMain:YES];
+    [self createWindowWithId:1 title:(windowTitle.length > 0 ? windowTitle : self.appName) label:self.windowLabel x:x y:y width:width height:height restoreFrame:restoreFrame titleBarStyle:titleBarStyle makeMain:YES];
     self.didShutdown = NO;
 
     return self;
 }
 
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle makeMain:(BOOL)makeMain {
     NSNumber *key = @(windowId);
     if (self.windows[key]) {
         return NO;
@@ -247,6 +248,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
     [window setTitle:(title.length > 0 ? title : self.appName)];
+    ZeroNativeApplyTitleBarStyle(window, titleBarStyle);
     if (!restoreFrame) {
         [window center];
     }
@@ -815,14 +817,21 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     return NO;
 }
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+static void ZeroNativeApplyTitleBarStyle(NSWindow *window, NSInteger style) {
+    if (style != 1) return;
+    window.titleVisibility = NSWindowTitleHidden;
+    window.titlebarAppearsTransparent = YES;
+    window.styleMask = window.styleMask | NSWindowStyleMaskFullSizeContentView;
+}
+
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style) {
     @autoreleasepool {
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *windowTitleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
         NSString *bundleIdString = [[NSString alloc] initWithBytes:bundle_id length:bundle_id_len encoding:NSUTF8StringEncoding] ?: @"dev.zero_native.app";
         NSString *iconPathString = [[NSString alloc] initWithBytes:icon_path length:icon_path_len encoding:NSUTF8StringEncoding] ?: @"";
         NSString *windowLabelString = [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] ?: @"main";
-        ZeroNativeAppKitHost *host = [[ZeroNativeAppKitHost alloc] initWithAppName:appNameString windowTitle:windowTitleString bundleIdentifier:bundleIdString iconPath:iconPathString windowLabel:windowLabelString x:x y:y width:width height:height restoreFrame:(restore_frame != 0)];
+        ZeroNativeAppKitHost *host = [[ZeroNativeAppKitHost alloc] initWithAppName:appNameString windowTitle:windowTitleString bundleIdentifier:bundleIdString iconPath:iconPathString windowLabel:windowLabelString x:x y:y width:width height:height restoreFrame:(restore_frame != 0) titleBarStyle:title_bar_style];
         return (__bridge_retained zero_native_appkit_host_t *)host;
     }
 }
@@ -894,11 +903,11 @@ void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, con
     [object setAllowedNavigationOrigins:origins externalURLs:externalURLs externalAction:external_action];
 }
 
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style) {
     ZeroNativeAppKitHost *object = (__bridge ZeroNativeAppKitHost *)host;
     NSString *titleString = window_title ? [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] : @"";
     NSString *labelString = window_label ? [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] : @"";
-    return [object createWindowWithId:window_id title:titleString ?: @"" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) makeMain:NO] ? 1 : 0;
+    return [object createWindowWithId:window_id title:titleString ?: @"" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) titleBarStyle:title_bar_style makeMain:NO] ? 1 : 0;
 }
 
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id) {

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -42,6 +42,7 @@ static NSString *ZeroNativeExistingPath(NSString *path);
 static NSString *ZeroNativeCefFrameworkPath(void);
 static NSString *ZeroNativeOriginForURL(NSURL *url);
 static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
+static void ZeroNativeApplyTitleBarStyle(NSWindow *window, NSInteger style);
 
 class ZeroNativeCefBridgeV8Handler final : public CefV8Handler {
 public:
@@ -338,11 +339,11 @@ static const char *ZeroNativeCefBridgeScript() {
 @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
 @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
 @property(nonatomic, assign) NSInteger externalLinkAction;
-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height;
+- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height titleBarStyle:(NSInteger)titleBarStyle;
 - (void)configureApplication;
 - (void)buildMenuBar;
 - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain;
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle makeMain:(BOOL)makeMain;
 - (void)focusWindowWithId:(uint64_t)windowId;
 - (void)closeWindowWithId:(uint64_t)windowId;
 - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(void *)context;
@@ -410,7 +411,7 @@ static const char *ZeroNativeCefBridgeScript() {
 
 @implementation ZeroNativeChromiumHost
 
-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height {
+- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height titleBarStyle:(NSInteger)titleBarStyle {
     self = [super init];
     if (!self) return nil;
 
@@ -432,7 +433,7 @@ static const char *ZeroNativeCefBridgeScript() {
     self.allowedExternalURLs = @[];
     self.externalLinkAction = 0;
 
-    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO makeMain:YES];
+    [self createWindowWithId:1 title:(title.length > 0 ? title : self.appName) label:@"main" x:0 y:0 width:width height:height restoreFrame:NO titleBarStyle:titleBarStyle makeMain:YES];
     self.didShutdown = NO;
     return self;
 }
@@ -521,7 +522,7 @@ static const char *ZeroNativeCefBridgeScript() {
     delete self.browsers;
 }
 
-- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
+- (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame titleBarStyle:(NSInteger)titleBarStyle makeMain:(BOOL)makeMain {
     NSNumber *key = @(windowId);
     if (self.windows[key]) return NO;
 
@@ -534,6 +535,7 @@ static const char *ZeroNativeCefBridgeScript() {
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
     [window setTitle:title.length > 0 ? title : @"zero-native"];
+    ZeroNativeApplyTitleBarStyle(window, titleBarStyle);
     if (!restoreFrame) [window center];
 
     NSView *browserContainer = [[NSView alloc] initWithFrame:rect];
@@ -880,6 +882,13 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     return NO;
 }
 
+static void ZeroNativeApplyTitleBarStyle(NSWindow *window, NSInteger style) {
+    if (style != 1) return;
+    window.titleVisibility = NSWindowTitleHidden;
+    window.titlebarAppearsTransparent = YES;
+    window.styleMask = window.styleMask | NSWindowStyleMaskFullSizeContentView;
+}
+
 void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
     [host_ setBrowser:browser windowId:window_id_];
 }
@@ -925,7 +934,7 @@ bool ZeroNativeCefClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser
 
 } // namespace
 
-zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style) {
     @autoreleasepool {
         (void)bundle_id;
         (void)bundle_id_len;
@@ -935,7 +944,7 @@ zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_
         (void)window_label_len;
         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
-        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height];
+        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height titleBarStyle:title_bar_style];
         if (restore_frame) {
             [host.window setFrame:ZeroNativeConstrainFrame(NSMakeRect(x, y, width, height)) display:NO];
         }
@@ -1008,11 +1017,11 @@ void zero_native_appkit_set_security_policy(zero_native_appkit_host_t *host, con
     [object setAllowedNavigationOrigins:origins externalURLs:externalURLs externalAction:external_action];
 }
 
-int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
+int zero_native_appkit_create_window(zero_native_appkit_host_t *host, uint64_t window_id, const char *window_title, size_t window_title_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame, int title_bar_style) {
     ZeroNativeChromiumHost *object = (__bridge ZeroNativeChromiumHost *)host;
     NSString *titleString = window_title ? [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] : @"zero-native";
     NSString *labelString = window_label ? [[NSString alloc] initWithBytes:window_label length:window_label_len encoding:NSUTF8StringEncoding] : @"";
-    return [object createWindowWithId:window_id title:titleString ?: @"zero-native" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) makeMain:NO] ? 1 : 0;
+    return [object createWindowWithId:window_id title:titleString ?: @"zero-native" label:labelString ?: @"" x:x y:y width:width height:height restoreFrame:(restore_frame != 0) titleBarStyle:title_bar_style makeMain:NO] ? 1 : 0;
 }
 
 int zero_native_appkit_focus_window(zero_native_appkit_host_t *host, uint64_t window_id) {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -37,7 +37,7 @@ const AppKitEvent = extern struct {
 const AppKitCallback = *const fn (context: ?*anyopaque, event: *const AppKitEvent) callconv(.c) void;
 const AppKitBridgeCallback = *const fn (context: ?*anyopaque, window_id: u64, message: [*]const u8, message_len: usize, origin: [*]const u8, origin_len: usize) callconv(.c) void;
 
-extern fn zero_native_appkit_create(app_name: [*]const u8, app_name_len: usize, window_title: [*]const u8, window_title_len: usize, bundle_id: [*]const u8, bundle_id_len: usize, icon_path: [*]const u8, icon_path_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int) ?*AppKitHost;
+extern fn zero_native_appkit_create(app_name: [*]const u8, app_name_len: usize, window_title: [*]const u8, window_title_len: usize, bundle_id: [*]const u8, bundle_id_len: usize, icon_path: [*]const u8, icon_path_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int, title_bar_style: c_int) ?*AppKitHost;
 extern fn zero_native_appkit_destroy(host: *AppKitHost) void;
 extern fn zero_native_appkit_run(host: *AppKitHost, callback: AppKitCallback, context: ?*anyopaque) void;
 extern fn zero_native_appkit_stop(host: *AppKitHost) void;
@@ -48,7 +48,7 @@ extern fn zero_native_appkit_bridge_respond(host: *AppKitHost, response: [*]cons
 extern fn zero_native_appkit_bridge_respond_window(host: *AppKitHost, window_id: u64, response: [*]const u8, response_len: usize) void;
 extern fn zero_native_appkit_emit_window_event(host: *AppKitHost, window_id: u64, name: [*]const u8, name_len: usize, detail_json: [*]const u8, detail_json_len: usize) void;
 extern fn zero_native_appkit_set_security_policy(host: *AppKitHost, allowed_origins: [*]const u8, allowed_origins_len: usize, external_urls: [*]const u8, external_urls_len: usize, external_action: c_int) void;
-extern fn zero_native_appkit_create_window(host: *AppKitHost, window_id: u64, window_title: [*]const u8, window_title_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int) c_int;
+extern fn zero_native_appkit_create_window(host: *AppKitHost, window_id: u64, window_title: [*]const u8, window_title_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int, title_bar_style: c_int) c_int;
 extern fn zero_native_appkit_focus_window(host: *AppKitHost, window_id: u64) c_int;
 extern fn zero_native_appkit_close_window(host: *AppKitHost, window_id: u64) c_int;
 extern fn zero_native_appkit_clipboard_read(host: *AppKitHost, buffer: [*]u8, buffer_len: usize) usize;
@@ -126,7 +126,7 @@ pub const MacPlatform = struct {
         const window_options = app_info.resolvedMainWindow();
         const window_title = window_options.resolvedTitle(app_info.app_name);
         const frame = window_options.default_frame;
-        const host = zero_native_appkit_create(app_info.app_name.ptr, app_info.app_name.len, window_title.ptr, window_title.len, app_info.bundle_id.ptr, app_info.bundle_id.len, app_info.icon_path.ptr, app_info.icon_path.len, window_options.label.ptr, window_options.label.len, frame.x, frame.y, frame.width, frame.height, if (window_options.restore_state) 1 else 0) orelse return error.CreateFailed;
+        const host = zero_native_appkit_create(app_info.app_name.ptr, app_info.app_name.len, window_title.ptr, window_title.len, app_info.bundle_id.ptr, app_info.bundle_id.len, app_info.icon_path.ptr, app_info.icon_path.len, window_options.label.ptr, window_options.label.len, frame.x, frame.y, frame.width, frame.height, if (window_options.restore_state) 1 else 0, titleBarStyleCode(window_options.title_bar_style)) orelse return error.CreateFailed;
         return .{
             .host = host,
             .web_engine = web_engine,
@@ -311,7 +311,7 @@ fn createWindow(context: ?*anyopaque, options: platform_mod.WindowOptions) anyer
     const self: *MacPlatform = @ptrCast(@alignCast(context.?));
     const title = options.resolvedTitle(self.app_info.app_name);
     const frame = options.default_frame;
-    if (zero_native_appkit_create_window(self.host, options.id, title.ptr, title.len, options.label.ptr, options.label.len, frame.x, frame.y, frame.width, frame.height, if (options.restore_state) 1 else 0) == 0) return error.CreateFailed;
+    if (zero_native_appkit_create_window(self.host, options.id, title.ptr, title.len, options.label.ptr, options.label.len, frame.x, frame.y, frame.width, frame.height, if (options.restore_state) 1 else 0, titleBarStyleCode(options.title_bar_style)) == 0) return error.CreateFailed;
     return .{
         .id = options.id,
         .label = options.label,
@@ -446,6 +446,13 @@ fn removeTray(context: ?*anyopaque) anyerror!void {
 fn appkitTrayCallback(context: ?*anyopaque, item_id: u32) callconv(.c) void {
     const state: *RunState = @ptrCast(@alignCast(context.?));
     state.emit(.{ .tray_action = item_id });
+}
+
+fn titleBarStyleCode(style: platform_mod.WindowTitleBarStyle) c_int {
+    return switch (style) {
+        .standard => 0,
+        .overlay => 1,
+    };
 }
 
 fn flattenFilters(filters: []const platform_mod.FileFilter, buffer: []u8) []const u8 {

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -62,12 +62,18 @@ pub const WindowRestorePolicy = enum {
     center_on_primary,
 };
 
+pub const WindowTitleBarStyle = enum {
+    standard,
+    overlay,
+};
+
 pub const WindowOptions = struct {
     id: WindowId = 1,
     label: []const u8 = "main",
     title: []const u8 = "",
     default_frame: geometry.RectF = geometry.RectF.init(0, 0, 720, 480),
     resizable: bool = true,
+    title_bar_style: WindowTitleBarStyle = .standard,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
 
@@ -116,6 +122,7 @@ pub const WindowCreateOptions = struct {
     title: []const u8 = "",
     default_frame: geometry.RectF = geometry.RectF.init(0, 0, 720, 480),
     resizable: bool = true,
+    title_bar_style: WindowTitleBarStyle = .standard,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
     source: ?WebViewSource = null,
@@ -127,6 +134,7 @@ pub const WindowCreateOptions = struct {
             .title = self.title,
             .default_frame = self.default_frame,
             .resizable = self.resizable,
+            .title_bar_style = self.title_bar_style,
             .restore_state = self.restore_state,
             .restore_policy = self.restore_policy,
         };

--- a/src/primitives/app_manifest/root.zig
+++ b/src/primitives/app_manifest/root.zig
@@ -187,6 +187,11 @@ pub const WindowRestorePolicy = enum {
     center_on_primary,
 };
 
+pub const WindowTitleBarStyle = enum {
+    standard,
+    overlay,
+};
+
 pub const Window = struct {
     label: []const u8 = "main",
     title: ?[]const u8 = null,
@@ -195,6 +200,7 @@ pub const Window = struct {
     x: ?f32 = null,
     y: ?f32 = null,
     resizable: bool = true,
+    title_bar_style: WindowTitleBarStyle = .standard,
     restore_state: bool = true,
     restore_policy: WindowRestorePolicy = .clamp_to_visible_screen,
 };

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,6 +40,7 @@ pub const WindowCreateOptions = platform.WindowCreateOptions;
 pub const WindowInfo = platform.WindowInfo;
 pub const WindowState = platform.WindowState;
 pub const WindowRestorePolicy = platform.WindowRestorePolicy;
+pub const WindowTitleBarStyle = platform.WindowTitleBarStyle;
 pub const FileFilter = platform.FileFilter;
 pub const OpenDialogOptions = platform.OpenDialogOptions;
 pub const OpenDialogResult = platform.OpenDialogResult;

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -699,10 +699,12 @@ pub const Runtime = struct {
         const x = jsonNumberField(payload, "x") orelse 0;
         const y = jsonNumberField(payload, "y") orelse 0;
         const source = if (jsonStringField(payload, "url", &storage)) |url| platform.WebViewSource.url(url) else null;
+        const title_bar_style = try parseWindowTitleBarStyle(jsonStringField(payload, "titleBarStyle", &storage) orelse "standard");
         const info = try self.createWindow(.{
             .label = label,
             .title = title,
             .default_frame = geometry.RectF.init(x, y, width, height),
+            .title_bar_style = title_bar_style,
             .restore_state = jsonBoolField(payload, "restoreState") orelse true,
             .source = source,
         });
@@ -852,6 +854,12 @@ fn jsonIntegerField(payload: []const u8, field: []const u8) ?platform.WindowId {
 
 fn jsonBoolField(payload: []const u8, field: []const u8) ?bool {
     return json.boolField(payload, field);
+}
+
+fn parseWindowTitleBarStyle(value: []const u8) !platform.WindowTitleBarStyle {
+    if (std.mem.eql(u8, value, "standard")) return .standard;
+    if (std.mem.eql(u8, value, "overlay")) return .overlay;
+    return error.InvalidWindowOptions;
 }
 
 pub fn TestHarness() type {
@@ -1223,6 +1231,12 @@ test "runtime builtin JSON field reader only reads top-level fields" {
     try std.testing.expectEqualStrings("palette \"one\"", jsonStringField(payload, "label", &storage).?);
     try std.testing.expectEqual(@as(f32, 320), jsonNumberField(payload, "width").?);
     try std.testing.expectEqual(false, jsonBoolField(payload, "restoreState").?);
+}
+
+test "runtime parses window title bar style values" {
+    try std.testing.expectEqual(platform.WindowTitleBarStyle.standard, try parseWindowTitleBarStyle("standard"));
+    try std.testing.expectEqual(platform.WindowTitleBarStyle.overlay, try parseWindowTitleBarStyle("overlay"));
+    try std.testing.expectError(error.InvalidWindowOptions, parseWindowTitleBarStyle("hidden"));
 }
 
 test "runtime returns bridge permission errors through platform response service" {

--- a/src/tooling/manifest.zig
+++ b/src/tooling/manifest.zig
@@ -72,6 +72,7 @@ pub const Metadata = struct {
         for (self.windows) |window| {
             allocator.free(window.label);
             if (window.title) |title| allocator.free(title);
+            allocator.free(window.title_bar_style);
         }
         if (self.windows.len > 0) allocator.free(self.windows);
     }
@@ -90,6 +91,7 @@ pub const WindowMetadata = struct {
     height: f32 = 480,
     x: ?f32 = null,
     y: ?f32 = null,
+    title_bar_style: []const u8 = "standard",
     restore_state: bool = true,
 };
 
@@ -150,7 +152,7 @@ pub fn validateFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8) 
     }
     const frontend = if (metadata.frontend) |frontend_value| convertFrontend(frontend_value) else null;
     const security = convertSecurity(metadata.security) catch return .{ .ok = false, .message = "app.zon security policy is invalid" };
-    const windows = try convertWindows(allocator, metadata.windows);
+    const windows = convertWindows(allocator, metadata.windows) catch return .{ .ok = false, .message = "app.zon windows are invalid" };
     defer allocator.free(windows);
     const manifest_web_engine = parseWebEngine(metadata.web_engine) catch return .{ .ok = false, .message = "app.zon web engine is invalid" };
 
@@ -269,6 +271,7 @@ fn convertRawWindows(allocator: std.mem.Allocator, windows: []const RawWindow) !
             .height = window.height,
             .x = window.x,
             .y = window.y,
+            .title_bar_style = try allocator.dupe(u8, window.title_bar_style),
             .restore_state = window.restore_state,
         };
     }
@@ -341,6 +344,7 @@ fn convertWindows(allocator: std.mem.Allocator, windows: []const WindowMetadata)
             .height = window.height,
             .x = window.x,
             .y = window.y,
+            .title_bar_style = parseWindowTitleBarStyle(window.title_bar_style) catch return error.InvalidWindow,
             .restore_state = window.restore_state,
         };
     }
@@ -433,6 +437,12 @@ fn parseExternalLinkAction(value: []const u8) !app_manifest.ExternalLinkAction {
     if (std.mem.eql(u8, value, "deny")) return .deny;
     if (std.mem.eql(u8, value, "open_system_browser")) return .open_system_browser;
     return error.InvalidAction;
+}
+
+fn parseWindowTitleBarStyle(value: []const u8) !app_manifest.WindowTitleBarStyle {
+    if (std.mem.eql(u8, value, "standard")) return .standard;
+    if (std.mem.eql(u8, value, "overlay")) return .overlay;
+    return error.InvalidWindow;
 }
 
 fn parseWebEngine(value: []const u8) !app_manifest.WebEngine {
@@ -557,4 +567,23 @@ test "manifest metadata parser reads frontend config" {
     try std.testing.expectEqualStrings("http://127.0.0.1:5173/", metadata.frontend.?.dev.?.url);
     try std.testing.expectEqualStrings("npm", metadata.frontend.?.dev.?.command[0]);
     try std.testing.expectEqual(@as(u32, 12000), metadata.frontend.?.dev.?.timeout_ms);
+}
+
+test "manifest metadata parser reads window title bar style" {
+    const metadata = try parseText(std.testing.allocator,
+        \\.{
+        \\  .id = "com.example.app",
+        \\  .name = "example",
+        \\  .version = "1.2.3",
+        \\  .windows = .{
+        \\    .{ .label = "main", .title = "Example", .title_bar_style = "overlay", .width = 800, .height = 600 },
+        \\  },
+        \\}
+    );
+    defer metadata.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("overlay", metadata.windows[0].title_bar_style);
+    const windows = try convertWindows(std.testing.allocator, metadata.windows);
+    defer std.testing.allocator.free(windows);
+    try std.testing.expectEqual(app_manifest.WindowTitleBarStyle.overlay, windows[0].title_bar_style);
 }

--- a/src/tooling/raw_manifest.zig
+++ b/src/tooling/raw_manifest.zig
@@ -67,5 +67,6 @@ pub const RawWindow = struct {
     height: f32 = 480,
     x: ?f32 = null,
     y: ?f32 = null,
+    title_bar_style: []const u8 = "standard",
     restore_state: bool = true,
 };


### PR DESCRIPTION
## Summary
- add a `title_bar_style` / `titleBarStyle` window option with `standard` and `overlay` values
- apply macOS overlay style by hiding the title and enabling full-size content view in both AppKit and CEF hosts
- document the new app.zon, Zig, and JavaScript options

## Tests
- `zig build test`
- `zig build test-webview-system-link -Dplatform=macos`
- `zig build validate`