### PR TITLE
Replace stray page_allocator usage in tools and embed ABI

### DIFF
--- a/src/embed/root.zig
+++ b/src/embed/root.zig
@@ -36,7 +36,7 @@ const MobileHostApp = struct {
     last_error: ?anyerror = null,
 
     fn create() !*MobileHostApp {
-        const allocator = std.heap.page_allocator;
+        const allocator = std.heap.c_allocator;
         const self = try allocator.create(MobileHostApp);
         self.null_platform = platform.NullPlatform.init(.{});
         self.embedded = EmbeddedApp.init(.{
@@ -74,7 +74,7 @@ pub fn zero_native_app_create() ?*anyopaque {
 
 pub fn zero_native_app_destroy(app: ?*anyopaque) void {
     const self = mobileApp(app) orelse return;
-    std.heap.page_allocator.destroy(self);
+    std.heap.c_allocator.destroy(self);
 }
 
 pub fn zero_native_app_start(app: ?*anyopaque) void {

--- a/src/tooling/package.zig
+++ b/src/tooling/package.zig
@@ -109,19 +109,6 @@ pub fn printDiagnostic(stats: PackageStats) void {
     }
 }
 
-pub fn createLocalPackage(io: std.Io, output_path: []const u8) !PackageStats {
-    const metadata: manifest_tool.Metadata = .{
-        .id = "dev.zero_native.local",
-        .name = "zero-native-local",
-        .version = "0.1.0",
-    };
-    return createMacosApp(std.heap.page_allocator, io, .{
-        .metadata = metadata,
-        .output_path = output_path,
-        .binary_path = null,
-    });
-}
-
 pub fn createMacosApp(allocator: std.mem.Allocator, io: std.Io, options: PackageOptions) !PackageStats {
     var cwd = std.Io.Dir.cwd();
     try cwd.createDirPath(io, options.output_path);

--- a/tools/zero-native/automation.zig
+++ b/tools/zero-native/automation.zig
@@ -7,9 +7,9 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !
     if (args.len == 0) return usage();
     const command = args[0];
     if (std.mem.eql(u8, command, "list")) {
-        try printFile(io, "windows.txt");
+        try printFile(allocator, io, "windows.txt");
     } else if (std.mem.eql(u8, command, "snapshot")) {
-        try printFile(io, "snapshot.txt");
+        try printFile(allocator, io, "snapshot.txt");
     } else if (std.mem.eql(u8, command, "screenshot")) {
         std.debug.print("screenshot capture is not available for this backend\n", .{});
         return error.UnsupportedCommand;
@@ -52,10 +52,10 @@ fn sendCommand(allocator: std.mem.Allocator, io: std.Io, action: []const u8, val
     std.debug.print("queued {s}\n", .{action});
 }
 
-fn printFile(io: std.Io, name: []const u8) !void {
+fn printFile(allocator: std.mem.Allocator, io: std.Io, name: []const u8) !void {
     var file_path: [256]u8 = undefined;
-    const bytes = readFile(std.heap.page_allocator, io, path(&file_path, name)) catch return fail("no app connected");
-    defer std.heap.page_allocator.free(bytes);
+    const bytes = readFile(allocator, io, path(&file_path, name)) catch return fail("no app connected");
+    defer allocator.free(bytes);
     std.debug.print("{s}", .{bytes});
 }
 


### PR DESCRIPTION
- deletes stray usage in createLocalPackage by deleting function as it appears to be fully dead code
- passes allocator smoothly for printFile()
- zero_native_app_destroy and create both do need to be called externally from non-zig so should declare internal allocators but as they're intended for c ffi they should use c_allocator so they route through malloc/free from libc allowing users to adjust the allocator in use through standard c conventions