### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,38 @@
 
 All notable changes to zero-native will be documented in this file.
 
-## 0.1.9
+## 0.2.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Layered WebViews**: Add first-class multi-WebView stacks with overlay positioning, routing, hover coverage, resizing, reload handling, and backend support across AppKit, CEF, GTK, and WebView2 (#28).
+- **zero-native skills**: Ship CLI-served agent skills and reference material for building and automating zero-native apps (#38).
+- **Browser example**: Add a browser-style example that demonstrates layered WebViews, browser controls, and frontend asset handling (#28).
+
+### Improvements
+
+- **WebView and bridge documentation**: Document WebView APIs, built-in bridge commands, security boundaries, packaging, testing, and app model updates (#28, #38).
+- **CEF runtime builds**: Harden the CEF runtime workflows across macOS, Linux, and Windows, including Windows runtime build fixes (#25, #26).
+- **macOS compatibility**: Set the native app baseline to macOS 11 (#22).
+- **Contributor guidance**: Clarify signed commit requirements and contribution PR guidance (#10).
+
+### Bug Fixes
+
+- **Windows WebView builds**: Fix Windows WebView build failures before the layered WebView release.
+- **React example dependencies**: Include the missing React example type dependencies (#11).
+- **GitHub release notes**: Avoid duplicate contributor lists when creating GitHub releases (#24).
+- **macOS package permissions**: Preserve executable permissions for packaged macOS app binaries (#39).
+
+### Contributors
+
+- @Anshuman71
+- @PrathamGhaywat
+- @ctate
+<!-- release:end -->
+
+## 0.1.9
 
 ### New Features
 
@@ -13,7 +42,6 @@ All notable changes to zero-native will be documented in this file.
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ All notable changes to zero-native will be documented in this file.
 
 ### New Features
 
-- **Layered WebViews**: Add first-class multi-WebView stacks with overlay positioning, routing, hover coverage, resizing, reload handling, and backend support across AppKit, CEF, GTK, and WebView2 (#28).
+- **Layered WebView runtime**: Model each native window as a stack of named WebViews, including the reserved startup `main` WebView and child WebViews with frame, layer, zoom, transparency, routing, resizing, reload, and close support across the native backends (#28).
+- **JavaScript WebView API**: Add typed `window.zero.webviews.*` helpers and `zero-native.webview.*` built-in bridge commands for create, list, setFrame, navigate, setZoom, setLayer, and close operations (#28).
+- **Isolated child WebViews**: Keep child WebViews bridge-isolated by default, allow trusted child chrome with `bridge: true`, enforce navigation policy on child URLs, and scope WebView commands to the calling native window (#28).
+- **Browser example**: Add a browser-style example that demonstrates layered WebViews, browser controls, isolated page content, frontend asset handling, and the root `zig build run-browser` command (#28).
 - **zero-native skills**: Ship CLI-served agent skills and reference material for building and automating zero-native apps (#38).
-- **Browser example**: Add a browser-style example that demonstrates layered WebViews, browser controls, and frontend asset handling (#28).
 
 ### Improvements
 
-- **WebView and bridge documentation**: Document WebView APIs, built-in bridge commands, security boundaries, packaging, testing, and app model updates (#28, #38).
+- **WebView and bridge documentation**: Document WebView APIs, built-in bridge commands, security boundaries, backend support, packaging, testing, and app model updates (#28, #38).
+- **WebView smoke coverage**: Extend automation smoke tests to exercise child WebView create, resize, navigate, and close operations for system WebView and macOS CEF builds (#28).
 - **CEF runtime builds**: Harden the CEF runtime workflows across macOS, Linux, and Windows, including Windows runtime build fixes (#25, #26).
 - **macOS compatibility**: Set the native app baseline to macOS 11 (#22).
 - **Contributor guidance**: Clarify signed commit requirements and contribution PR guidance (#10).

--- a/packages/zero-native/package.json
+++ b/packages/zero-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zero-native",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Zig desktop app shell with WebView — CLI tools",
   "type": "module",
   "bin": {

--- a/tools/zero-native/main.zig
+++ b/tools/zero-native/main.zig
@@ -3,7 +3,7 @@ const automation_cli = @import("automation.zig");
 const skills_cli = @import("skills.zig");
 const tooling = @import("tooling");
 
-const version = "0.1.9";
+const version = "0.2.0";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
## Summary
- Bumps zero-native to 0.2.0 and syncs the CLI version constant.
- Adds the marked 0.2.0 changelog entry for the release workflow.