### PR TITLE
Fix Windows zero-native init path resolution error

### DIFF
--- a/tools/zero-native/main.zig
+++ b/tools/zero-native/main.zig
@@ -215,6 +215,13 @@ fn frameworkRootFromExecutable(allocator: std.mem.Allocator, io: std.Io) !?[]con
 fn hasFrameworkRoot(allocator: std.mem.Allocator, io: std.Io, root: []const u8) !bool {
     const root_zig = try std.fs.path.join(allocator, &.{ root, "src", "root.zig" });
     defer allocator.free(root_zig);
+    
+    if (std.fs.path.isAbsolute(root_zig)) {
+        var file = std.Io.Dir.openFileAbsolute(io, root_zig, .{}) catch return false;
+        defer file.close(io);
+        return true;
+    }
+    
     var file = std.Io.Dir.cwd().openFile(io, root_zig, .{}) catch return false;
     defer file.close(io);
     return true;


### PR DESCRIPTION
Fixes #53.

**Cause:**
`zero-native` initialization tries to locate its source files by taking its executable path (an absolute path) and joining it with `src/root.zig`. It passed this to `std.Io.Dir.cwd().openFile()`. On macOS and Linux, the underlying POSIX `openat` allows absolute paths, ignoring the directory file descriptor. However, on Windows, `NtCreateFile` rejects an absolute path when a parent directory handle (`RootDirectory`) is provided, causing `cwd().openFile` to throw an error. This caused `hasFrameworkRoot` to silently catch the error and return `false` on Windows.

**Fix:**
Explicitly use `std.Io.Dir.openFileAbsolute` if `std.fs.path.isAbsolute(root_zig)` is true, bypassing the directory handle and ensuring the absolute path is correctly read on Windows.