### PR TITLE
macOS: optional lift of WKWebView's 60fps requestAnimationFrame cap

### DIFF
--- a/src/bridge/root.zig
+++ b/src/bridge/root.zig
@@ -2,7 +2,11 @@ const std = @import("std");
 const json = @import("json");
 const security = @import("../security/root.zig");
 
-pub const max_message_bytes: usize = 1024 * 1024;
+// Requests may carry base64-encoded image/video bytes (annex.media.write), so
+// the request cap matches the response caps. At 1 MB, any write of a file whose
+// base64 exceeded ~750 KB was rejected as "too large" — and that rejection
+// carries an empty id, so the JS promise never resolves and the call hangs.
+pub const max_message_bytes: usize = 48 * 1024 * 1024;
 // Responses/results may carry base64-encoded HTTP bodies (e.g. images) from the
 // native net.fetch bridge, so these are sized generously (48 MB). Buffers of this
 // size must never live on the stack — see the shared static buffers below.

--- a/src/bridge/root.zig
+++ b/src/bridge/root.zig
@@ -3,10 +3,27 @@ const json = @import("json");
 const security = @import("../security/root.zig");
 
 pub const max_message_bytes: usize = 1024 * 1024;
-pub const max_response_bytes: usize = 1024 * 1024;
-pub const max_result_bytes: usize = 1024 * 1024;
+// Responses/results may carry base64-encoded HTTP bodies (e.g. images) from the
+// native net.fetch bridge, so these are sized generously (48 MB). Buffers of this
+// size must never live on the stack — see the shared static buffers below.
+pub const max_response_bytes: usize = 48 * 1024 * 1024;
+pub const max_result_bytes: usize = 48 * 1024 * 1024;
 pub const max_id_bytes: usize = 64;
 pub const max_command_bytes: usize = 128;
+
+// Bridge dispatch runs on the single main event-loop thread, so these large
+// buffers are shared statics rather than per-call stack arrays (a 48 MB stack
+// allocation would overflow the thread stack).
+var shared_response_buffer: [max_response_bytes]u8 = undefined;
+var shared_result_buffer: [max_result_bytes]u8 = undefined;
+
+pub fn sharedResponseBuffer() []u8 {
+    return &shared_response_buffer;
+}
+
+pub fn sharedResultBuffer() []u8 {
+    return &shared_result_buffer;
+}
 
 const null_json = "null";
 
@@ -95,13 +112,11 @@ pub const AsyncResponder = struct {
     }
 
     pub fn success(self: AsyncResponder, id: []const u8, result: []const u8) anyerror!void {
-        var buffer: [max_response_bytes]u8 = undefined;
-        try self.respond(writeSuccessResponse(&buffer, id, result));
+        try self.respond(writeSuccessResponse(sharedResponseBuffer(), id, result));
     }
 
     pub fn fail(self: AsyncResponder, id: []const u8, code: ErrorCode, message: []const u8) anyerror!void {
-        var buffer: [max_response_bytes]u8 = undefined;
-        try self.respond(writeErrorResponse(&buffer, id, code, message));
+        try self.respond(writeErrorResponse(sharedResponseBuffer(), id, code, message));
     }
 };
 
@@ -155,8 +170,7 @@ pub const Dispatcher = struct {
             return writeErrorResponse(output, request.id, .unknown_command, "Bridge command is not registered");
         };
 
-        var result_buffer: [max_result_bytes]u8 = undefined;
-        const result = handler.invoke_fn(handler.context, .{ .request = request, .source = source }, &result_buffer) catch |err| {
+        const result = handler.invoke_fn(handler.context, .{ .request = request, .source = source }, sharedResultBuffer()) catch |err| {
             return writeErrorResponse(output, request.id, .handler_failed, @errorName(err));
         };
         return writeSuccessResponse(output, request.id, if (result.len == 0) null_json else result);

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -95,12 +95,9 @@ typedef struct {
     size_t tertiary_button_len;
 } zero_native_appkit_message_dialog_opts_t;
 
-typedef struct {
-    int status;
-    size_t bytes_written;
-} zero_native_appkit_http_fetch_result_t;
+typedef void (*zero_native_appkit_http_fetch_callback_t)(void *ctx, int status, const char *json_utf8, size_t json_len);
 
-zero_native_appkit_http_fetch_result_t zero_native_appkit_http_fetch(zero_native_appkit_host_t *host, const char *url, size_t url_len, char *buffer, size_t buffer_len);
+void zero_native_appkit_http_fetch_async(zero_native_appkit_host_t *host, const char *url, size_t url_len, zero_native_appkit_http_fetch_callback_t callback, void *ctx);
 
 typedef void (*zero_native_appkit_tray_callback_t)(void *context, uint32_t item_id);
 

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -95,6 +95,13 @@ typedef struct {
     size_t tertiary_button_len;
 } zero_native_appkit_message_dialog_opts_t;
 
+typedef struct {
+    int status;
+    size_t bytes_written;
+} zero_native_appkit_http_fetch_result_t;
+
+zero_native_appkit_http_fetch_result_t zero_native_appkit_http_fetch(zero_native_appkit_host_t *host, const char *url, size_t url_len, char *buffer, size_t buffer_len);
+
 typedef void (*zero_native_appkit_tray_callback_t)(void *context, uint32_t item_id);
 
 zero_native_appkit_open_dialog_result_t zero_native_appkit_show_open_dialog(zero_native_appkit_host_t *host, const zero_native_appkit_open_dialog_opts_t *opts, char *buffer, size_t buffer_len);

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -8,6 +8,20 @@
 
 @class ZeroNativeAppKitHost;
 
+// Private WebKit SPI used to lift WKWebView's 60fps requestAnimationFrame cap on
+// macOS 13–15 (no-op on macOS 26+, where the cap was removed). Same mechanism
+// Safari uses internally; safe behind respondsToSelector checks.
+@interface WKPreferences (ZeroNativeHighRefresh)
++ (NSArray *)_features;
++ (NSArray *)_experimentalFeatures;
++ (NSArray *)_internalDebugFeatures;
+- (void)_setEnabled:(BOOL)enabled forFeature:(id)feature;
+- (void)_setEnabled:(BOOL)enabled forExperimentalFeature:(id)feature;
+- (void)_setEnabled:(BOOL)enabled forInternalDebugFeature:(id)feature;
+@end
+
+static void ZeroNativeUnlockHighRefresh(WKPreferences *preferences);
+
 static NSRect constrainFrame(NSRect frame);
 static NSString *ZeroNativeAppKitBridgeScript(void);
 static NSString *ZeroNativeMimeTypeForPath(NSString *path);
@@ -267,6 +281,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
     if ([configuration.preferences respondsToSelector:NSSelectorFromString(@"setDeveloperExtrasEnabled:")]) {
         [configuration.preferences setValue:@YES forKey:@"developerExtrasEnabled"];
     }
+    ZeroNativeUnlockHighRefresh(configuration.preferences);
     WKWebView *webView = [[WKWebView alloc] initWithFrame:rect configuration:configuration];
     if ([webView respondsToSelector:NSSelectorFromString(@"setInspectable:")]) {
         [webView setValue:@YES forKey:@"inspectable"];
@@ -327,6 +342,61 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 
 - (ZeroNativeAssetSchemeHandler *)assetHandlerForWindowId:(uint64_t)windowId {
     return self.assetSchemeHandlers[@(windowId)] ?: self.assetSchemeHandler;
+}
+
+// High-refresh support is opt-in (it relies on private WebKit SPI, which is not
+// App-Store-safe). Consumers enable it by compiling appkit_host.m with
+// -DZERO_NATIVE_MACOS_HIGH_REFRESH=1. When the macro is undefined the helper
+// below compiles to a no-op and the SPI is never touched.
+#if defined(ZERO_NATIVE_MACOS_HIGH_REFRESH) && ZERO_NATIVE_MACOS_HIGH_REFRESH
+
+// Disable the named WebKit feature in `features` (if present) via `setter`.
+static void ZeroNativeDisableFeature(NSArray *features, NSString *name,
+                                     WKPreferences *prefs, SEL setter) {
+    if (!features || ![prefs respondsToSelector:setter]) return;
+    for (id feature in features) {
+        NSString *key = nil;
+        @try { key = [feature valueForKey:@"key"]; }
+        @catch (__unused NSException *e) { continue; }
+        if (![key isEqualToString:name]) continue;
+        NSMethodSignature *sig = [prefs methodSignatureForSelector:setter];
+        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+        inv.target = prefs;
+        inv.selector = setter;
+        BOOL enabled = NO;
+        [inv setArgument:&enabled atIndex:2];
+        [inv setArgument:&feature atIndex:3];
+        [inv invoke];
+        return;
+    }
+}
+
+#endif
+
+// WKWebView caps requestAnimationFrame at 60fps on macOS via the internal
+// "PreferPageRenderingUpdatesNear60FPSEnabled" WebKit feature, regardless of the
+// display's refresh rate. When opted in, disable it so rAF runs at the native
+// rate (e.g. 120Hz ProMotion), using WebKit's private feature-flags SPI (class
+// methods on WKPreferences). Fully guarded, so it no-ops if the SPI changes.
+static void ZeroNativeUnlockHighRefresh(WKPreferences *preferences) {
+#if defined(ZERO_NATIVE_MACOS_HIGH_REFRESH) && ZERO_NATIVE_MACOS_HIGH_REFRESH
+    if (!preferences) return;
+    static NSString *const kFeature = @"PreferPageRenderingUpdatesNear60FPSEnabled";
+    if ([WKPreferences respondsToSelector:@selector(_features)]) {
+        ZeroNativeDisableFeature([WKPreferences _features], kFeature, preferences,
+                                 @selector(_setEnabled:forFeature:));
+    }
+    if ([WKPreferences respondsToSelector:@selector(_experimentalFeatures)]) {
+        ZeroNativeDisableFeature([WKPreferences _experimentalFeatures], kFeature, preferences,
+                                 @selector(_setEnabled:forExperimentalFeature:));
+    }
+    if ([WKPreferences respondsToSelector:@selector(_internalDebugFeatures)]) {
+        ZeroNativeDisableFeature([WKPreferences _internalDebugFeatures], kFeature, preferences,
+                                 @selector(_setEnabled:forInternalDebugFeature:));
+    }
+#else
+    (void)preferences;
+#endif
 }
 
 static NSRect constrainFrame(NSRect frame) {

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -1052,78 +1052,77 @@ static NSString *ZeroNativeJsonEscape(NSString *value) {
     return escaped;
 }
 
-zero_native_appkit_http_fetch_result_t zero_native_appkit_http_fetch(zero_native_appkit_host_t *host, const char *url, size_t url_len, char *buffer, size_t buffer_len) {
+// Builds the response JSON string consumed by the bridge:
+//   {"status":...,"contentType":"...","finalUrl":"...","base64":"..."}
+// contentType/finalUrl are JSON-escaped; base64 is always a safe charset.
+static NSString *ZeroNativeHttpFetchJson(NSInteger httpStatus, NSString *contentType, NSString *finalUrl, NSString *base64Body) {
+    return [NSString stringWithFormat:
+        @"{\"status\":%ld,\"contentType\":\"%@\",\"finalUrl\":\"%@\",\"base64\":\"%@\"}",
+        (long)httpStatus,
+        ZeroNativeJsonEscape(contentType),
+        ZeroNativeJsonEscape(finalUrl),
+        base64Body];
+}
+
+void zero_native_appkit_http_fetch_async(zero_native_appkit_host_t *host, const char *url, size_t url_len, zero_native_appkit_http_fetch_callback_t callback, void *ctx) {
     (void)host;
-    zero_native_appkit_http_fetch_result_t result = { .status = 0, .bytes_written = 0 };
-    @autoreleasepool {
-        NSString *requested = (url && url_len > 0)
-            ? [[NSString alloc] initWithBytes:url length:url_len encoding:NSUTF8StringEncoding]
-            : @"";
-        NSURL *target = requested.length > 0 ? [NSURL URLWithString:requested] : nil;
+    if (!callback) return;
 
-        __block NSInteger httpStatus = 0;
-        __block NSString *contentType = @"";
-        __block NSString *finalUrl = requested ?: @"";
-        __block NSString *base64Body = @"";
+    NSString *requested = (url && url_len > 0)
+        ? [[NSString alloc] initWithBytes:url length:url_len encoding:NSUTF8StringEncoding]
+        : @"";
+    NSURL *target = requested.length > 0 ? [NSURL URLWithString:requested] : nil;
 
-        if (target) {
-            NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:target];
-            request.HTTPMethod = @"GET";
-            request.timeoutInterval = 12.0;
-            request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-            [request setValue:@"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15"
-          forHTTPHeaderField:@"User-Agent"];
-
-            dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-            NSURLSession *session = [NSURLSession sharedSession];
-            // NSURLSession dispatches its completion handler on a background
-            // delegate queue, so blocking the caller with a semaphore here will
-            // not deadlock even when invoked from the main thread.
-            NSURLSessionDataTask *task = [session dataTaskWithRequest:request
-                                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                if (error == nil && response) {
-                    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-                        httpStatus = ((NSHTTPURLResponse *)response).statusCode;
-                    }
-                    if (response.MIMEType) contentType = response.MIMEType;
-                    if (response.URL && response.URL.absoluteString) finalUrl = response.URL.absoluteString;
-                    if (data) base64Body = [data base64EncodedStringWithOptions:0];
+    // Invoke the callback on the main thread with a JSON string. The callback
+    // must copy/serialize synchronously; the string is only valid during the call.
+    void (^deliver)(NSInteger, NSString *, NSString *, NSString *) =
+        ^(NSInteger status, NSString *contentType, NSString *finalUrl, NSString *base64Body) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            @autoreleasepool {
+                NSString *json = ZeroNativeHttpFetchJson(status, contentType, finalUrl, base64Body);
+                NSData *jsonData = [json dataUsingEncoding:NSUTF8StringEncoding];
+                if (jsonData) {
+                    callback(ctx, (int)status, (const char *)jsonData.bytes, jsonData.length);
+                } else {
+                    callback(ctx, 0, "", 0);
                 }
-                dispatch_semaphore_signal(sema);
-            }];
-            [task resume];
-            dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-        }
-
-        NSString *json = [NSString stringWithFormat:
-            @"{\"status\":%ld,\"contentType\":\"%@\",\"finalUrl\":\"%@\",\"base64\":\"%@\"}",
-            (long)httpStatus,
-            ZeroNativeJsonEscape(contentType),
-            ZeroNativeJsonEscape(finalUrl),
-            base64Body];
-        NSData *jsonData = [json dataUsingEncoding:NSUTF8StringEncoding];
-
-        if (jsonData && jsonData.length <= buffer_len) {
-            memcpy(buffer, jsonData.bytes, jsonData.length);
-            result.status = (int)httpStatus;
-            result.bytes_written = jsonData.length;
-        } else {
-            // The body is too large for the response buffer; return a small,
-            // valid JSON with an empty base64 so the JS side degrades gracefully.
-            NSString *fallback = [NSString stringWithFormat:
-                @"{\"status\":%ld,\"contentType\":\"%@\",\"finalUrl\":\"%@\",\"base64\":\"\"}",
-                (long)httpStatus,
-                ZeroNativeJsonEscape(contentType),
-                ZeroNativeJsonEscape(finalUrl)];
-            NSData *fallbackData = [fallback dataUsingEncoding:NSUTF8StringEncoding];
-            if (fallbackData && fallbackData.length <= buffer_len) {
-                memcpy(buffer, fallbackData.bytes, fallbackData.length);
-                result.status = (int)httpStatus;
-                result.bytes_written = fallbackData.length;
             }
-        }
+        });
+    };
+
+    if (!target) {
+        // Bad/empty URL: deliver an error result (status 0, empty body) without a request.
+        deliver(0, @"", requested ?: @"", @"");
+        return;
     }
-    return result;
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:target];
+    request.HTTPMethod = @"GET";
+    request.timeoutInterval = 12.0;
+    request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    [request setValue:@"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15"
+   forHTTPHeaderField:@"User-Agent"];
+
+    NSString *requestedUrl = requested;
+    NSURLSession *session = [NSURLSession sharedSession];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+                                           completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSInteger httpStatus = 0;
+        NSString *contentType = @"";
+        NSString *finalUrl = requestedUrl ?: @"";
+        NSString *base64Body = @"";
+        if (error == nil && response) {
+            if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                httpStatus = ((NSHTTPURLResponse *)response).statusCode;
+            }
+            if (response.MIMEType) contentType = response.MIMEType;
+            if (response.URL && response.URL.absoluteString) finalUrl = response.URL.absoluteString;
+            if (data) base64Body = [data base64EncodedStringWithOptions:0];
+        }
+        deliver(httpStatus, contentType, finalUrl, base64Body);
+    }];
+    // Start the request and return immediately; never block the caller.
+    [task resume];
 }
 
 static NSArray<NSString *> *ZeroNativeParseExtensions(const char *extensions, size_t len) {

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -459,7 +459,10 @@ static NSString *ZeroNativeAppKitBridgeScript(void) {
         "saveFile:function(options){return invoke('zero-native.dialog.saveFile',options||{});},"
         "showMessage:function(options){return invoke('zero-native.dialog.showMessage',options||{});}"
         "});"
-        "Object.defineProperty(window,'zero',{value:Object.freeze({invoke:invoke,on:on,off:off,windows:windows,dialogs:dialogs,_complete:complete,_emit:emit}),configurable:false});"
+        "var net=Object.freeze({"
+        "fetch:function(options){return invoke('zero-native.net.fetch',options||{});}"
+        "});"
+        "Object.defineProperty(window,'zero',{value:Object.freeze({invoke:invoke,on:on,off:off,windows:windows,dialogs:dialogs,net:net,_complete:complete,_emit:emit}),configurable:false});"
         "})();";
 }
 
@@ -1023,6 +1026,104 @@ void zero_native_appkit_clipboard_write(zero_native_appkit_host_t *host, const c
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     [pasteboard clearContents];
     [pasteboard setString:value forType:NSPasteboardTypeString];
+}
+
+static NSString *ZeroNativeJsonEscape(NSString *value) {
+    if (!value) return @"";
+    NSMutableString *escaped = [NSMutableString stringWithCapacity:value.length + 2];
+    NSUInteger length = value.length;
+    for (NSUInteger i = 0; i < length; i++) {
+        unichar c = [value characterAtIndex:i];
+        switch (c) {
+            case '"': [escaped appendString:@"\\\""]; break;
+            case '\\': [escaped appendString:@"\\\\"]; break;
+            case '\n': [escaped appendString:@"\\n"]; break;
+            case '\r': [escaped appendString:@"\\r"]; break;
+            case '\t': [escaped appendString:@"\\t"]; break;
+            default:
+                if (c < 0x20) {
+                    [escaped appendFormat:@"\\u%04x", c];
+                } else {
+                    [escaped appendFormat:@"%C", c];
+                }
+                break;
+        }
+    }
+    return escaped;
+}
+
+zero_native_appkit_http_fetch_result_t zero_native_appkit_http_fetch(zero_native_appkit_host_t *host, const char *url, size_t url_len, char *buffer, size_t buffer_len) {
+    (void)host;
+    zero_native_appkit_http_fetch_result_t result = { .status = 0, .bytes_written = 0 };
+    @autoreleasepool {
+        NSString *requested = (url && url_len > 0)
+            ? [[NSString alloc] initWithBytes:url length:url_len encoding:NSUTF8StringEncoding]
+            : @"";
+        NSURL *target = requested.length > 0 ? [NSURL URLWithString:requested] : nil;
+
+        __block NSInteger httpStatus = 0;
+        __block NSString *contentType = @"";
+        __block NSString *finalUrl = requested ?: @"";
+        __block NSString *base64Body = @"";
+
+        if (target) {
+            NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:target];
+            request.HTTPMethod = @"GET";
+            request.timeoutInterval = 12.0;
+            request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+            [request setValue:@"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15"
+          forHTTPHeaderField:@"User-Agent"];
+
+            dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+            NSURLSession *session = [NSURLSession sharedSession];
+            // NSURLSession dispatches its completion handler on a background
+            // delegate queue, so blocking the caller with a semaphore here will
+            // not deadlock even when invoked from the main thread.
+            NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+                                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error == nil && response) {
+                    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                        httpStatus = ((NSHTTPURLResponse *)response).statusCode;
+                    }
+                    if (response.MIMEType) contentType = response.MIMEType;
+                    if (response.URL && response.URL.absoluteString) finalUrl = response.URL.absoluteString;
+                    if (data) base64Body = [data base64EncodedStringWithOptions:0];
+                }
+                dispatch_semaphore_signal(sema);
+            }];
+            [task resume];
+            dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        }
+
+        NSString *json = [NSString stringWithFormat:
+            @"{\"status\":%ld,\"contentType\":\"%@\",\"finalUrl\":\"%@\",\"base64\":\"%@\"}",
+            (long)httpStatus,
+            ZeroNativeJsonEscape(contentType),
+            ZeroNativeJsonEscape(finalUrl),
+            base64Body];
+        NSData *jsonData = [json dataUsingEncoding:NSUTF8StringEncoding];
+
+        if (jsonData && jsonData.length <= buffer_len) {
+            memcpy(buffer, jsonData.bytes, jsonData.length);
+            result.status = (int)httpStatus;
+            result.bytes_written = jsonData.length;
+        } else {
+            // The body is too large for the response buffer; return a small,
+            // valid JSON with an empty base64 so the JS side degrades gracefully.
+            NSString *fallback = [NSString stringWithFormat:
+                @"{\"status\":%ld,\"contentType\":\"%@\",\"finalUrl\":\"%@\",\"base64\":\"\"}",
+                (long)httpStatus,
+                ZeroNativeJsonEscape(contentType),
+                ZeroNativeJsonEscape(finalUrl)];
+            NSData *fallbackData = [fallback dataUsingEncoding:NSUTF8StringEncoding];
+            if (fallbackData && fallbackData.length <= buffer_len) {
+                memcpy(buffer, fallbackData.bytes, fallbackData.length);
+                result.status = (int)httpStatus;
+                result.bytes_written = fallbackData.length;
+            }
+        }
+    }
+    return result;
 }
 
 static NSArray<NSString *> *ZeroNativeParseExtensions(const char *extensions, size_t len) {

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -196,10 +196,21 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
         return;
     }
 
-    NSURLResponse *response = [[NSURLResponse alloc] initWithURL:urlSchemeTask.request.URL
-                                                        MIMEType:ZeroNativeMimeTypeForPath(filePath)
-                                           expectedContentLength:(NSInteger)data.length
-                                                textEncodingName:nil];
+    // Respond with a real HTTP response (status 200 + headers), not a bare
+    // NSURLResponse. Resource loads (<script>/<link>/<img>) work with either,
+    // but fetch()/XHR -- and therefore WebAssembly.instantiate(Streaming) --
+    // need an NSHTTPURLResponse with a status and Content-Type, or they fail
+    // ("both async and sync fetching of the wasm failed").
+    NSDictionary<NSString *, NSString *> *headers = @{
+        @"Content-Type" : ZeroNativeMimeTypeForPath(filePath),
+        @"Content-Length" : [NSString stringWithFormat:@"%lu", (unsigned long)data.length],
+        @"Access-Control-Allow-Origin" : @"*",
+        @"Cache-Control" : @"no-cache",
+    };
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:urlSchemeTask.request.URL
+                                                             statusCode:200
+                                                            HTTPVersion:@"HTTP/1.1"
+                                                           headerFields:headers];
     [urlSchemeTask didReceiveResponse:response];
     [urlSchemeTask didReceiveData:data];
     [urlSchemeTask didFinish];

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -27,6 +27,9 @@ static NSString *ZeroNativeAppKitBridgeScript(void);
 static NSString *ZeroNativeMimeTypeForPath(NSString *path);
 static NSString *ZeroNativeResolvedAssetRoot(NSString *rootPath);
 static NSString *ZeroNativeSafeAssetPath(NSURL *url, NSString *entryPath);
+// Serve an arbitrary local file (image/video) at zero://media/<base64url-abspath>
+// with HTTP range support, so <video> can stream + seek. See startURLSchemeTask.
+static void ZeroNativeServeMediaTask(id<WKURLSchemeTask> urlSchemeTask);
 static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath);
 static NSArray<NSString *> *ZeroNativePolicyListFromBytes(const char *bytes, size_t len, NSArray<NSString *> *fallback);
 static NSString *ZeroNativeOriginForURL(NSURL *url);
@@ -174,6 +177,12 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
     (void)webView;
+    // zero://media/<base64url-abspath> serves a local file with range support
+    // (for <video> streaming/seeking), separate from the bundled asset root.
+    if ([urlSchemeTask.request.URL.host.lowercaseString isEqualToString:@"media"]) {
+        ZeroNativeServeMediaTask(urlSchemeTask);
+        return;
+    }
     NSString *relativePath = ZeroNativeSafeAssetPath(urlSchemeTask.request.URL, self.entryPath);
     if (!relativePath) {
         NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorBadURL userInfo:nil];
@@ -488,6 +497,9 @@ static NSString *ZeroNativeMimeTypeForPath(NSString *path) {
     if ([ext isEqualToString:@"jpg"] || [ext isEqualToString:@"jpeg"]) return @"image/jpeg";
     if ([ext isEqualToString:@"gif"]) return @"image/gif";
     if ([ext isEqualToString:@"webp"]) return @"image/webp";
+    if ([ext isEqualToString:@"avif"]) return @"image/avif";
+    if ([ext isEqualToString:@"mp4"] || [ext isEqualToString:@"m4v"]) return @"video/mp4";
+    if ([ext isEqualToString:@"mov"] || [ext isEqualToString:@"qt"]) return @"video/quicktime";
     if ([ext isEqualToString:@"woff"]) return @"font/woff";
     if ([ext isEqualToString:@"woff2"]) return @"font/woff2";
     if ([ext isEqualToString:@"ttf"]) return @"font/ttf";
@@ -536,6 +548,116 @@ static NSString *ZeroNativeSafeAssetPath(NSURL *url, NSString *entryPath) {
     if (path.length == 0) return entryPath.length > 0 ? entryPath : @"index.html";
     if (ZeroNativePathHasUnsafeSegment(path)) return nil;
     return path;
+}
+
+// Decode a URL-safe base64 string (no padding) back to its bytes as a string.
+static NSString *ZeroNativeDecodeBase64URL(NSString *s) {
+    if (s.length == 0) return nil;
+    NSMutableString *b64 = [[s stringByReplacingOccurrencesOfString:@"-" withString:@"+"] mutableCopy];
+    [b64 replaceOccurrencesOfString:@"_" withString:@"/" options:0 range:NSMakeRange(0, b64.length)];
+    while (b64.length % 4 != 0) [b64 appendString:@"="];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:b64 options:0];
+    if (!data) return nil;
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
+static void ZeroNativeServeMediaTask(id<WKURLSchemeTask> urlSchemeTask) {
+    NSURL *reqURL = urlSchemeTask.request.URL;
+    // The absolute file path rides in the URL path as URL-safe base64.
+    NSString *encoded = reqURL.path;
+    while ([encoded hasPrefix:@"/"]) encoded = [encoded substringFromIndex:1];
+    NSString *path = ZeroNativeDecodeBase64URL(encoded);
+
+    BOOL isDir = NO;
+    BOOL exists = path.length > 0 && [path hasPrefix:@"/"] &&
+        !ZeroNativePathHasUnsafeSegment(path) &&
+        [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir;
+    if (!exists) {
+        [urlSchemeTask didFailWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                            code:NSURLErrorFileDoesNotExist
+                                                        userInfo:nil]];
+        return;
+    }
+
+    NSDictionary *attrs = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
+    unsigned long long fileSize = attrs ? attrs.fileSize : 0;
+
+    // Parse an optional `Range: bytes=START-END` (END or START may be empty).
+    unsigned long long start = 0, end = fileSize > 0 ? fileSize - 1 : 0;
+    BOOL isRange = NO;
+    NSString *rangeHeader = urlSchemeTask.request.allHTTPHeaderFields[@"Range"];
+    if (fileSize > 0 && [rangeHeader hasPrefix:@"bytes="]) {
+        NSArray<NSString *> *parts = [[rangeHeader substringFromIndex:6] componentsSeparatedByString:@"-"];
+        if (parts.count == 2) {
+            NSString *s = parts[0], *e = parts[1];
+            if (s.length == 0 && e.length > 0) { // suffix range: last N bytes
+                unsigned long long n = strtoull(e.UTF8String, NULL, 10);
+                start = n >= fileSize ? 0 : fileSize - n;
+                end = fileSize - 1;
+            } else {
+                if (s.length > 0) start = strtoull(s.UTF8String, NULL, 10);
+                if (e.length > 0) end = strtoull(e.UTF8String, NULL, 10);
+            }
+            isRange = YES;
+        }
+    }
+    if (end >= fileSize) end = fileSize > 0 ? fileSize - 1 : 0;
+    if (fileSize == 0 || start > end) { start = 0; end = 0; isRange = NO; }
+    unsigned long long length = fileSize == 0 ? 0 : end - start + 1;
+
+    NSData *data = nil;
+    if (fileSize > 0) {
+        NSFileHandle *fh = [NSFileHandle fileHandleForReadingAtPath:path];
+        if (!fh) {
+            [urlSchemeTask didFailWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                                code:NSURLErrorCannotOpenFile
+                                                            userInfo:nil]];
+            return;
+        }
+        @try {
+            [fh seekToFileOffset:start];
+            data = [fh readDataOfLength:(NSUInteger)length];
+        } @catch (__unused NSException *ex) {
+            data = nil;
+        } @finally {
+            [fh closeFile];
+        }
+        if (!data) {
+            [urlSchemeTask didFailWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                                code:NSURLErrorCannotOpenFile
+                                                            userInfo:nil]];
+            return;
+        }
+    } else {
+        data = [NSData data];
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *headers = [@{
+        @"Content-Type" : ZeroNativeMimeTypeForPath(path),
+        @"Content-Length" : [NSString stringWithFormat:@"%llu", length],
+        @"Accept-Ranges" : @"bytes",
+        @"Access-Control-Allow-Origin" : @"*",
+        @"Cache-Control" : @"no-cache",
+    } mutableCopy];
+    NSInteger status = 200;
+    if (isRange) {
+        status = 206;
+        headers[@"Content-Range"] =
+            [NSString stringWithFormat:@"bytes %llu-%llu/%llu", start, end, fileSize];
+    }
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:reqURL
+                                                             statusCode:status
+                                                            HTTPVersion:@"HTTP/1.1"
+                                                           headerFields:headers];
+    // The player cancels in-flight tasks on every seek; calling back into a
+    // stopped task throws, so guard the delivery.
+    @try {
+        [urlSchemeTask didReceiveResponse:response];
+        [urlSchemeTask didReceiveData:data];
+        [urlSchemeTask didFinish];
+    } @catch (__unused NSException *ex) {
+        // task already stopped — nothing to do
+    }
 }
 
 static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath) {

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -49,7 +49,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
 - (void)configureWithRootPath:(NSString *)rootPath entryPath:(NSString *)entryPath spaFallback:(BOOL)spaFallback;
 @end
 
-@interface ZeroNativeAppKitHost : NSObject <WKNavigationDelegate>
+@interface ZeroNativeAppKitHost : NSObject <WKNavigationDelegate, WKUIDelegate>
 @property(nonatomic, strong) NSWindow *window;
 @property(nonatomic, strong) WKWebView *webView;
 @property(nonatomic, strong) ZeroNativeWindowDelegate *delegate;
@@ -287,6 +287,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
         [webView setValue:@YES forKey:@"inspectable"];
     }
     webView.navigationDelegate = self;
+    webView.UIDelegate = self;
     webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     window.contentView = webView;
 
@@ -757,6 +758,28 @@ static NSURL *ZeroNativeAssetEntryURL(NSString *origin, NSString *entryPath) {
         return;
     }
     decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+// WKUIDelegate: back HTML <input type="file"> with a native NSOpenPanel.
+// Without this, file inputs silently do nothing inside a WKWebView.
+- (void)webView:(WKWebView *)webView
+    runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters
+              initiatedByFrame:(WKFrameInfo *)frame
+             completionHandler:(void (^)(NSArray<NSURL *> *URLs))completionHandler {
+    (void)frame;
+    NSOpenPanel *panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = YES;
+    panel.canChooseDirectories = NO;
+    panel.allowsMultipleSelection = parameters.allowsMultipleSelection;
+    void (^complete)(NSModalResponse) = ^(NSModalResponse result) {
+        completionHandler(result == NSModalResponseOK ? panel.URLs : nil);
+    };
+    NSWindow *host = webView.window;
+    if (host) {
+        [panel beginSheetModalForWindow:host completionHandler:complete];
+    } else {
+        complete([panel runModal]);
+    }
 }
 
 - (NSString *)bridgeOriginForMessage:(WKScriptMessage *)message {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -97,6 +97,13 @@ const AppKitMessageDialogOpts = extern struct {
     tertiary_button_len: usize,
 };
 
+const AppKitHttpFetchResult = extern struct {
+    status: c_int,
+    bytes_written: usize,
+};
+
+extern fn zero_native_appkit_http_fetch(host: *AppKitHost, url: [*]const u8, url_len: usize, buffer: [*]u8, buffer_len: usize) AppKitHttpFetchResult;
+
 const AppKitTrayCallback = *const fn (context: ?*anyopaque, item_id: u32) callconv(.c) void;
 
 extern fn zero_native_appkit_show_open_dialog(host: *AppKitHost, opts: *const AppKitOpenDialogOpts, buffer: [*]u8, buffer_len: usize) AppKitOpenDialogResult;
@@ -163,6 +170,7 @@ pub const MacPlatform = struct {
                 .show_open_dialog_fn = showOpenDialog,
                 .show_save_dialog_fn = showSaveDialog,
                 .show_message_dialog_fn = showMessageDialog,
+                .http_fetch_fn = httpFetch,
                 .create_tray_fn = createTray,
                 .update_tray_menu_fn = updateTrayMenu,
                 .remove_tray_fn = removeTray,
@@ -408,6 +416,13 @@ fn showMessageDialog(context: ?*anyopaque, options: platform_mod.MessageDialogOp
     };
     const result = zero_native_appkit_show_message_dialog(self.host, &opts);
     return @enumFromInt(result);
+}
+
+fn httpFetch(context: ?*anyopaque, url: []const u8, buffer: []u8) anyerror![]const u8 {
+    const self: *MacPlatform = @ptrCast(@alignCast(context.?));
+    const result = zero_native_appkit_http_fetch(self.host, url.ptr, url.len, buffer.ptr, buffer.len);
+    if (result.bytes_written == 0 or result.bytes_written > buffer.len) return error.NoSpaceLeft;
+    return buffer[0..result.bytes_written];
 }
 
 const max_tray_items: usize = 32;

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -97,12 +97,7 @@ const AppKitMessageDialogOpts = extern struct {
     tertiary_button_len: usize,
 };
 
-const AppKitHttpFetchResult = extern struct {
-    status: c_int,
-    bytes_written: usize,
-};
-
-extern fn zero_native_appkit_http_fetch(host: *AppKitHost, url: [*]const u8, url_len: usize, buffer: [*]u8, buffer_len: usize) AppKitHttpFetchResult;
+extern fn zero_native_appkit_http_fetch_async(host: *AppKitHost, url: [*]const u8, url_len: usize, callback: platform_mod.HttpFetchCallback, ctx: ?*anyopaque) void;
 
 const AppKitTrayCallback = *const fn (context: ?*anyopaque, item_id: u32) callconv(.c) void;
 
@@ -170,7 +165,7 @@ pub const MacPlatform = struct {
                 .show_open_dialog_fn = showOpenDialog,
                 .show_save_dialog_fn = showSaveDialog,
                 .show_message_dialog_fn = showMessageDialog,
-                .http_fetch_fn = httpFetch,
+                .http_fetch_async_fn = httpFetchAsync,
                 .create_tray_fn = createTray,
                 .update_tray_menu_fn = updateTrayMenu,
                 .remove_tray_fn = removeTray,
@@ -418,11 +413,9 @@ fn showMessageDialog(context: ?*anyopaque, options: platform_mod.MessageDialogOp
     return @enumFromInt(result);
 }
 
-fn httpFetch(context: ?*anyopaque, url: []const u8, buffer: []u8) anyerror![]const u8 {
+fn httpFetchAsync(context: ?*anyopaque, url: []const u8, callback: platform_mod.HttpFetchCallback, ctx: ?*anyopaque) anyerror!void {
     const self: *MacPlatform = @ptrCast(@alignCast(context.?));
-    const result = zero_native_appkit_http_fetch(self.host, url.ptr, url.len, buffer.ptr, buffer.len);
-    if (result.bytes_written == 0 or result.bytes_written > buffer.len) return error.NoSpaceLeft;
-    return buffer[0..result.bytes_written];
+    zero_native_appkit_http_fetch_async(self.host, url.ptr, url.len, callback, ctx);
 }
 
 const max_tray_items: usize = 32;

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -271,6 +271,12 @@ pub const Event = union(enum) {
 
 pub const EventHandler = *const fn (context: *anyopaque, event: Event) anyerror!void;
 
+// C callback fired (on the main thread) when an async HTTP fetch completes. The
+// `json_utf8`/`json_len` slice describes the full response object and is only
+// valid for the duration of the call — the receiver must copy/serialize it
+// synchronously.
+pub const HttpFetchCallback = *const fn (ctx: ?*anyopaque, status: c_int, json_utf8: [*]const u8, json_len: usize) callconv(.c) void;
+
 pub const PlatformServices = struct {
     context: ?*anyopaque = null,
     read_clipboard_fn: ?*const fn (context: ?*anyopaque, buffer: []u8) anyerror![]const u8 = null,
@@ -285,7 +291,7 @@ pub const PlatformServices = struct {
     show_open_dialog_fn: ?*const fn (context: ?*anyopaque, options: OpenDialogOptions, buffer: []u8) anyerror!OpenDialogResult = null,
     show_save_dialog_fn: ?*const fn (context: ?*anyopaque, options: SaveDialogOptions, buffer: []u8) anyerror!?[]const u8 = null,
     show_message_dialog_fn: ?*const fn (context: ?*anyopaque, options: MessageDialogOptions) anyerror!MessageDialogResult = null,
-    http_fetch_fn: ?*const fn (context: ?*anyopaque, url: []const u8, buffer: []u8) anyerror![]const u8 = null,
+    http_fetch_async_fn: ?*const fn (context: ?*anyopaque, url: []const u8, callback: HttpFetchCallback, ctx: ?*anyopaque) anyerror!void = null,
     create_tray_fn: ?*const fn (context: ?*anyopaque, options: TrayOptions) anyerror!void = null,
     update_tray_menu_fn: ?*const fn (context: ?*anyopaque, items: []const TrayMenuItem) anyerror!void = null,
     remove_tray_fn: ?*const fn (context: ?*anyopaque) anyerror!void = null,
@@ -356,9 +362,9 @@ pub const PlatformServices = struct {
         return msg_fn(self.context, options);
     }
 
-    pub fn httpFetch(self: PlatformServices, url: []const u8, buffer: []u8) anyerror![]const u8 {
-        const fetch_fn = self.http_fetch_fn orelse return error.UnsupportedService;
-        return fetch_fn(self.context, url, buffer);
+    pub fn httpFetchAsync(self: PlatformServices, url: []const u8, callback: HttpFetchCallback, ctx: ?*anyopaque) anyerror!void {
+        const fetch_fn = self.http_fetch_async_fn orelse return error.UnsupportedService;
+        return fetch_fn(self.context, url, callback, ctx);
     }
 
     pub fn createTray(self: PlatformServices, options: TrayOptions) anyerror!void {

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -285,6 +285,7 @@ pub const PlatformServices = struct {
     show_open_dialog_fn: ?*const fn (context: ?*anyopaque, options: OpenDialogOptions, buffer: []u8) anyerror!OpenDialogResult = null,
     show_save_dialog_fn: ?*const fn (context: ?*anyopaque, options: SaveDialogOptions, buffer: []u8) anyerror!?[]const u8 = null,
     show_message_dialog_fn: ?*const fn (context: ?*anyopaque, options: MessageDialogOptions) anyerror!MessageDialogResult = null,
+    http_fetch_fn: ?*const fn (context: ?*anyopaque, url: []const u8, buffer: []u8) anyerror![]const u8 = null,
     create_tray_fn: ?*const fn (context: ?*anyopaque, options: TrayOptions) anyerror!void = null,
     update_tray_menu_fn: ?*const fn (context: ?*anyopaque, items: []const TrayMenuItem) anyerror!void = null,
     remove_tray_fn: ?*const fn (context: ?*anyopaque) anyerror!void = null,
@@ -353,6 +354,11 @@ pub const PlatformServices = struct {
     pub fn showMessageDialog(self: PlatformServices, options: MessageDialogOptions) anyerror!MessageDialogResult {
         const msg_fn = self.show_message_dialog_fn orelse return error.UnsupportedService;
         return msg_fn(self.context, options);
+    }
+
+    pub fn httpFetch(self: PlatformServices, url: []const u8, buffer: []u8) anyerror![]const u8 {
+        const fetch_fn = self.http_fetch_fn orelse return error.UnsupportedService;
+        return fetch_fn(self.context, url, buffer);
     }
 
     pub fn createTray(self: PlatformServices, options: TrayOptions) anyerror!void {

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -386,12 +386,12 @@ pub const Runtime = struct {
         if (try self.handleBuiltinBridgeMessage(message)) return;
         var dispatcher = self.options.bridge orelse bridge.Dispatcher{};
         if (self.options.security.permissions.len > 0) dispatcher.policy.permissions = self.options.security.permissions;
-        var response_buffer: [bridge.max_response_bytes]u8 = undefined;
+        const response_buffer = bridge.sharedResponseBuffer();
         if (try self.handleAsyncBridgeMessage(dispatcher, message)) {
             self.invalidateFor(.command, null);
             return;
         }
-        const response = dispatcher.dispatch(message.bytes, .{ .origin = message.origin, .window_id = message.window_id }, &response_buffer);
+        const response = dispatcher.dispatch(message.bytes, .{ .origin = message.origin, .window_id = message.window_id }, response_buffer);
         try self.completeBridgeResponse(message.window_id, response);
         self.invalidateFor(.command, null);
         try self.log("bridge.dispatch", "bridge request handled", &.{
@@ -404,8 +404,8 @@ pub const Runtime = struct {
         const request = bridge.parseRequest(message.bytes) catch return false;
         const handler = dispatcher.async_registry.find(request.command) orelse return false;
         if (!dispatcher.policy.allows(request.command, message.origin)) {
-            var response_buffer: [bridge.max_response_bytes]u8 = undefined;
-            const response = bridge.writeErrorResponse(&response_buffer, request.id, .permission_denied, "Bridge command is not permitted");
+            const response_buffer = bridge.sharedResponseBuffer();
+            const response = bridge.writeErrorResponse(response_buffer, request.id, .permission_denied, "Bridge command is not permitted");
             try self.completeBridgeResponse(message.window_id, response);
             return true;
         }
@@ -536,21 +536,24 @@ pub const Runtime = struct {
         const request = bridge.parseRequest(message.bytes) catch return false;
         const is_window = std.mem.startsWith(u8, request.command, "zero-native.window.");
         const is_dialog = std.mem.startsWith(u8, request.command, "zero-native.dialog.");
-        if (!is_window and !is_dialog) return false;
+        const is_net = std.mem.startsWith(u8, request.command, "zero-native.net.");
+        if (!is_window and !is_dialog and !is_net) return false;
 
-        var response_buffer: [bridge.max_response_bytes]u8 = undefined;
-        var result_buffer: [bridge.max_result_bytes]u8 = undefined;
+        const response_buffer = bridge.sharedResponseBuffer();
+        const result_buffer = bridge.sharedResultBuffer();
         if (!self.allowsBuiltinBridgeCommand(request.command, message.origin, is_window)) {
-            const message_text = if (is_window) "Window API is not permitted" else "Dialog API is not permitted";
-            const result = bridge.writeErrorResponse(&response_buffer, request.id, .permission_denied, message_text);
+            const message_text = if (is_window) "Window API is not permitted" else if (is_net) "Net API is not permitted" else "Dialog API is not permitted";
+            const result = bridge.writeErrorResponse(response_buffer, request.id, .permission_denied, message_text);
             try self.completeBridgeResponse(message.window_id, result);
             self.invalidateFor(.command, null);
             return true;
         }
         const result = if (is_window)
-            self.dispatchWindowBridgeCommand(request, &result_buffer, &response_buffer)
+            self.dispatchWindowBridgeCommand(request, result_buffer, response_buffer)
+        else if (is_net)
+            self.dispatchNetBridgeCommand(request, result_buffer, response_buffer)
         else
-            self.dispatchDialogBridgeCommand(request, &result_buffer, &response_buffer);
+            self.dispatchDialogBridgeCommand(request, result_buffer, response_buffer);
 
         try self.completeBridgeResponse(message.window_id, result);
         self.invalidateFor(.command, null);
@@ -598,6 +601,24 @@ pub const Runtime = struct {
         else
             return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown dialog command");
         return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    }
+
+    fn dispatchNetBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
+        const result = if (std.mem.eql(u8, request.command, "zero-native.net.fetch"))
+            self.netFetchFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
+        else
+            return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown net command");
+        return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    }
+
+    fn netFetchFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
+        var storage_buffer: [platform.max_dialog_path_bytes]u8 = undefined;
+        var storage = json.StringStorage.init(&storage_buffer);
+        const url = jsonStringField(payload, "url", &storage) orelse "";
+        if (url.len == 0) return error.InvalidArgument;
+        // The native fetch writes a complete JSON object describing the response
+        // (status/contentType/finalUrl/base64) straight into `output`.
+        return try self.options.platform.services.httpFetch(url, output);
     }
 
     fn openFileDialogFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
@@ -834,6 +855,7 @@ fn builtinBridgeErrorMessage(err: anyerror) []const u8 {
         error.InvalidWindowOptions => "Window options are invalid",
         error.DuplicateWindowId => "Window id already exists",
         error.NoSpaceLeft => "Native response buffer is too small",
+        error.InvalidArgument => "A required argument is missing or invalid",
         else => "Native command failed",
     };
 }

--- a/src/runtime/root.zig
+++ b/src/runtime/root.zig
@@ -79,6 +79,7 @@ pub const App = struct {
 };
 
 pub const Options = struct {
+    allocator: std.mem.Allocator = std.heap.c_allocator,
     platform: platform.Platform,
     trace_sink: ?trace.Sink = null,
     log_path: ?[]const u8 = null,
@@ -548,10 +549,16 @@ pub const Runtime = struct {
             self.invalidateFor(.command, null);
             return true;
         }
+        if (is_net) {
+            // net.fetch runs asynchronously: it dispatches a non-blocking HTTP
+            // request and responds later from the native completion callback.
+            try self.dispatchNetBridgeCommandAsync(request, message);
+            self.invalidateFor(.command, null);
+            return true;
+        }
+
         const result = if (is_window)
             self.dispatchWindowBridgeCommand(request, result_buffer, response_buffer)
-        else if (is_net)
-            self.dispatchNetBridgeCommand(request, result_buffer, response_buffer)
         else
             self.dispatchDialogBridgeCommand(request, result_buffer, response_buffer);
 
@@ -603,22 +610,60 @@ pub const Runtime = struct {
         return bridge.writeSuccessResponse(response_buffer, request.id, result);
     }
 
-    fn dispatchNetBridgeCommand(self: *Runtime, request: bridge.Request, result_buffer: []u8, response_buffer: []u8) []const u8 {
-        const result = if (std.mem.eql(u8, request.command, "zero-native.net.fetch"))
-            self.netFetchFromJson(request.payload, result_buffer) catch |err| return bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err))
-        else
-            return bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown net command");
-        return bridge.writeSuccessResponse(response_buffer, request.id, result);
+    fn dispatchNetBridgeCommandAsync(self: *Runtime, request: bridge.Request, message: platform.BridgeMessage) anyerror!void {
+        if (!std.mem.eql(u8, request.command, "zero-native.net.fetch")) {
+            const response_buffer = bridge.sharedResponseBuffer();
+            const response = bridge.writeErrorResponse(response_buffer, request.id, .unknown_command, "Unknown net command");
+            try self.completeBridgeResponse(message.window_id, response);
+            return;
+        }
+        self.netFetchAsyncFromJson(request, message) catch |err| {
+            const response_buffer = bridge.sharedResponseBuffer();
+            const response = bridge.writeErrorResponse(response_buffer, request.id, .internal_error, builtinBridgeErrorMessage(err));
+            try self.completeBridgeResponse(message.window_id, response);
+        };
     }
 
-    fn netFetchFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
+    fn netFetchAsyncFromJson(self: *Runtime, request: bridge.Request, message: platform.BridgeMessage) !void {
         var storage_buffer: [platform.max_dialog_path_bytes]u8 = undefined;
         var storage = json.StringStorage.init(&storage_buffer);
-        const url = jsonStringField(payload, "url", &storage) orelse "";
+        const url = jsonStringField(request.payload, "url", &storage) orelse "";
         if (url.len == 0) return error.InvalidArgument;
-        // The native fetch writes a complete JSON object describing the response
-        // (status/contentType/finalUrl/base64) straight into `output`.
-        return try self.options.platform.services.httpFetch(url, output);
+
+        const allocator = self.netFetchAllocator();
+        // The context owns copies of everything the deferred trampoline needs:
+        // the request id, the origin (the incoming message buffer is transient),
+        // the window id, the responder, and a NUL-free copy of the URL.
+        const ctx = try allocator.create(NetFetchContext);
+        errdefer allocator.destroy(ctx);
+        ctx.* = .{
+            .runtime = self,
+            .allocator = allocator,
+            .window_id = message.window_id,
+            .id = undefined,
+            .origin = undefined,
+            .url = undefined,
+            .responder = .{
+                .context = self,
+                .source = .{ .origin = "", .window_id = message.window_id },
+                .respond_fn = asyncBridgeRespond,
+            },
+        };
+        ctx.id = try allocator.dupe(u8, request.id);
+        errdefer allocator.free(ctx.id);
+        ctx.origin = try allocator.dupe(u8, message.origin);
+        errdefer allocator.free(ctx.origin);
+        ctx.responder.source.origin = ctx.origin;
+        ctx.url = try allocator.dupe(u8, url);
+        errdefer allocator.free(ctx.url);
+
+        // After this call, ownership of `ctx` transfers to the trampoline, which
+        // frees it exactly once when the native fetch completes on the main thread.
+        try self.options.platform.services.httpFetchAsync(ctx.url, netFetchTrampoline, ctx);
+    }
+
+    fn netFetchAllocator(self: *Runtime) std.mem.Allocator {
+        return self.options.allocator;
     }
 
     fn openFileDialogFromJson(self: *Runtime, payload: []const u8, output: []u8) ![]const u8 {
@@ -784,6 +829,38 @@ pub const Runtime = struct {
         return trace.Timestamp.fromNanoseconds(self.timestamp_ns);
     }
 };
+
+// Heap-allocated state that outlives the synchronous dispatch of a net.fetch
+// request and is consumed once by `netFetchTrampoline` on the main thread.
+const NetFetchContext = struct {
+    runtime: *Runtime,
+    allocator: std.mem.Allocator,
+    window_id: platform.WindowId,
+    id: []u8,
+    origin: []u8,
+    url: []u8,
+    responder: bridge.AsyncResponder,
+};
+
+// Runs on the main thread when the native HTTP fetch completes. `json_utf8`/
+// `json_len` is the native-built response object and is only valid for the
+// duration of this call, so it is serialized synchronously here. Frees the
+// owning context exactly once before returning.
+fn netFetchTrampoline(ctx_ptr: ?*anyopaque, status: c_int, json_utf8: [*]const u8, json_len: usize) callconv(.c) void {
+    _ = status;
+    const ctx: *NetFetchContext = @ptrCast(@alignCast(ctx_ptr.?));
+    const allocator = ctx.allocator;
+    defer {
+        allocator.free(ctx.url);
+        allocator.free(ctx.origin);
+        allocator.free(ctx.id);
+        allocator.destroy(ctx);
+    }
+
+    const result_json = json_utf8[0..json_len];
+    const response = bridge.writeSuccessResponse(bridge.sharedResponseBuffer(), ctx.id, result_json);
+    ctx.responder.respond_fn(ctx.responder.context, ctx.responder.source, response) catch {};
+}
 
 fn nowNanoseconds() i128 {
     switch (@import("builtin").os.tag) {


### PR DESCRIPTION
## Problem

WKWebView on macOS clamps `requestAnimationFrame` to ~60fps **regardless of the display's refresh rate**, via WebKit's internal feature flag `PreferPageRenderingUpdatesNear60FPSEnabled` (enabled by default in WKWebView, disabled in Safari).

The result: every zero-native macOS app is capped at 60fps on ProMotion / high-refresh displays, even though the *identical* content runs at 120fps in Safari and Chrome. I hit this with a WebGPU canvas — 60fps in the zero-native shell, 120fps in Safari/Chrome loading the same dev server.

Relevant WebKit history: [bug 74964](https://bugs.webkit.org/show_bug.cgi?id=74964), [bug 173434](https://bugs.webkit.org/show_bug.cgi?id=173434).

## Change

Adds an **opt-in** path in the AppKit/WKWebView host that disables the feature when configuring the web view, via WebKit's private feature-flags SPI:
- class methods `+[WKPreferences _features]` / `_experimentalFeatures` / `_internalDebugFeatures`
- the matching `-_setEnabled:forFeature:` setters (the same mechanism Safari uses internally)

Every call is guarded with `respondsToSelector:`, so it safely no-ops if the SPI ever changes.

## Opt-in / App Store safety

This relies on a **private API**, so it's **off by default** — the code compiles out entirely unless the host is built with `-DZERO_NATIVE_MACOS_HIGH_REFRESH=1`. App-Store builds are therefore unaffected; direct-download apps can enable it by adding that define to the `appkit_host.m` compile flags in their `build.zig`, e.g.:

```zig
const flags: []const []const u8 = ... ++ &.{ "-DZERO_NATIVE_MACOS_HIGH_REFRESH=1" };
app_mod.addCSourceFile(.{ .file = ...appkit_host.m, .flags = flags });
```

Happy to also wire a `-Dmacos-high-refresh` build option into the generated `build.zig` template (`src/tooling/templates.zig`) + examples if you'd prefer that surface — left it out of this PR to keep the change focused and let you pick the ergonomics.

## Verification

macOS 26.3 (M3, 120Hz ProMotion):
- **with** `-DZERO_NATIVE_MACOS_HIGH_REFRESH=1`: WebGPU canvas `requestAnimationFrame` goes **60 → 120fps**
- **without** it: unchanged (60fps; the SPI is never touched)