### PR TITLE
Add a mobile menu to the doc site header

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { GeistPixelSquare } from "geist/font/pixel";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Search } from "@/components/search";
-import { HeaderNav } from "@/components/header-nav";
+import { HeaderNav, HeaderMobileMenu } from "@/components/header-nav";
 import { DocsMobileNav } from "@/components/docs-mobile-nav";
 import { DocsNav } from "@/components/docs-nav";
 import { getStarCount } from "@/lib/github";
@@ -94,7 +94,10 @@ function Header({ stars }: { stars?: string }) {
             </svg>
             {stars && <span>{stars}</span>}
           </a>
-          <ThemeToggle />
+          <div className="hidden md:block">
+            <ThemeToggle />
+          </div>
+          <HeaderMobileMenu />
         </div>
       </div>
     </header>

--- a/docs/src/components/header-nav.tsx
+++ b/docs/src/components/header-nav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Sheet, SheetTrigger, SheetContent, SheetTitle } from "@/components/ui/sheet";
 
 const links = [
   { name: "Home", href: "/" },
@@ -37,5 +39,61 @@ export function HeaderNav() {
         );
       })}
     </nav>
+  );
+}
+
+export function HeaderMobileMenu() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        aria-label="Open menu"
+        className="md:hidden flex items-center text-gray-900 hover:text-gray-1000 transition-colors"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="4" y1="6" x2="20" y2="6" />
+          <line x1="4" y1="12" x2="20" y2="12" />
+          <line x1="4" y1="18" x2="20" y2="18" />
+        </svg>
+      </SheetTrigger>
+      <SheetContent side="right" className="overflow-y-auto overscroll-contain p-6">
+        <SheetTitle className="sr-only">Site menu</SheetTitle>
+        <nav aria-label="Site" className="mt-8">
+          <ul className="space-y-0.5">
+            {links.map(({ name, href }) => {
+              const current = isCurrent(href, pathname);
+              return (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    onClick={() => setOpen(false)}
+                    aria-current={current ? "page" : undefined}
+                    className={`text-sm block py-2 transition-colors ${
+                      current
+                        ? "text-neutral-900 dark:text-neutral-100 font-medium"
+                        : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100"
+                    }`}
+                  >
+                    {name}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -117,7 +117,7 @@ export function Search() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="hidden sm:flex h-8 items-center gap-2 rounded-md border border-gray-alpha-400 bg-background-200 px-3 label-14 text-gray-900 hover:text-gray-1000 hover:border-gray-alpha-500 transition-colors"
+        className="hidden md:flex h-8 items-center gap-2 rounded-md border border-gray-alpha-400 bg-background-200 px-3 label-14 text-gray-900 hover:text-gray-1000 hover:border-gray-alpha-500 transition-colors"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -137,27 +137,6 @@ export function Search() {
         <kbd className="pointer-events-none flex h-5 items-center rounded border border-gray-alpha-400 bg-background-100 px-1 font-sans text-[11px] leading-none text-gray-900">
           &#8984;K
         </kbd>
-      </button>
-
-      <button
-        onClick={() => setOpen(true)}
-        className="sm:hidden flex items-center text-gray-900 hover:text-gray-1000 transition-colors"
-        aria-label="Search docs"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <circle cx="11" cy="11" r="8" />
-          <path d="m21 21-4.3-4.3" />
-        </svg>
       </button>
 
       <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
- Add a hamburger button on mobile that opens the site nav (Home, Docs, Components) in a sheet
- Hide the search box and theme toggle below the md breakpoint so the mobile header stays minimal