### PR TITLE
Ship CLI package assets

### DIFF
--- a/changelog.d/native-sdk-package-assets.md
+++ b/changelog.d/native-sdk-package-assets.md
@@ -1,0 +1,1 @@
+fix: **CLI package assets**: `@native-sdk/cli` now ships the SDK `assets/` payload so Windows builds can find `native-sdk.manifest` after a fresh npm install.


### PR DESCRIPTION
## Summary

Follow-up for #72.

The packaging fix for `@native-sdk/cli` assets has already landed on upstream `main`; this PR now keeps the release notes aligned by adding the changelog fragment for that fix.

## Validation

- Rebased onto current `origin/main`; PR is mergeable
- Socket checks pass on the rebased commit
- Vercel preview deployment still requires Vercel authorization for this forked PR
