### PR TITLE
docs: clarify JS to Zig bridge example

### DIFF
--- a/changelog.d/bridge-docs-js-zig-example.md
+++ b/changelog.d/bridge-docs-js-zig-example.md
@@ -1,0 +1,1 @@
+improvement: **Bridge docs**: the Web Content and Bridge docs now point directly to a complete JavaScript-to-Zig custom command flow, with `examples/webview` called out as the runnable reference.

--- a/docs/src/app/bridge/page.mdx
+++ b/docs/src/app/bridge/page.mdx
@@ -2,6 +2,8 @@
 
 For apps that [embed web content](/frontend), the bridge connects JavaScript in the WebView to native Zig handlers via JSON messages. Native-rendered apps have no bridge — markup dispatches typed messages straight into `update` (see [App Model](/app-model)).
 
+The complete working reference is [`examples/webview`](https://github.com/vercel-labs/native/tree/main/examples/webview): it registers a custom `native.ping` Zig handler, calls it from inline JavaScript with `window.zero.invoke(...)`, and tests the bridge response through the headless runtime.
+
 ## Architecture
 
 ```
@@ -33,17 +35,56 @@ The handler writes its JSON result into the provided `output` buffer (max 12 KiB
 return native_sdk.bridge.writeJsonStringValue(output, user_supplied_name);
 ```
 
+`invocation.request.payload` is the raw JSON payload string from JavaScript. Parse it when the handler needs structured input; ignore it for simple commands like `native.ping`.
+
 ## Wiring the dispatcher
 
 ```zig
-fn bridge(self: *App) native_sdk.BridgeDispatcher {
-    self.handlers = .{.{ .name = "native.ping", .context = self, .invoke_fn = ping }};
-    return .{
-        .policy = .{ .enabled = true, .commands = &policies },
-        .registry = .{ .handlers = &self.handlers },
-    };
+const bridge_origins = [_][]const u8{
+    "zero://inline",
+    "zero://app",
+    "http://127.0.0.1:5173",
+};
+const bridge_policies = [_]native_sdk.BridgeCommandPolicy{
+    .{ .name = "native.ping", .origins = &bridge_origins },
+};
+
+const App = struct {
+    ping_count: u32 = 0,
+    bridge_handlers: [1]native_sdk.BridgeHandler = undefined,
+
+    // ...
+
+    fn bridge(self: *App) native_sdk.BridgeDispatcher {
+        self.bridge_handlers = .{.{ .name = "native.ping", .context = self, .invoke_fn = ping }};
+        return .{
+            .policy = .{ .enabled = true, .commands = &bridge_policies },
+            .registry = .{ .handlers = &self.bridge_handlers },
+        };
+    }
+};
+```
+
+Pass the dispatcher into the generated runner or directly into `Runtime.initAt`:
+
+```zig
+pub fn main(init: std.process.Init) !void {
+    var app = App{};
+    try runner.runWithOptions(app.app(), .{
+        .app_name = "my-app",
+        .window_title = "My App",
+        .bundle_id = "dev.example.my-app",
+        .bridge = app.bridge(),
+        .security = .{
+            .navigation = .{ .allowed_origins = &bridge_origins },
+        },
+    }, init);
 }
 ```
+
+For larger apps, keep the handlers array on your app state. The dispatcher stores pointers to the handler table, so the array must outlive `runtime.run(...)`.
+
+When using `native dev`, add the origin from your frontend dev URL to the bridge policy and navigation allow-list too. For example, Vite commonly uses `http://127.0.0.1:5173`; Next.js commonly uses `http://127.0.0.1:3000`. If the origin is missing, the shell may deny navigation or `window.zero.invoke(...)` may reject an otherwise trusted page.
 
 ## Calling from JavaScript
 
@@ -51,6 +92,8 @@ fn bridge(self: *App) native_sdk.BridgeDispatcher {
 const result = await window.zero.invoke("native.ping", { source: "webview" });
 console.log(result); // { message: "pong from Zig", count: 1 }
 ```
+
+The generated web-frontend templates expose `window.zero` inside the trusted WebView. Browser-only development, such as `npm run dev` in the frontend folder, does not have the native bridge injected; guard optional UI with `if (window.zero)`.
 
 ## Invocation
 

--- a/docs/src/app/frontend/page.mdx
+++ b/docs/src/app/frontend/page.mdx
@@ -6,6 +6,8 @@ The same machinery also carries an entire existing web frontend — a React, Vue
 
 For frontends with a build step, the Native SDK provides helpers to switch between a dev server during development and bundled assets in production.
 
+If that frontend needs to call native Zig code, register an app-defined [Bridge](/bridge) handler in the shell and call it from JavaScript with `window.zero.invoke("command.name", payload)`. The scaffolded frontend files only check whether `window.zero` is present; [`examples/webview`](https://github.com/vercel-labs/native/tree/main/examples/webview) shows the complete custom command flow.
+
 ## Dynamic source function
 
 Use `source_fn` on your `App` so development uses a localhost server and production uses bundled assets:
@@ -106,6 +108,8 @@ The repository includes complete frontend examples:
 - `examples/vue` - Vue app built with Vite.
 
 Each example can be run from its directory with `zig build run`, or with `zig build dev` for the managed frontend dev server flow.
+
+For a custom Zig function exposed to JavaScript, start from `examples/webview`: it registers `native.ping`, returns JSON from Zig, and calls the handler from the WebView. WebView calls only work inside the Native SDK shell; a standalone browser dev server will not have `window.zero`.
 
 ## Production source
 

--- a/examples/webview/README.md
+++ b/examples/webview/README.md
@@ -2,6 +2,32 @@
 
 A Native SDK app with inline HTML, a native bridge command (`native.ping`), and builtin window management commands.
 
+Use this example when you need to call Zig from JavaScript. The shape is:
+
+1. Add a Zig handler with the `native_sdk.bridge.Invocation` signature.
+2. Register it in a `BridgeDispatcher`.
+3. Pass the dispatcher as `.bridge = app.bridge()` when starting the runner.
+4. Call it from WebView JavaScript with `window.zero.invoke("native.ping", payload)`.
+
+Inside the example app struct, the `native.ping` handler increments a Zig counter and returns JSON:
+
+```zig
+fn ping(context: *anyopaque, invocation: native_sdk.bridge.Invocation, output: []u8) anyerror![]const u8 {
+    _ = invocation;
+    const self: *@This() = @ptrCast(@alignCast(context));
+    self.ping_count += 1;
+    return std.fmt.bufPrint(output, "{{\"message\":\"pong from Zig\",\"count\":{d}}}", .{self.ping_count});
+}
+```
+
+The WebView calls it like any other async JavaScript API:
+
+```javascript
+const result = await window.zero.invoke("native.ping", { source: "webview" });
+```
+
+The example also has a unit test that dispatches the same bridge message without launching a real WebView.
+
 ## Run
 
 ```bash


### PR DESCRIPTION
Summary
- expand the Bridge docs with a concrete custom `native.ping` handler and dispatcher wiring
- point Web Content readers to `examples/webview` for the complete JavaScript-to-Zig command flow
- document the webview example flow in its README and add a changelog fragment

Closes #51.

Tests
- `git diff --check`
- `CI=true npm exec --package=pnpm@10.23.0 -- scripts/gate.sh fast`