### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.4.0
+## 0.4.1
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **npm package assets**: Ship the SDK's root `assets/` directory in `@native-sdk/cli` so installed packages include `assets/native-sdk.manifest`, the default macOS icon, and entitlements needed by generated apps (#72, #75).
+
+### Contributors
+
+- @ctate
+- @lzitser23
+<!-- release:end -->
+
+## 0.4.0
 
 ### New Features
 
@@ -99,7 +111,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.3.0
 

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -22,14 +22,14 @@
     "LICENSE"
   ],
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.4.0",
-    "@native-sdk/cli-darwin-x64": "0.4.0",
-    "@native-sdk/cli-linux-arm64-gnu": "0.4.0",
-    "@native-sdk/cli-linux-arm64-musl": "0.4.0",
-    "@native-sdk/cli-linux-x64-gnu": "0.4.0",
-    "@native-sdk/cli-linux-x64-musl": "0.4.0",
-    "@native-sdk/cli-win32-arm64": "0.4.0",
-    "@native-sdk/cli-win32-x64": "0.4.0"
+    "@native-sdk/cli-darwin-arm64": "0.4.1",
+    "@native-sdk/cli-darwin-x64": "0.4.1",
+    "@native-sdk/cli-linux-arm64-gnu": "0.4.1",
+    "@native-sdk/cli-linux-arm64-musl": "0.4.1",
+    "@native-sdk/cli-linux-x64-gnu": "0.4.1",
+    "@native-sdk/cli-linux-x64-musl": "0.4.1",
+    "@native-sdk/cli-win32-arm64": "0.4.1",
+    "@native-sdk/cli-win32-x64": "0.4.1"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.4.0";
+const version = "0.4.1";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Bump the Native SDK CLI and all platform package versions to 0.4.1.
- Mark the v0.4.1 changelog entry for the npm assets packaging fix.
- Leave the previous v0.4.0 changelog entry unmarked for release publishing.