### PR TITLE
fix: run frontend npm steps with cwd instead of --prefix in scaffolded build.zig

### DIFF
--- a/examples/next/build.zig
+++ b/examples/next/build.zig
@@ -96,11 +96,13 @@ pub fn build(b: *std.Build) void {
     linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, native_sdk_path, cef_dir, cef_auto_install);
     b.installArtifact(exe);
 
-    const frontend_install = b.addSystemCommand(&.{ "npm", "install", "--prefix", "frontend" });
+    const frontend_install = b.addSystemCommand(&.{ "npm", "install" });
+    frontend_install.setCwd(b.path("frontend"));
     const frontend_install_step = b.step("frontend-install", "Install frontend dependencies");
     frontend_install_step.dependOn(&frontend_install.step);
 
-    const frontend_build = b.addSystemCommand(&.{ "npm", "--prefix", "frontend", "run", "build" });
+    const frontend_build = b.addSystemCommand(&.{ "npm", "run", "build" });
+    frontend_build.setCwd(b.path("frontend"));
     frontend_build.step.dependOn(&frontend_install.step);
     const frontend_step = b.step("frontend-build", "Build the frontend");
     frontend_step.dependOn(&frontend_build.step);

--- a/examples/react/build.zig
+++ b/examples/react/build.zig
@@ -96,11 +96,13 @@ pub fn build(b: *std.Build) void {
     linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, native_sdk_path, cef_dir, cef_auto_install);
     b.installArtifact(exe);
 
-    const frontend_install = b.addSystemCommand(&.{ "npm", "install", "--prefix", "frontend" });
+    const frontend_install = b.addSystemCommand(&.{ "npm", "install" });
+    frontend_install.setCwd(b.path("frontend"));
     const frontend_install_step = b.step("frontend-install", "Install frontend dependencies");
     frontend_install_step.dependOn(&frontend_install.step);
 
-    const frontend_build = b.addSystemCommand(&.{ "npm", "--prefix", "frontend", "run", "build" });
+    const frontend_build = b.addSystemCommand(&.{ "npm", "run", "build" });
+    frontend_build.setCwd(b.path("frontend"));
     frontend_build.step.dependOn(&frontend_install.step);
     const frontend_step = b.step("frontend-build", "Build the frontend");
     frontend_step.dependOn(&frontend_build.step);

--- a/examples/svelte/build.zig
+++ b/examples/svelte/build.zig
@@ -96,11 +96,13 @@ pub fn build(b: *std.Build) void {
     linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, native_sdk_path, cef_dir, cef_auto_install);
     b.installArtifact(exe);
 
-    const frontend_install = b.addSystemCommand(&.{ "npm", "install", "--prefix", "frontend" });
+    const frontend_install = b.addSystemCommand(&.{ "npm", "install" });
+    frontend_install.setCwd(b.path("frontend"));
     const frontend_install_step = b.step("frontend-install", "Install frontend dependencies");
     frontend_install_step.dependOn(&frontend_install.step);
 
-    const frontend_build = b.addSystemCommand(&.{ "npm", "--prefix", "frontend", "run", "build" });
+    const frontend_build = b.addSystemCommand(&.{ "npm", "run", "build" });
+    frontend_build.setCwd(b.path("frontend"));
     frontend_build.step.dependOn(&frontend_install.step);
     const frontend_step = b.step("frontend-build", "Build the frontend");
     frontend_step.dependOn(&frontend_build.step);

--- a/examples/vue/build.zig
+++ b/examples/vue/build.zig
@@ -96,11 +96,13 @@ pub fn build(b: *std.Build) void {
     linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, native_sdk_path, cef_dir, cef_auto_install);
     b.installArtifact(exe);
 
-    const frontend_install = b.addSystemCommand(&.{ "npm", "install", "--prefix", "frontend" });
+    const frontend_install = b.addSystemCommand(&.{ "npm", "install" });
+    frontend_install.setCwd(b.path("frontend"));
     const frontend_install_step = b.step("frontend-install", "Install frontend dependencies");
     frontend_install_step.dependOn(&frontend_install.step);
 
-    const frontend_build = b.addSystemCommand(&.{ "npm", "--prefix", "frontend", "run", "build" });
+    const frontend_build = b.addSystemCommand(&.{ "npm", "run", "build" });
+    frontend_build.setCwd(b.path("frontend"));
     frontend_build.step.dependOn(&frontend_install.step);
     const frontend_step = b.step("frontend-build", "Build the frontend");
     frontend_step.dependOn(&frontend_build.step);

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -932,11 +932,13 @@ fn buildZig(allocator: std.mem.Allocator, names: TemplateNames, framework_path: 
         \\    linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, native_sdk_path, cef_dir, cef_auto_install);
         \\    b.installArtifact(exe);
         \\
-        \\    const frontend_install = b.addSystemCommand(&.{ "npm", "install", "--prefix", "frontend" });
+        \\    const frontend_install = b.addSystemCommand(&.{ "npm", "install" });
+        \\    frontend_install.setCwd(b.path("frontend"));
         \\    const frontend_install_step = b.step("frontend-install", "Install frontend dependencies");
         \\    frontend_install_step.dependOn(&frontend_install.step);
         \\
-        \\    const frontend_build = b.addSystemCommand(&.{ "npm", "--prefix", "frontend", "run", "build" });
+        \\    const frontend_build = b.addSystemCommand(&.{ "npm", "run", "build" });
+        \\    frontend_build.setCwd(b.path("frontend"));
         \\    frontend_build.step.dependOn(&frontend_install.step);
         \\    const frontend_step = b.step("frontend-build", "Build the frontend");
         \\    frontend_step.dependOn(&frontend_build.step);
@@ -2004,6 +2006,8 @@ fn appZon(allocator: std.mem.Allocator, names: TemplateNames, frontend: Frontend
     try appendZigString(&out, allocator, frontend.devUrl());
     try out.appendSlice(allocator,
         \\,
+        // `native dev` runs manifest commands from the app root and does not
+        // expose a command cwd, so this invocation still needs `--prefix`.
         \\            .command = .{ "npm", "--prefix", "frontend", "run", "dev"
     );
     if (frontend != .next) {
@@ -2743,7 +2747,8 @@ fn readme(allocator: std.mem.Allocator, names: TemplateNames, framework_path: []
         \\`zig build dev`, `zig build run`, and `zig build package` install frontend dependencies automatically. To install them explicitly, run:
         \\
         \\```sh
-        \\npm install --prefix frontend
+        \\cd frontend
+        \\npm install
         \\```
         \\
         \\The generated build defaults to this Native SDK framework path:
@@ -2859,6 +2864,8 @@ test "writeDefaultApp emits Vite project files" {
     defer std.testing.allocator.free(main_zig_text);
     const runner_zig_text = try readTestFile(std.testing.allocator, std.testing.io, destination, "src/runner.zig");
     defer std.testing.allocator.free(runner_zig_text);
+    const readme_text = try readTestFile(std.testing.allocator, std.testing.io, destination, "README.md");
+    defer std.testing.allocator.free(readme_text);
     const package_json_text = try readTestFile(std.testing.allocator, std.testing.io, destination, "frontend/package.json");
     defer std.testing.allocator.free(package_json_text);
     const main_js_text = try readTestFile(std.testing.allocator, std.testing.io, destination, "frontend/src/main.js");
@@ -2866,11 +2873,17 @@ test "writeDefaultApp emits Vite project files" {
 
     try std.testing.expect(std.mem.indexOf(u8, app_zon_text, ".frontend") != null);
     try std.testing.expect(std.mem.indexOf(u8, app_zon_text, "frontend/dist") != null);
-    try std.testing.expect(std.mem.indexOf(u8, app_zon_text, "npm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, app_zon_text, "\"npm\", \"--prefix\", \"frontend\", \"run\", \"dev\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, app_zon_text, ".windows") != null);
     try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "frontend-install") != null);
-    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "\"npm\", \"install\", \"--prefix\", \"frontend\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "\"npm\", \"install\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "frontend_install.setCwd(b.path(\"frontend\"))") != null);
     try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "frontend-build") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "\"npm\", \"run\", \"build\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "frontend_build.setCwd(b.path(\"frontend\"))") != null);
+    try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "--prefix") == null);
+    try std.testing.expect(std.mem.indexOf(u8, readme_text, "cd frontend\nnpm install") != null);
+    try std.testing.expect(std.mem.indexOf(u8, readme_text, "--prefix") == null);
     try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "frontend_build.step.dependOn(&frontend_install.step)") != null);
     try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "\"native\", \"dev\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, build_zig_text, "dev.step.dependOn(&frontend_install.step)") != null);


### PR DESCRIPTION
## Summary
In src/tooling/templates.zig, change the generated build.zig's frontend steps (`npm install --prefix frontend` at ~line 935 and `npm --prefix frontend run build` at ~line 939) to plain `npm install` / `npm run build` with `frontend_install.setCwd(b.path("frontend"))` / `frontend_build.setCwd(b.path("frontend"))`, and update the templated README snippet (~line 2746) plus the dev-command template (~line 2007) to `cd frontend`-style or cwd-based invocations consistent with how the runner executes them. Mirror the same change in the four checked-in example apps (examples/next, react, svelte, vue build.zig), which are copies of the template output. Update the inline std.testing assertions in templates.zig (~line 2872) that currently pin the exact `"npm", "install", "--prefix", "frontend"` argv.

## Why this matters
A macOS user hit "No binary found for darwin-x64" from the old zero-native postinstall-download dispatcher, and its suggested remedy (`npm run build:native`) failed outside the repo. A Windows user reproduced the follow-on failure: the scaffolded app's `zig build run` executes `npm install --prefix frontend`, and npm 10.9.3 dies with ENOENT trying to read the app root's nonexistent package.json; upgrading to npm 11 made it work. The original darwin-x64 half is already obsolete: the package is now `@native-sdk/cli` with per-platform optionalDependencies (`@native-sdk/cli-darwin-x64` exists under packages/native-sdk/npm/) and bin/native.js no longer suggests build:native. The remaining reproducible bug in current code is the npm `--prefix` invocation baked into the scaffold and examples, which breaks on npm < 11 (notably on Windows).

See https://github.com/vercel-labs/native/issues/56.

## Testing
- Happy path: `zig build test` (or the templates.zig inline tests) passes with the updated argv assertions; generated build.zig contains cwd-scoped npm steps and no `--prefix`. - Edge case: scaffold an app with `native init --frontend next` and confirm `zig build run` installs frontend deps with npm 10.x semantics (no read of app-root package.json). - Edge case: examples/*/build.zig stay in sync with the template (check-framework-sync/CI template checks still pass). - Error path: npm missing from PATH still surfaces the run-step failure for the frontend-install step with a clear failed-command message.

Fixes #56
