### PR TITLE
Add Native SDK design guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Run `scripts/gate.sh fast` before finishing any change; it maps your diff to the
 
 Pinned goldens (pixel signatures, schema fingerprints, command counts) are updated deliberately: review the rendered output or the counted commands first, and keep the pin's comment a self-contained description of what the value represents.
 
+## Design guide
+
+Read and follow [DESIGN.md](./DESIGN.md) before changing built-in UI, examples, templates, component previews, or Native UI docs. New UI should use the framework's native widgets first, keep visual identity token-driven, and verify accessibility, keyboard behavior, and layout stability. Call out any deliberate divergence in the change summary.
+
 ## Changelog
 
 Do not edit `CHANGELOG.md` directly. Each user-visible change ships a fragment in `changelog.d/` — see `changelog.d/README.md` for the format and voice. Internal-only polish needs no fragment.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,122 @@
+# Native SDK Design Guide
+
+This guide is the design contract for Native SDK itself: built-in components,
+examples, templates, docs screenshots, and agent-generated native UI should all
+pull in this direction. It complements the Native UI language reference and the
+theming docs; it does not replace either.
+
+## Default Stance
+
+- Build the real product surface first. An app opens on the workspace, editor,
+  dashboard, browser, board, player, or tool the user came for.
+- Prefer native, familiar controls over decorative imitations. Buttons, lists,
+  fields, tabs, menus, sliders, charts, and dialogs should use the framework's
+  widgets unless a new primitive is genuinely needed.
+- Make operational software quiet and scannable. Dense information, stable
+  alignment, restrained color, and predictable navigation beat big marketing
+  composition inside an app.
+- Let brand live in tokens. Component behavior and structure should stay stable
+  while color, radius, type, motion, and control metrics move through
+  `DesignTokens`.
+
+## Product Shape
+
+- Start with a useful first viewport. Avoid splash screens, landing pages, and
+  ornamental hero sections for apps, dashboards, internal tools, and games.
+- Give screens a clear job: navigation or collection on one side, the primary
+  work area in the center, detail/actions where they are needed, and status at
+  the edge.
+- Choose the display primitive that matches the data:
+  - `list` / `list-item` for selectable records and feeds.
+  - `table` or `data_grid` for comparison across columns.
+  - `chart` for quantitative trends, with labels and semantics.
+  - `tree` for nested disclosure, not hand-indented lists.
+  - `timeline` / `stepper` for progress through time or stages.
+- Always design the non-happy states: empty, loading, disabled, invalid,
+  selected, focused, error, and offline or unavailable surfaces.
+
+## Component Discipline
+
+- Do not make fake controls out of styled containers. If it can be a `button`,
+  `checkbox`, `radio`, `switch`, `slider`, `select`, `text-field`, or
+  `list-item`, use that widget.
+- Icon actions need a real vector icon plus an accessible label. Prefer the
+  built-in icon registry or registered app icons to glyph text.
+- Keep one control size register per row. Mixing `sm`, default, and `lg` in the
+  same toolbar should be a deliberate exception, not drift.
+- `heading` and `display` are typography rungs for text, not control sizes.
+  Hero-sized text belongs only where it improves scanning or hierarchy.
+- Do not nest cards inside cards. Use cards for repeated standalone items or
+  modal content; use panels, full-width bands, rows, columns, and split panes
+  for page structure.
+- Composite selectable rows should stay rows. Use `list-item` with children for
+  title/snippet/badge layouts; reserve bordered cards for items that are truly
+  card-like.
+- Charts should visualize live data, not screenshots. Label series, report
+  semantics, and make hover details optional interaction chrome.
+
+## Layout
+
+- Prefer explicit constraints over lucky content fit: widths for fixed columns,
+  heights for fixed controls, min-widths for split panes, and grow only where
+  space can actually flex.
+- Text must not overlap or escape its container. Use `wrap`, `overflow`, stable
+  widths, and layout tests when labels can vary.
+- Rows and columns do not wrap children. If content needs wrapping, wrap text
+  leaves or change the structure.
+- Stacking containers (`stack`, `panel`, `card`, modal surfaces) layer children;
+  put a `row` or `column` inside when you want flow and `gap`.
+- Keep spacing regular. Use the token scale and small local variation instead
+  of ad hoc offsets.
+- Avoid decoration that does not carry information or affordance. Background
+  blobs, ornamental gradients, and visual noise make native-rendered apps feel
+  less native.
+
+## Tokens And Theming
+
+- Use semantic color tokens in views (`background`, `surface`, `text`,
+  `text_muted`, `accent`, `success`, `warning`, `destructive`, `info`) rather
+  than raw colors.
+- Raw colors belong in token packs, token overrides, generated assets, or
+  custom low-level drawing where a token has already been chosen by the caller.
+- Every theme decision should be checked in light, dark, and high contrast.
+  Reduced motion must preserve the same state transitions without relying on
+  animation to communicate meaning.
+- Theme first, eject second, build third: use tokens for visual changes, eject
+  library composites when you need to own their structure, and create new
+  components only when neither path fits.
+
+## Accessibility And Input
+
+- Every interactive or informative non-text surface needs a stable accessible
+  name. Icon-only controls must have `label`.
+- Roles should describe the interaction users get: `listitem`, `treeitem`,
+  `button`, `chart`, `group`, and so on. Do not add roles for styling.
+- Keyboard behavior must match the component's native contract. Selection rows,
+  tabs, radio groups, sliders, split dividers, dialogs, and menus should all be
+  reachable and operable without a pointer.
+- Focus rings are product UI, not debug chrome. They must be visible, clipped
+  correctly, and consistent with the token pack.
+- Status, errors, and progress need text equivalents. A color-only signal is not
+  enough.
+
+## Verification
+
+Before finishing framework UI work, run the checks that match the change:
+
+- `native check` for markup and manifest validation in an app workspace.
+- `native test` or the relevant `zig build test-example-<name>` for examples.
+- Layout sweeps for fixed-format surfaces and accessibility sweeps for all
+  focusable UI.
+- Reference screenshots or component previews when a visual decision changed.
+- `scripts/gate.sh fast` from the framework repo before merging.
+
+## Review Checklist
+
+- Does the first screen perform the app's real job?
+- Did the implementation use built-in widgets before custom drawing?
+- Are lists, tables, charts, trees, and timelines chosen for the right data?
+- Are spacing, type, color, and radii token-driven?
+- Do all states exist and stay stable under resize and longer text?
+- Can keyboard and assistive-tech users identify and operate every control?
+- Are visual changes covered by tests, previews, or screenshots?

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The full documentation is at [native-sdk.dev](https://native-sdk.dev).
 - [Philosophy](https://native-sdk.dev/philosophy) — the six principles behind the toolkit
 - [App Model](https://native-sdk.dev/app-model) — the model/message/update loop, wiring, and hot reload
 - [Native UI](https://native-sdk.dev/native-ui) — every element, attribute, and pattern in the markup
+- [Design Guide](https://native-sdk.dev/design-guide) — the product and component design contract for native-rendered UI
 - [Components](https://native-sdk.dev/components) — the component catalog
 - [State & Data Flow](https://native-sdk.dev/state) — derive-don't-store, bindings, and text editing
 - [Testing](https://native-sdk.dev/testing) — full-loop UI tests, headless on any machine

--- a/changelog.d/design-guide.md
+++ b/changelog.d/design-guide.md
@@ -1,0 +1,1 @@
+improvement: **Design guide**: Native SDK now documents a framework-level design contract for built-in components, examples, docs, and agent-generated native UI, and exposes it in the docs navigation.

--- a/docs/src/app/design-guide/layout.tsx
+++ b/docs/src/app/design-guide/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("design-guide");
+
+export default function DesignGuideLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/docs/src/app/design-guide/page.mdx
+++ b/docs/src/app/design-guide/page.mdx
@@ -1,0 +1,82 @@
+# Design Guide
+
+Native SDK's design system is a contract between the component engine, the docs,
+the examples, and generated app code. The short version: build the real product
+surface first, use the framework's native widgets, and put visual identity in
+tokens instead of one-off styling.
+
+This page mirrors the repository guide in `DESIGN.md` and turns it into the
+public authoring baseline for Native UI.
+
+## Start with the product
+
+Native-rendered apps should open on the surface the user came for: the editor,
+dashboard, board, browser, player, form, timeline, or game. Avoid splash pages,
+marketing heroes, and decorative landing screens for app workspaces.
+
+A good default structure is a quiet shell: navigation or collection on one
+side, the primary work area in the center, detail and actions where they are
+needed, and a status edge for persistent feedback.
+
+## Pick the right primitive
+
+Use the widget that matches the data and interaction:
+
+- `list` / `list-item` for selectable records and feeds.
+- `table` or `data_grid` for comparison across columns.
+- `chart` for quantitative trends, with axis labels, series labels, and chart
+  semantics.
+- `tree` for nested disclosure.
+- `timeline` and `stepper` for progress through time or stages.
+- `tabs`, `toggle-group`, and `split` for switching or arranging views.
+
+Do not make fake controls out of styled containers. If something behaves like a
+button, checkbox, radio, switch, slider, select, text field, or list row, use
+the matching widget.
+
+## Compose with restraint
+
+Operational software should be easy to scan repeatedly. Prefer stable
+alignment, dense but readable rows, predictable navigation, and clear state over
+ornamental composition. Cards are for repeated standalone items and modal
+content; page structure should use panels, rows, columns, split panes, and
+full-width regions.
+
+Avoid nested cards. A panel or card is a stacking container, so put a single
+`row` or `column` inside when you need flow and `gap`.
+
+## Use tokens for identity
+
+Views should use semantic tokens such as `background`, `surface`, `text`,
+`text_muted`, `accent`, `success`, `warning`, `destructive`, and `info`.
+Raw colors belong in theme packs, token overrides, generated assets, or
+low-level drawing where a token choice has already been made.
+
+Check visual choices in light, dark, and high contrast. Reduced motion should
+keep the same meaning without relying on animation.
+
+## Keep layout honest
+
+Prefer explicit constraints over lucky content fit: widths for fixed columns,
+heights for fixed controls, min-widths for split panes, and `grow` only where
+space can really flex. Text should wrap or elide inside its frame; it should not
+overlap nearby content or paint past the layout the user can reason about.
+
+Keep one control size register per row. `heading` and `display` are text rungs,
+not control sizes.
+
+## Design every state
+
+A finished surface includes empty, loading, disabled, invalid, selected,
+focused, error, and unavailable states. Color is not enough: status, errors,
+progress, and charts need text or semantic equivalents.
+
+Every interactive or informative non-text surface needs a stable accessible
+name. Roles should describe behavior, not styling.
+
+## Verify it
+
+For app work, run `native check` and `native test`. For framework and example
+changes, run the relevant example test or `scripts/gate.sh fast`. When visual
+output changes, review a screenshot, component preview, or pinned reference
+signature before blessing it.

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -26,6 +26,7 @@ export const navSections: NavSection[] = [
     items: [
       { name: "App Model", href: "/app-model" },
       { name: "Native UI", href: "/native-ui" },
+      { name: "Design Guide", href: "/design-guide" },
       { name: "State & Data Flow", href: "/state" },
       { name: "Theming", href: "/theming" },
       { name: "Building Components", href: "/building-components" },

--- a/docs/src/lib/page-titles.ts
+++ b/docs/src/lib/page-titles.ts
@@ -9,6 +9,7 @@ export const PAGE_TITLES: Record<string, string> = {
   "quick-start": "Quick Start",
   "app-model": "App Model",
   "native-ui": "Native UI",
+  "design-guide": "Design Guide",
   state: "State & Data Flow",
   theming: "Theming",
   "building-components": "Building Components",

--- a/skill-data/native-ui/SKILL.md
+++ b/skill-data/native-ui/SKILL.md
@@ -12,6 +12,10 @@ A native-rendered Native SDK app is a markup view plus Zig logic:
 
 The markup compiles to the same widget tree a hand-written `canvas.Ui(Msg)` builder view would produce: identical structural widget ids, identical typed handler table. Markup can never mutate state — it binds values and dispatches messages; all logic lives in Zig.
 
+## Design contract
+
+Follow the framework design guide when authoring Native UI: build the real product surface first, use built-in widgets before custom drawing, and put visual identity in `DesignTokens` rather than ad hoc styling. Choose the primitive that matches the data (`list`/`list-item` for selectable records, `table`/`data_grid` for column comparison, `chart` for quantitative trends, `tree` for nested disclosure, `timeline`/`stepper` for progress). Avoid fake controls made from panels, nested cards, ornamental hero screens in apps, and raw colors in views. Every interactive surface needs an accessible name, keyboard behavior, and stable layout under longer text, empty/loading/error states, light/dark/high-contrast themes, and reduced motion.
+
 Editors highlight `.native` markup well in HTML mode — the default scaffold writes no editor config, so add `.vscode/settings.json` with `"files.associations": {"*.native": "html"}` yourself, or scaffold with `native init --full`, which writes it.
 
 Start a new app with `native init` (zero-config: app.zon + src + assets, the CLI generates the build graph), or copy `examples/habits/` (smallest): change the name/id in app.zon and `assets/` copies verbatim — there are no build files to edit. The `native dev|test|build` verbs drive any app directory shaped this way.


### PR DESCRIPTION
## Summary
- add a framework-level DESIGN.md contract for Native SDK UI work
- publish the guide at /design-guide and add it to docs navigation/page metadata
- point AGENTS.md and the shipped native-ui skill at the design contract

## Verification
- pnpm --dir docs check
- scripts/gate.sh fast could not complete locally because zig is not installed/on PATH in this environment; the docs portion passed

Ready for review/merge.