### PR TITLE
fix: mount Svelte example and CLI template with Svelte 5 API

### DIFF
--- a/changelog.d/svelte-mount-api.md
+++ b/changelog.d/svelte-mount-api.md
@@ -1,0 +1,1 @@
+fix: **Svelte example and template mount correctly on Svelte 5**: `main.js` used the removed Svelte 4 `new App({ target })` constructor, which throws `component_api_invalid_new` under Svelte 5. Both the `examples/svelte` app and the `native init` Svelte scaffold now mount with `mount(App, { target })` from `svelte`.

--- a/examples/svelte/frontend/src/main.js
+++ b/examples/svelte/frontend/src/main.js
@@ -1,6 +1,7 @@
+import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
 
-const app = new App({ target: document.getElementById("app") });
+const app = mount(App, { target: document.getElementById("app") });
 
 export default app;

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -2589,10 +2589,11 @@ fn svelteIndexHtml(allocator: std.mem.Allocator, names: TemplateNames) ![]const 
 
 fn svelteMainJs() []const u8 {
     return
+    \\import { mount } from "svelte";
     \\import App from "./App.svelte";
     \\import "./app.css";
     \\
-    \\const app = new App({ target: document.getElementById("app") });
+    \\const app = mount(App, { target: document.getElementById("app") });
     \\
     \\export default app;
     \\


### PR DESCRIPTION
## Summary
- `examples/svelte/frontend/src/main.js` and the `native init` Svelte scaffold (`svelteMainJs()` in `src/tooling/templates.zig`) both called `new App({ target })`, the Svelte 4 component constructor.
- Svelte 5 (this repo depends on `^5.55.5`) removed that constructor, so both the checked-out example and every freshly generated Svelte project throw `component_api_invalid_new` on load, as reported in #48.
- Switched both to Svelte 5's `mount(App, { target })` from the `svelte` package. Added a changelog fragment per CONTRIBUTING.md.

Fixes #48

## Test plan
- [x] `bun install && bun run build` in `examples/svelte/frontend` builds cleanly
- [x] Served the production build and loaded it in a browser: renders with zero console errors
- [x] `zig build test` passes (exit code 0)