### PR TITLE
Add Awesome Native SDK community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The full documentation is at [native-sdk.dev](https://native-sdk.dev).
 
 ## Community
 
-- [Awesome Native SDK](https://github.com/henryoman/awesome-native-sdk#readme) — Curated list of Native SDK apps, examples, framework integrations, and tooling.
+- [Awesome Native SDK](https://github.com/henryoman/awesome-vercel-native#readme) — Curated list of Native SDK apps, examples, framework integrations, and tooling.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,7 @@ The full documentation is at [native-sdk.dev](https://native-sdk.dev).
 - [Capabilities](https://native-sdk.dev/capabilities) — guarded OS services: notifications, clipboard, dialogs, credentials
 - [Packaging](https://native-sdk.dev/packaging) — from binary to distributable app
 - [Platform Support](https://native-sdk.dev/platform-support) — what each host supports today
-
-## Community
-
-- [Awesome Native SDK](https://github.com/henryoman/awesome-vercel-native#readme) — Curated list of Native SDK apps, examples, framework integrations, and tooling.
+- [Awesome Vercel Native](https://github.com/henryoman/awesome-vercel-native#readme) — Curated apps, examples, integrations, and tooling.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ The full documentation is at [native-sdk.dev](https://native-sdk.dev).
 - [Packaging](https://native-sdk.dev/packaging) — from binary to distributable app
 - [Platform Support](https://native-sdk.dev/platform-support) — what each host supports today
 
+## Community
+
+- [Awesome Native SDK](https://github.com/henryoman/awesome-native-sdk#readme) — Curated list of Native SDK apps, examples, framework integrations, and tooling.
+
 ## Contributing
 
 Native SDK is pre-1.0: APIs still move, and the toolkit is evolving quickly. Bug reports and focused pull requests are welcome — for larger changes, open an issue first so the design can be discussed. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development setup and local checks.


### PR DESCRIPTION
Adds a small Community section linking to Awesome Native SDK, a curated list of Native SDK apps, examples, framework integrations, themes, and tooling.

This is a README-only documentation change. No code tests were run.