### PR TITLE
Give @native-sdk/core the provenance repository metadata npm requires

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,12 @@
   "name": "@native-sdk/core",
   "version": "0.5.0",
   "description": "The TypeScript authoring tier: the app-core subset, its dev-time transpiler to arena-backed Zig, and the SDK module cores import",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/native.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://native-sdk.dev",
   "type": "module",
   "types": "./sdk/core.ts",
   "files": [

--- a/packages/core/test/package_manifest.test.ts
+++ b/packages/core/test/package_manifest.test.ts
@@ -29,6 +29,16 @@ test("the manifest names the published package and a real version", () => {
   assert.equal(manifest.type, "module");
 });
 
+test("provenance metadata names the real repository", () => {
+  // npm publish --provenance validates repository.url against the
+  // publishing workflow's repository and rejects the tarball on any
+  // mismatch — a publish-blocking field, not decoration.
+  assert.equal(manifest.repository?.type, "git");
+  assert.equal(manifest.repository?.url, "git+https://github.com/vercel-labs/native.git");
+  assert.equal(manifest.repository?.directory, "packages/core");
+  assert.equal(manifest.homepage, "https://native-sdk.dev");
+});
+
 test("the artifact is exactly package.json + sdk/", () => {
   assert.deepEqual(manifest.files, ["sdk"]);
   // A bin entry would drag its target file into the tarball behind the

--- a/packages/native-sdk/scripts/check-version-sync.js
+++ b/packages/native-sdk/scripts/check-version-sync.js
@@ -82,6 +82,17 @@ if (coreJson.version !== expectedVersion) {
   console.error(`Version mismatch: packages/core/package.json=${coreJson.version}, expected ${expectedVersion}`);
   errors++;
 }
+// npm validates repository.url against publish provenance for
+// @native-sdk/core exactly as it does for the platform packages — a
+// missing or renamed URL fails the publish, so pin it to the main package.
+if (coreJson.repository?.url !== packageJson.repository?.url) {
+  console.error(`Repository mismatch: packages/core/package.json repository.url is ${coreJson.repository?.url}, expected ${packageJson.repository?.url} from package.json`);
+  errors++;
+}
+if (coreJson.homepage !== packageJson.homepage) {
+  console.error(`Homepage mismatch: packages/core/package.json homepage is ${coreJson.homepage}, expected ${packageJson.homepage} from package.json`);
+  errors++;
+}
 const coreLock = JSON.parse(readFileSync(join(repoRoot, 'packages', 'core', 'package-lock.json'), 'utf-8'));
 if (coreLock.version !== expectedVersion || coreLock.packages?.['']?.version !== expectedVersion) {
   console.error(`Version mismatch: packages/core/package-lock.json=${coreLock.version}/${coreLock.packages?.['']?.version}, expected ${expectedVersion}`);


### PR DESCRIPTION
The v0.5.0 publish run failed on `@native-sdk/core` with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@native-sdk%2fcore - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/vercel-labs/native" from provenance
```

The manifest had no `repository` field — the platform packages carry it (and `check-version-sync` enforces it for them), but `packages/core` was never covered.

- Adds `repository` (url + `directory: packages/core`) and `homepage` to `packages/core/package.json`, matching the CLI package.
- Extends `check-version-sync` to pin both fields for `packages/core` so a rename or drift fails before publish.
- Pins the fields in the package-manifest test (suite 204/204).

State of the interrupted publish: the GitHub release and all eight platform packages are live; `@native-sdk/core` and `@native-sdk/cli` did not publish (the CLI publishes last by design, so nothing resolves to missing packages). On merge, the release workflow re-runs: already-published packages skip, core and cli publish.