### PR TITLE
fix(macos): emit the content rect for WINDOW_FRAME events

### DIFF
--- a/changelog.d/macos-window-frame-content-rect.md
+++ b/changelog.d/macos-window-frame-content-rect.md
@@ -1,0 +1,2 @@
+fix: **macOS shell-view geometry**: `WINDOW_FRAME` events now emit the window's content rect instead of the outer frame, ending the per-frame relayout fight with `RESIZE` events that clipped the bottom titlebar-height of the canvas and grew `restore_state` windows by one titlebar per launch.
+- **Cross-display moves**: the window delegate now re-emits the resize chain on `windowDidChangeScreen:` and `windowDidChangeBackingProperties:`, so dragging to another display refreshes layout immediately instead of waiting for the next key-window change.

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -928,6 +928,26 @@ static void NativeSdkEmitGpuSurfaceResizes(NSView *view) {
     [self.host scheduleFrame];
 }
 
+// Crossing displays changes the backing scale and titlebar chrome
+// geometry without a windowDidResize: — re-emit the resize chain like
+// windowDidBecomeKey: does so the runtime sees the new screen's metrics
+// immediately instead of at the next key-window change.
+- (void)windowDidChangeScreen:(NSNotification *)notification {
+    (void)notification;
+    [self.host emitWindowFrameForWindowId:self.windowId open:YES];
+    [self.host emitResizeForWindowId:self.windowId];
+    [self.host emitDeferredResizeForWindowId:self.windowId];
+    [self.host scheduleFrame];
+}
+
+- (void)windowDidChangeBackingProperties:(NSNotification *)notification {
+    (void)notification;
+    [self.host emitWindowFrameForWindowId:self.windowId open:YES];
+    [self.host emitResizeForWindowId:self.windowId];
+    [self.host emitDeferredResizeForWindowId:self.windowId];
+    [self.host scheduleFrame];
+}
+
 - (void)windowDidBecomeKey:(NSNotification *)notification {
     (void)notification;
     [self.host emitWindowFrameForWindowId:self.windowId open:YES];
@@ -8336,7 +8356,14 @@ static void NativeSdkApplyProcessDisplayName(NSString *displayName) {
 - (void)emitWindowFrameForWindowId:(uint64_t)windowId open:(BOOL)open {
     NSWindow *window = self.windows[@(windowId)] ?: self.window;
     NSString *label = self.windowLabels[@(windowId)] ?: (windowId == 1 ? self.windowLabel : @"");
-    NSRect frame = window.frame;
+    // Emit the CONTENT rect, not the window frame: windows are created
+    // with initWithContentRect:, the runtime's shellBoundsForWindow
+    // treats this size as the layout viewport, and the state store
+    // round-trips it back into initWithContentRect:. Emitting the outer
+    // frame makes shell views a titlebar taller than the content area
+    // (clipping the bottom) and makes restored windows grow by one
+    // titlebar per launch.
+    NSRect frame = [window contentRectForFrameRect:window.frame];
     [self emitEvent:(native_sdk_appkit_event_t){
         .kind = NATIVE_SDK_APPKIT_EVENT_WINDOW_FRAME,
         .window_id = windowId,


### PR DESCRIPTION
## Symptom

On a multi-display setup (built-in Retina + external monitor), dragging a window to the other display and back leaves the bottom of the canvas clipped — a UiApp's bottom `status-bar` disappears. Clicking another app and back (key-window change), or manually resizing, heals it. Single-display apps can also hit it intermittently.

## Root cause

The macOS host's `WINDOW_FRAME` event carried `window.frame` — the **outer** frame, one titlebar (~32pt) taller than the content area. Everything else in the pipeline speaks content-rect:

- windows are created with `initWithContentRect:`
- the runtime's `shellBoundsForWindow` uses the event's size as the shell-view layout viewport (`window_frame_changed` → `relayoutShellViews`)
- the window state store round-trips the saved frame back into `initWithContentRect:`

So every `window_frame_changed` relayouts shell views to the outer-frame height (the fill `gpu_surface` gets `frame={{0,-32},{560,592}}` inside a 560-tall contentView — bottom 32pt clipped), and every `RESIZE` event snaps them back to the content height. The two events fight continuously; whichever lands last wins. Instrumented log of an idle app:

```
updateDrawableSize changed scale=2.0 bounds={560, 560} frame={{0, 0}, {560, 560}}
updateDrawableSize changed scale=2.0 bounds={560, 592} frame={{0, -32}, {560, 592}}
updateDrawableSize changed scale=2.0 bounds={560, 560} frame={{0, 0}, {560, 560}}
... (oscillates every frame)
```

Dragging across displays reliably parks the war on the clipped side; a key-window change parks it on the correct side — which made the bug masquerade as a multi-display issue.

Separately, `restore_state` windows grow by one titlebar height per launch (outer frame saved, restored as a content rect).

## Fix

- `emitWindowFrameForWindowId:` now emits `[window contentRectForFrameRect:window.frame]`, matching the content-rect semantics of window creation, shell layout, and state restore.
- Add the missing `windowDidChangeScreen:` / `windowDidChangeBackingProperties:` delegate re-emits (mirroring `windowDidBecomeKey:`) so crossing displays refreshes geometry immediately instead of at the next key-window change.

## Verification

Dual-display MacBook (built-in Retina @2x + external monitor): before, dragging across displays clipped the bottom 32pt of a zig-core UiApp's canvas; after, layout is stable across display moves, focus changes, and resizes, and the per-frame relayout oscillation is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)