### PR TITLE
Command palette example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1048,6 +1048,7 @@ pub fn build(b: *std.Build) void {
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-split-collapse", "Run split collapse example tests", "examples/split-collapse", .managed);
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-system-monitor", "Run system monitor example tests", "examples/system-monitor", .managed);
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-system-monitor-ts", "Run system-monitor-ts example tests", "examples/system-monitor-ts", .managed);
+    addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-command-palette", "Run command palette example tests", "examples/command-palette", .managed);
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-effects-probe", "Run effects probe example tests", "examples/effects-probe", .managed);
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-feed", "Run feed example tests", "examples/feed", .managed);
     addExampleTestStep(b, host_cli_exe, native_examples_step, "test-example-canvas-preview", "Run canvas preview example tests", "examples/canvas-preview", .managed);

--- a/changelog.d/command-palette-example.md
+++ b/changelog.d/command-palette-example.md
@@ -1,0 +1,1 @@
+feature: **Command palette example**: `examples/command-palette` is the `openCommandPalette()` the keyboard-shortcuts docs call, implemented as a TypeScript-core task app: Cmd+Shift+P toggles it, typing filters static and per-task commands, Enter runs the selection, and plain ArrowUp/Down navigate the list in pure userland over the edit-derivation seam, no runtime changes.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ native build   # produce a ReleaseFast binary in zig-out/bin/
 | `deck` | Two model-declared windows and a dense track ledger. |
 | `markdown-viewer` | Real file I/O through effects, hidden-inset titlebar retrofit, preview + editor. |
 | `system-monitor` | Live process sampling, confirmation dialogs, a settings window. |
+| `command-palette` | Cmd+Shift+P palette over a task list: type-to-filter commands, userland arrow navigation, TypeScript core. |
 | `gpu-surface` | A Metal-backed GPU surface composed beside native controls and WebView content. |
 | `gpu-dashboard` | Native chrome, a GPU surface, and a retained canvas display list. |
 | `gpu-components` | The retained GPU widget controls in one native-first component lab. |

--- a/examples/command-palette/README.md
+++ b/examples/command-palette/README.md
@@ -1,0 +1,25 @@
+# Native SDK command-palette example
+
+The keyboard-shortcuts docs use `command.palette` as their example shortcut id and call `openCommandPalette()` in their JavaScript snippet. This app is that example, implemented: a task list where every action is a palette command.
+
+- **Cmd+Shift+P** (the docs' exact binding) toggles the palette; Escape and a click on the scrim close it.
+- **Type to filter** across static commands and the per-task "Complete:" commands — the rows are DERIVED from app data, which is the point of a palette.
+- **Plain ArrowUp/Down move the selection while you type.** No runtime changes and no app-level key fallback: a single-line field maps unmodified vertical arrows to caret start/end jumps, and the edit-derivation seam stamps that edit onto the dispatched event — so `on-input` hears `move_caret` and the core reinterprets it as list navigation (see `palette_edit` in `src/core.ts`). Unmodified Home/End alias to the same jumps and also navigate; shift-extended selections stay text edits.
+- **Enter runs the selected command**; the selection stays visible — the scroll offset is model-owned and follows it.
+
+Run it (macOS):
+
+```sh
+native dev
+```
+
+Drive it through the automation harness:
+
+```sh
+native build -Dautomation=true && ./zig-out/bin/command-palette &
+native automate shortcut command.palette
+native automate widget-key main-canvas arrowdown
+native automate widget-key main-canvas enter
+```
+
+Known gap vs the web's cmdk: selection changes are visual (the row wash) — there is no activedescendant-style announcement for screen readers while focus stays in the query field.

--- a/examples/command-palette/app.zon
+++ b/examples/command-palette/app.zon
@@ -1,0 +1,40 @@
+.{
+    .id = "dev.native_sdk.command_palette",
+    .name = "command-palette",
+    .display_name = "Command Palette",
+    .description = "A command palette over a task list: Cmd+Shift+P, type to filter, plain arrows navigate, Enter runs.",
+    .version = "0.1.0",
+    .platforms = .{"macos"},
+    .permissions = .{"view"},
+    .capabilities = .{ "native_views", "gpu_surfaces", "shortcuts" },
+    // The exact shortcut the keyboard-shortcuts docs use as their
+    // example id — this app is that example, implemented.
+    .shortcuts = .{
+        .{ .id = "command.palette", .key = "p", .modifiers = .{ "primary", "shift" } },
+        .{ .id = "command.dismiss", .key = "escape" },
+    },
+    .shell = .{
+        .windows = .{
+            .{
+                .label = "main",
+                .title = "Command Palette",
+                .width = 760,
+                .height = 560,
+                .min_width = 560,
+                .min_height = 420,
+                .restore_state = false,
+                .restore_policy = "center_on_primary",
+                .views = .{
+                    .{ .label = "main-canvas", .kind = "gpu_surface", .fill = true, .role = "Task list canvas", .accessibility_label = "Command palette demo", .gpu_backend = "metal", .gpu_pixel_format = "bgra8_unorm", .gpu_present_mode = "timer", .gpu_alpha_mode = "opaque", .gpu_color_space = "srgb", .gpu_vsync = true },
+                },
+            },
+        },
+    },
+    .security = .{
+        .navigation = .{
+            .allowed_origins = .{"zero://app"},
+            .external_links = .{ .action = "deny" },
+        },
+    },
+    .web_engine = "system",
+}

--- a/examples/command-palette/package.json
+++ b/examples/command-palette/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-palette",
+  "private": true,
+  "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
+  "dependencies": {
+    "@native-sdk/core": "0.5.3"
+  }
+}

--- a/examples/command-palette/src/app.native
+++ b/examples/command-palette/src/app.native
@@ -1,0 +1,76 @@
+<!-- command-palette: the palette overlay as a reusable template — a
+     scrim catcher, a dialog, the query field, and the command rows.
+     Model contract: paletteOpen, paletteQuery, paletteRows
+     {id, prefix, title, hasPrefix, selected}; Msg arms toggle_palette /
+     close_palette / palette_edit / palette_exec / palette_run:{id} /
+     palette_scrolled. Plain ArrowUp/Down ride the edit-derivation seam
+     (see core.ts's palette_edit arm). -->
+<template name="command-palette">
+  <panel background="scrim" on-press="close_palette" label="Palette backdrop">
+    <column cross="center" padding="60">
+      <dialog width="520" height="340" on-dismiss="close_palette" label="Command palette">
+        <column padding="10" gap="8">
+          <text-field text="{paletteQuery}" placeholder="Type a command…" autofocus="true" on-input="palette_edit" on-submit="palette_exec" label="Command query" />
+          <scroll grow="1" value="{paletteScroll}" on-scroll="palette_scrolled" label="Command results">
+            <column>
+              <for each="paletteRows" key="id" as="c">
+                <list-item on-press="palette_run:{c.id}" selected="{c.selected}" padding="10" gap="8" cross="center" label="{c.title}">
+                  <if test="{c.hasPrefix}">
+                    <text size="sm" foreground="text_muted">{c.prefix}</text>
+                  </if>
+                  <text grow="1" wrap="false">{c.title}</text>
+                </list-item>
+              </for>
+              <else>
+                <column padding="14" cross="center">
+                  <text size="sm" foreground="text_muted">No matching commands</text>
+                </column>
+              </else>
+            </column>
+          </scroll>
+          <row cross="center">
+            <text size="sm" foreground="text_muted" grow="1">Up/Down select · Enter runs · Esc closes</text>
+          </row>
+        </column>
+      </dialog>
+    </column>
+  </panel>
+</template>
+<stack>
+  <column background="background">
+    <row height="46" padding="12" gap="10" cross="center" background="surface" label="Header">
+      <text>Tasks</text>
+      <spacer grow="1" />
+      <button size="sm" variant="outline" on-press="toggle_palette">Cmd+Shift+P Commands</button>
+    </row>
+    <separator />
+    <scroll grow="1" label="Task list">
+      <column padding="16" gap="2">
+        <for each="taskRows" key="id" as="t">
+          <list-item on-press="task_toggle:{t.id}" selected="{t.done}" padding="10" gap="10" cross="center" label="{t.title}">
+            <if test="{t.done}">
+              <icon name="check-circle" foreground="success" />
+            </if>
+            <else>
+              <icon name="circle-dot" foreground="text_muted" />
+            </else>
+            <text grow="1" wrap="false">{t.title}</text>
+            <if test="{t.done}">
+              <badge variant="secondary">done</badge>
+            </if>
+          </list-item>
+        </for>
+        <else>
+          <column padding="24" cross="center" gap="6">
+            <text foreground="text_muted">No tasks</text>
+            <text size="sm" foreground="text_muted">Run "Restore sample tasks" from the palette.</text>
+          </column>
+        </else>
+      </column>
+    </scroll>
+    <status-bar>{statusLine} · {openCount} open · {doneCount} done</status-bar>
+  </column>
+  <if test="{paletteOpen}">
+    <use template="command-palette" />
+  </if>
+</stack>

--- a/examples/command-palette/src/core.ts
+++ b/examples/command-palette/src/core.ts
@@ -1,0 +1,349 @@
+// The command palette example: a task list whose every action is a
+// palette command. Cmd+Shift+P (the exact shortcut id the
+// keyboard-shortcuts docs use as their example) toggles the palette,
+// typing filters, plain ArrowUp/Down move the selection, Enter runs.
+//
+// The arrow navigation rides the edit-derivation seam: a single-line
+// field maps unmodified ArrowUp/Down to caret start/end jumps, and the
+// derivation stamps that edit onto the dispatched event — so on-input
+// hears `move_caret` and the palette treats it as list navigation
+// instead of applying it to the query draft. No runtime changes, no
+// app-level key fallback: the palette is pure userland.
+
+import { Sub, asciiBytes } from "@native-sdk/core";
+import { type ScrollState } from "@native-sdk/core/events";
+import {
+  applyTextInputEvent,
+  clampedInsertEvent,
+  containsIgnoreCase,
+  orderIgnoreCase,
+  type TextEditState,
+  type TextInputEvent,
+} from "@native-sdk/core/text";
+
+export type Bytes = Uint8Array;
+
+const MAX_QUERY = 96;
+
+interface Draft {
+  readonly bytes: Bytes;
+  readonly anchor: number;
+  readonly focus: number;
+  readonly compStart: number;
+  readonly compEnd: number;
+}
+
+function draftInit(): Draft {
+  return { bytes: asciiBytes(""), anchor: 0, focus: 0, compStart: -1, compEnd: -1 };
+}
+
+function draftState(d: Draft): TextEditState {
+  return {
+    text: d.bytes,
+    selection: { anchor: d.anchor, focus: d.focus },
+    composition: d.compStart >= 0 ? { start: d.compStart, end: d.compEnd } : null,
+  };
+}
+
+function draftFrom(next: TextEditState): Draft {
+  return {
+    bytes: next.text,
+    anchor: next.selection.anchor,
+    focus: next.selection.focus,
+    compStart: next.composition !== null ? next.composition.start : -1,
+    compEnd: next.composition !== null ? next.composition.end : -1,
+  };
+}
+
+function draftApply(d: Draft, event: TextInputEvent): Draft {
+  const state = draftState(d);
+  const next = applyTextInputEvent(state, event, MAX_QUERY);
+  if (next === null) {
+    const clamped = clampedInsertEvent(state, event, MAX_QUERY);
+    if (clamped === null) return d;
+    const nextClamped = applyTextInputEvent(state, clamped, MAX_QUERY);
+    if (nextClamped === null) return d;
+    return draftFrom(nextClamped);
+  }
+  return draftFrom(next);
+}
+
+// ------------------------------------------------------------ tasks
+
+export interface Task {
+  readonly id: number;
+  readonly title: Bytes;
+  readonly done: boolean;
+}
+
+function sampleTasks(): readonly Task[] {
+  return [
+    { id: 1, title: asciiBytes("Review the markup diff"), done: false },
+    { id: 2, title: asciiBytes("Ship the changelog fragment"), done: false },
+    { id: 3, title: asciiBytes("Answer the design thread"), done: true },
+    { id: 4, title: asciiBytes("Rebuild the docs site"), done: false },
+    { id: 5, title: asciiBytes("Tag the release"), done: false },
+  ];
+}
+
+// ------------------------------------------------------------ commands
+
+// Static commands own ids below 100; every open task contributes a
+// dynamic "Complete:" command at 100 + task id — the palette's rows are
+// DERIVED from app data, which is the whole point of a palette.
+const CMD_CLEAR = 1;
+const CMD_RESTORE = 2;
+const CMD_SORT = 3;
+const CMD_TASK_BASE = 100;
+
+const TITLE_CLEAR = asciiBytes("Clear completed tasks");
+const TITLE_RESTORE = asciiBytes("Restore sample tasks");
+const TITLE_SORT = asciiBytes("Sort tasks A to Z");
+const PREFIX_COMPLETE = asciiBytes("Complete:");
+const PREFIX_NONE = asciiBytes("");
+
+// Palette results geometry: uniform rows inside the dialog's scroll.
+const PALETTE_ROW_EXTENT = 37.5;
+const PALETTE_VIEWPORT = 235.75;
+
+function paletteScrollFor(offset: number, rowTop: number): number {
+  const bottom = rowTop + PALETTE_ROW_EXTENT;
+  if (rowTop < offset) return rowTop;
+  if (bottom > offset + PALETTE_VIEWPORT) return bottom - PALETTE_VIEWPORT;
+  return offset;
+}
+
+// ------------------------------------------------------------ model
+
+export interface Model {
+  readonly tasks: readonly Task[];
+  readonly paletteOpen: boolean;
+  readonly paletteDraft: Draft;
+  readonly paletteSelected: number;
+  readonly paletteScroll: number;
+  readonly status: Bytes;
+}
+
+export type Msg =
+  | { readonly kind: "toggle_palette" }
+  | { readonly kind: "close_palette" }
+  | { readonly kind: "palette_edit"; readonly edit: TextInputEvent }
+  | { readonly kind: "palette_exec" }
+  | { readonly kind: "palette_run"; readonly id: number }
+  | { readonly kind: "palette_scrolled"; readonly scroll: ScrollState }
+  | { readonly kind: "task_toggle"; readonly id: number };
+
+export function initialModel(): Model {
+  return {
+    tasks: sampleTasks(),
+    paletteOpen: false,
+    paletteDraft: draftInit(),
+    paletteSelected: 0,
+    paletteScroll: 0 * PALETTE_ROW_EXTENT,
+    status: asciiBytes("Cmd+Shift+P for commands"),
+  };
+}
+
+export function commandMsg(name: string): Msg | null {
+  if (name === "command.palette") return { kind: "toggle_palette" };
+  if (name === "command.dismiss") return { kind: "close_palette" };
+  return null;
+}
+
+// ------------------------------------------------------------ update
+
+interface CommandRow {
+  readonly id: number;
+  readonly prefix: Bytes;
+  readonly title: Bytes;
+}
+
+function visibleCommands(model: Model): readonly CommandRow[] {
+  const query = model.paletteDraft.bytes;
+  const out: CommandRow[] = [];
+  const statics: readonly CommandRow[] = [
+    { id: CMD_CLEAR, prefix: PREFIX_NONE, title: TITLE_CLEAR },
+    { id: CMD_RESTORE, prefix: PREFIX_NONE, title: TITLE_RESTORE },
+    { id: CMD_SORT, prefix: PREFIX_NONE, title: TITLE_SORT },
+  ];
+  for (let i = 0; i < statics.length; i++) {
+    if (query.length > 0 && !containsIgnoreCase(statics[i].title, query)) continue;
+    out[out.length] = statics[i];
+  }
+  for (let i = 0; i < model.tasks.length; i++) {
+    const task = model.tasks[i];
+    if (task.done) continue;
+    if (query.length > 0 && !containsIgnoreCase(task.title, query)) continue;
+    out[out.length] = { id: CMD_TASK_BASE + task.id, prefix: PREFIX_COMPLETE, title: task.title };
+  }
+  return out;
+}
+
+function paletteStep(model: Model, delta: number): Model {
+  const count = visibleCommands(model).length;
+  if (count === 0) return model;
+  let next = model.paletteSelected + delta;
+  if (next < 0) next = count - 1;
+  if (next >= count) next = 0;
+  let rowTop = 0 * PALETTE_ROW_EXTENT;
+  for (let i = 0; i < next; i++) rowTop = rowTop + PALETTE_ROW_EXTENT;
+  return { ...model, paletteSelected: next, paletteScroll: paletteScrollFor(model.paletteScroll, rowTop) };
+}
+
+function setTaskDone(tasks: readonly Task[], id: number, done: boolean): readonly Task[] {
+  const out: Task[] = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    out[out.length] = task.id === id ? { id: task.id, title: task.title, done: done } : task;
+  }
+  return out;
+}
+
+function runCommand(model: Model, id: number): Model {
+  const closed: Model = {
+    ...model,
+    paletteOpen: false,
+    paletteDraft: draftInit(),
+    paletteSelected: 0,
+    paletteScroll: 0 * PALETTE_ROW_EXTENT,
+  };
+  if (id === CMD_CLEAR) {
+    const open: Task[] = [];
+    for (let i = 0; i < model.tasks.length; i++) {
+      if (!model.tasks[i].done) open[open.length] = model.tasks[i];
+    }
+    return { ...closed, tasks: open, status: asciiBytes("Cleared completed tasks") };
+  }
+  if (id === CMD_RESTORE) {
+    return { ...closed, tasks: sampleTasks(), status: asciiBytes("Restored sample tasks") };
+  }
+  if (id === CMD_SORT) {
+    const sorted = model.tasks.slice();
+    for (let i = 1; i < sorted.length; i++) {
+      let j = i;
+      while (j > 0 && orderIgnoreCase(sorted[j].title, sorted[j - 1].title) < 0) {
+        const held = sorted[j];
+        sorted[j] = sorted[j - 1];
+        sorted[j - 1] = held;
+        j = j - 1;
+      }
+    }
+    return { ...closed, tasks: sorted, status: asciiBytes("Sorted tasks") };
+  }
+  if (id >= CMD_TASK_BASE) {
+    return {
+      ...closed,
+      tasks: setTaskDone(model.tasks, id - CMD_TASK_BASE, true),
+      status: asciiBytes("Completed a task"),
+    };
+  }
+  return closed;
+}
+
+export function update(model: Model, msg: Msg): Model {
+  switch (msg.kind) {
+    case "toggle_palette":
+      if (model.paletteOpen) return { ...model, paletteOpen: false };
+      return { ...model, paletteOpen: true, paletteDraft: draftInit(), paletteSelected: 0, paletteScroll: 0 * PALETTE_ROW_EXTENT };
+    case "close_palette":
+      return { ...model, paletteOpen: false };
+    case "palette_edit": {
+      // The seam in action: unmodified vertical arrows arrive as caret
+      // start/end jumps — reinterpret them as list navigation. Extend
+      // variants (shift held) stay text-selection edits and apply.
+      const edit = msg.edit;
+      if (edit.kind === "move_caret") {
+        if (!edit.move.extend) {
+          if (edit.move.direction === "end") return paletteStep(model, 1);
+          if (edit.move.direction === "start") return paletteStep(model, -1);
+        }
+      }
+      return { ...model, paletteDraft: draftApply(model.paletteDraft, edit), paletteSelected: 0, paletteScroll: 0 * PALETTE_ROW_EXTENT };
+    }
+    case "palette_exec": {
+      const visible = visibleCommands(model);
+      if (visible.length === 0) return model;
+      const index = model.paletteSelected < visible.length ? model.paletteSelected : 0;
+      return runCommand(model, visible[index].id);
+    }
+    case "palette_run":
+      return runCommand(model, msg.id);
+    case "palette_scrolled":
+      return { ...model, paletteScroll: msg.scroll.offset };
+    case "task_toggle": {
+      let found = false;
+      let wasDone = false;
+      for (let i = 0; i < model.tasks.length; i++) {
+        if (model.tasks[i].id === msg.id) {
+          found = true;
+          wasDone = model.tasks[i].done;
+        }
+      }
+      if (!found) return model;
+      return { ...model, tasks: setTaskDone(model.tasks, msg.id, !wasDone) };
+    }
+  }
+}
+
+export function subscriptions(model: Model): Sub<Msg> {
+  return Sub.none;
+}
+
+// ------------------------------------------------------------ bindings
+
+export interface PaletteRow {
+  readonly id: number;
+  readonly prefix: Bytes;
+  readonly title: Bytes;
+  readonly hasPrefix: boolean;
+  readonly selected: boolean;
+}
+
+export function paletteRows(model: Model): readonly PaletteRow[] {
+  const visible = visibleCommands(model);
+  const rows: PaletteRow[] = [];
+  for (let i = 0; i < visible.length; i++) {
+    rows[rows.length] = {
+      id: visible[i].id,
+      prefix: visible[i].prefix,
+      title: visible[i].title,
+      hasPrefix: visible[i].prefix.length > 0,
+      selected: i === model.paletteSelected,
+    };
+  }
+  return rows;
+}
+
+export function paletteQuery(model: Model): Bytes {
+  return model.paletteDraft.bytes;
+}
+
+export interface TaskRow {
+  readonly id: number;
+  readonly title: Bytes;
+  readonly done: boolean;
+}
+
+export function taskRows(model: Model): readonly TaskRow[] {
+  const rows: TaskRow[] = [];
+  for (let i = 0; i < model.tasks.length; i++) {
+    rows[rows.length] = { id: model.tasks[i].id, title: model.tasks[i].title, done: model.tasks[i].done };
+  }
+  return rows;
+}
+
+export function openCount(model: Model): number {
+  let count = 0;
+  for (let i = 0; i < model.tasks.length; i++) {
+    if (!model.tasks[i].done) count = count + 1;
+  }
+  return count;
+}
+
+export function doneCount(model: Model): number {
+  return model.tasks.length - openCount(model);
+}
+
+export function statusLine(model: Model): Bytes {
+  return model.status;
+}

--- a/examples/command-palette/tsconfig.json
+++ b/examples/command-palette/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  // Mirrors the compiler options the @native-sdk/core checker enforces,
+  // so editor diagnostics match `native check` reality. @native-sdk/core
+  // resolves from node_modules: the native CLI materializes the SDK's
+  // copy there (and keeps it fresh) until the package is on npm.
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["esnext"],
+    "types": [],
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Description

The keyboard-shortcuts docs call an `openCommandPalette()` that existed nowhere in the tree. This example implements it: a task app where Cmd+Shift+P opens the palette, typing filters static and per-task commands, and Enter runs the selection.

ArrowUp/Down navigation is pure userland: the v0.5.2 edit-derivation seam stamps vertical arrows in single-line fields as `move_caret` edits, and the core reads those as list navigation. No runtime changes. Verified through the automation harness on current main; `scripts/gate.sh fast origin/main` is green.

Known gap: no screen-reader announcement when arrowing through results; candidate SDK-level follow-up.

### Screenshot
<img width="872" height="704" alt="image" src="https://github.com/user-attachments/assets/7ab640a2-197f-4a95-a5d9-920e82753032" />
