### PR TITLE
Make build validation portable on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -382,6 +382,14 @@ pub fn build(b: *std.Build) void {
         .name = "check-file-contains",
         .root_module = file_contains_checker_mod,
     });
+    const file_contains_checker_tests = testArtifact(b, file_contains_checker_mod);
+
+    const file_exists_checker_mod = module(b, host_target, optimize, "tools/check_file_exists.zig");
+    const file_exists_checker = b.addExecutable(.{
+        .name = "check-file-exists",
+        .root_module = file_exists_checker_mod,
+    });
+    const file_exists_checker_tests = testArtifact(b, file_exists_checker_mod);
 
     // Registry pin printer: emits the ui_schema table counts and
     // fingerprints in the exact form ui_schema_tests.zig pins, plus the
@@ -447,6 +455,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(automation_cli_tests).step);
     test_step.dependOn(&b.addRunArtifact(markup_cli_tests).step);
     test_step.dependOn(&b.addRunArtifact(evals_cmdview_tests).step);
+    test_step.dependOn(&b.addRunArtifact(file_contains_checker_tests).step);
+    test_step.dependOn(&b.addRunArtifact(file_exists_checker_tests).step);
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-package-types", "Verify package TypeScript platform feature names", &.{
         .{ .path = "packages/native-sdk/native-sdk.d.ts", .pattern = "NativeSdkCommandInfo" },
         .{ .path = "packages/native-sdk/native-sdk.d.ts", .pattern = "list(): Promise<NativeSdkCommandInfo[]>" },
@@ -666,7 +676,7 @@ pub fn build(b: *std.Build) void {
         .{ .path = "build/app.zig", .pattern = "\"-DNATIVE_SDK_ALLOW_WEBKITGTK_STUB\"" },
         .{ .path = "src/tooling/templates.zig", .pattern = "\"-DNATIVE_SDK_ALLOW_WEBKITGTK_STUB\"" },
     });
-    addLayoutCheckStep(b, test_step, "test-windows-webview2-loader-layout", "Verify the vendored WebView2 loader binaries are present", &.{
+    addLayoutCheckStep(b, file_exists_checker, test_step, "test-windows-webview2-loader-layout", "Verify the vendored WebView2 loader binaries are present", &.{
         "third_party/webview2/x64/WebView2Loader.dll",
         "third_party/webview2/arm64/WebView2Loader.dll",
     });
@@ -1277,7 +1287,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const mobile_examples_step = b.step("test-examples-mobile", "Verify mobile example project layouts");
-    addLayoutCheckStep(b, mobile_examples_step, "test-example-ios-layout", "Verify iOS example layout", &.{
+    addLayoutCheckStep(b, file_exists_checker, mobile_examples_step, "test-example-ios-layout", "Verify iOS example layout", &.{
         "examples/ios/README.md",
         "examples/ios/app.zon",
         "examples/ios/NativeSdkIOSExample.xcodeproj/project.pbxproj",
@@ -1287,7 +1297,7 @@ pub fn build(b: *std.Build) void {
         "examples/ios/NativeSdkIOSExample/native_sdk.h",
         "examples/ios/NativeSdkIOSExample/NativeSdkDyldShim.c",
     });
-    addLayoutCheckStep(b, mobile_examples_step, "test-example-android-layout", "Verify Android example layout", &.{
+    addLayoutCheckStep(b, file_exists_checker, mobile_examples_step, "test-example-android-layout", "Verify Android example layout", &.{
         "examples/android/README.md",
         "examples/android/app.zon",
         "examples/android/settings.gradle",
@@ -1299,7 +1309,7 @@ pub fn build(b: *std.Build) void {
         "examples/android/app/src/main/cpp/native_sdk_jni.c",
         "examples/android/app/src/main/cpp/native_sdk.h",
     });
-    addLayoutCheckStep(b, mobile_examples_step, "test-example-mobile-shell-layout", "Verify shared mobile-shell metadata", &.{
+    addLayoutCheckStep(b, file_exists_checker, mobile_examples_step, "test-example-mobile-shell-layout", "Verify shared mobile-shell metadata", &.{
         "examples/mobile-shell/README.md",
         "examples/mobile-shell/app.zon",
     });
@@ -1329,7 +1339,7 @@ pub fn build(b: *std.Build) void {
         "examples/calculator/zig-out/package/test-ios-layout/package-manifest.zon",
     };
     for (package_ios_layout_paths) |path| {
-        const check = b.addSystemCommand(&.{ "test", "-f", path });
+        const check = addFileExistsCheck(b, file_exists_checker, path);
         check.step.dependOn(&package_ios_layout_run.step);
         package_ios_layout_step.dependOn(&check.step);
         mobile_examples_step.dependOn(&check.step);
@@ -1376,7 +1386,7 @@ pub fn build(b: *std.Build) void {
         "examples/calculator/zig-out/package/test-android-layout/package-manifest.zon",
     };
     for (package_android_layout_paths) |path| {
-        const check = b.addSystemCommand(&.{ "test", "-f", path });
+        const check = addFileExistsCheck(b, file_exists_checker, path);
         check.step.dependOn(&package_android_layout_run.step);
         package_android_layout_step.dependOn(&check.step);
         mobile_examples_step.dependOn(&check.step);
@@ -3186,10 +3196,17 @@ fn managedExampleRun(b: *std.Build, cli_exe: *std.Build.Step.Compile, argv_tail:
     return run;
 }
 
-fn addLayoutCheckStep(b: *std.Build, group: *std.Build.Step, name: []const u8, description: []const u8, paths: []const []const u8) void {
+fn addFileExistsCheck(b: *std.Build, checker: *std.Build.Step.Compile, path: []const u8) *std.Build.Step.Run {
+    const check = b.addRunArtifact(checker);
+    check.setCwd(b.path("."));
+    check.addArg(path);
+    return check;
+}
+
+fn addLayoutCheckStep(b: *std.Build, checker: *std.Build.Step.Compile, group: *std.Build.Step, name: []const u8, description: []const u8, paths: []const []const u8) void {
     const step = b.step(name, description);
     for (paths) |path| {
-        const check = b.addSystemCommand(&.{ "test", "-f", path });
+        const check = addFileExistsCheck(b, checker, path);
         step.dependOn(&check.step);
         group.dependOn(&check.step);
     }

--- a/tools/check_file_contains.zig
+++ b/tools/check_file_contains.zig
@@ -15,8 +15,51 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(1);
     };
 
-    if (std.mem.indexOf(u8, content, pattern) == null) {
+    if (!try containsNormalizedNewlines(allocator, content, pattern)) {
         std.debug.print("missing pattern in {s}: {s}\n", .{ path, pattern });
         std.process.exit(1);
     }
+}
+
+fn containsNormalizedNewlines(allocator: std.mem.Allocator, content: []const u8, pattern: []const u8) !bool {
+    if (std.mem.indexOf(u8, content, pattern) != null) return true;
+    if (std.mem.indexOf(u8, content, "\r\n") == null and std.mem.indexOf(u8, pattern, "\r\n") == null) return false;
+
+    const normalized_content = try normalizeNewlines(allocator, content);
+    defer allocator.free(normalized_content);
+    const normalized_pattern = try normalizeNewlines(allocator, pattern);
+    defer allocator.free(normalized_pattern);
+    return std.mem.indexOf(u8, normalized_content, normalized_pattern) != null;
+}
+
+fn normalizeNewlines(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    var crlf_count: usize = 0;
+    var index: usize = 0;
+    while (index + 1 < input.len) : (index += 1) {
+        if (input[index] == '\r' and input[index + 1] == '\n') crlf_count += 1;
+    }
+
+    const normalized = try allocator.alloc(u8, input.len - crlf_count);
+    var source: usize = 0;
+    var destination: usize = 0;
+    while (source < input.len) : (source += 1) {
+        if (input[source] == '\r' and source + 1 < input.len and input[source + 1] == '\n') continue;
+        normalized[destination] = input[source];
+        destination += 1;
+    }
+    return normalized;
+}
+
+test "contains exact content without normalization" {
+    try std.testing.expect(try containsNormalizedNewlines(std.testing.allocator, "alpha\nbeta", "alpha"));
+    try std.testing.expect(!try containsNormalizedNewlines(std.testing.allocator, "alpha\nbeta", "gamma"));
+}
+
+test "contains treats LF and CRLF as equivalent" {
+    try std.testing.expect(try containsNormalizedNewlines(std.testing.allocator, "alpha\r\nbeta\r\n", "alpha\nbeta\n"));
+    try std.testing.expect(try containsNormalizedNewlines(std.testing.allocator, "alpha\nbeta\n", "alpha\r\nbeta\r\n"));
+}
+
+test "contains preserves standalone carriage returns" {
+    try std.testing.expect(!try containsNormalizedNewlines(std.testing.allocator, "alpha\rbeta", "alpha\nbeta"));
 }

--- a/tools/check_file_exists.zig
+++ b/tools/check_file_exists.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(allocator);
+    if (args.len != 2) {
+        std.debug.print("usage: check_file_exists <path>\n", .{});
+        std.process.exit(2);
+    }
+
+    if (!fileExists(std.Io.Dir.cwd(), init.io, args[1])) {
+        std.debug.print("missing file: {s}\n", .{args[1]});
+        std.process.exit(1);
+    }
+}
+
+fn fileExists(dir: std.Io.Dir, io: std.Io, path: []const u8) bool {
+    const stat = dir.statFile(io, path, .{}) catch return false;
+    return stat.kind == .file;
+}
+
+test "file existence distinguishes files from missing paths and directories" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try std.testing.expect(!fileExists(tmp.dir, io, "artifact.bin"));
+    var file = try tmp.dir.createFile(io, "artifact.bin", .{});
+    file.close(io);
+    try std.testing.expect(fileExists(tmp.dir, io, "artifact.bin"));
+
+    try tmp.dir.createDir(io, "artifact-dir", .default_dir);
+    try std.testing.expect(!fileExists(tmp.dir, io, "artifact-dir"));
+}


### PR DESCRIPTION
## Summary

- treat LF and CRLF as equivalent in build-time file-content checks
- replace POSIX `test -f` layout checks with a host-native Zig checker
- run focused unit tests for both checker contracts as part of the root suite

## Why

The documented `zig build test` workflow failed on Windows for two reasons unrelated to the files being validated:

1. A checkout with `core.autocrlf=true` stored CRLF in the working tree, while the embedded patterns used LF and were compared byte-for-byte.
2. Layout validation invoked the POSIX `test -f` command, which is not available in a native PowerShell environment.

This made valid Windows checkouts report missing patterns and missing artifacts even though the expected files were present.

## Implementation

The content checker keeps its existing exact-match fast path, then normalizes CRLF to LF for comparison only. Standalone carriage returns remain significant.

The new file checker uses Zig's `statFile` and verifies that the path is a regular file. All layout checks run the compiled checker from the repository root, preserving the previous relative-path behavior without requiring a Unix shell.

## Validation

- `zig test tools/check_file_contains.zig` — 3 tests passed
- `zig test tools/check_file_exists.zig` — 1 test passed
- `zig build validate`
- `scripts/gate.sh fast origin/main` after rebasing onto v0.5.4:
  - manifest validation passed
  - frontend examples passed
  - native examples passed
  - mobile examples passed
  - root tests reached an unrelated Windows compile error in `src/runtime/effects.zig:7159`; `zig build test-desktop-runtime-core` reproduces the same error on an unmodified `origin/main` worktree

Before the v0.5.4 upstream change introduced that baseline error, the complete root test and fast gate passed from native PowerShell/Git Bash with this change.

No changelog fragment is included because this changes contributor and test infrastructure only.