### PR TITLE
Run the core package gate on Windows

### DIFF
--- a/packages/core/scripts/gate.mjs
+++ b/packages/core/scripts/gate.mjs
@@ -49,17 +49,19 @@ try {
   }
 
   const zig = (args) => execFileSync("zig", args, { cwd: work, stdio: "inherit" });
+  const executableName = (name) => process.platform === "win32" ? `${name}.exe` : name;
+  const executable = (name) => path.join(work, executableName(name));
 
   // 3. Build ReleaseSafe (the shipping mode: index checks stay on).
-  zig(["build-lib", "-OReleaseSafe", "-femit-bin=libinbox.a", "shim.zig"]);
+  zig(["build-lib", "-OReleaseSafe", "-femit-bin=libinbox.a", "shim.zig", "-lc"]);
   zig([
-    "build-exe", "-OReleaseSafe", "-femit-bin=bench_safe",
+    "build-exe", "-OReleaseSafe", `-femit-bin=${executableName("bench_safe")}`,
     "--dep", "impl", "-Mroot=bench.zig", "-Mimpl=impl.zig", "libinbox.a", "-lc",
   ]);
   log("built ReleaseSafe");
 
   // 4. run1k digest gate.
-  execFileSync(path.join(work, "bench_safe"), ["run1k", "run1k.txt"], { cwd: work, stdio: "inherit" });
+  execFileSync(executable("bench_safe"), ["run1k", "run1k.txt"], { cwd: work, stdio: "inherit" });
   const digest = createHash("md5").update(fs.readFileSync(path.join(work, "run1k.txt"))).digest("hex");
   if (digest !== ORACLE_RUN1K_MD5) {
     console.error(`[gate] FAIL run1k digest ${digest} != oracle ${ORACLE_RUN1K_MD5}`);
@@ -70,14 +72,14 @@ try {
   // 5. Perf band.
   if (!skipBench) {
     log("bench10k (ReleaseSafe):");
-    execFileSync(path.join(work, "bench_safe"), ["bench10k"], { cwd: work, stdio: "inherit" });
-    zig(["build-lib", "-OReleaseFast", "-femit-bin=libinbox_fast.a", "shim.zig"]);
+    execFileSync(executable("bench_safe"), ["bench10k"], { cwd: work, stdio: "inherit" });
+    zig(["build-lib", "-OReleaseFast", "-femit-bin=libinbox_fast.a", "shim.zig", "-lc"]);
     zig([
-      "build-exe", "-OReleaseFast", "-femit-bin=bench_fast",
+      "build-exe", "-OReleaseFast", `-femit-bin=${executableName("bench_fast")}`,
       "--dep", "impl", "-Mroot=bench.zig", "-Mimpl=impl.zig", "libinbox_fast.a", "-lc",
     ]);
     log("bench10k (ReleaseFast):");
-    execFileSync(path.join(work, "bench_fast"), ["bench10k"], { cwd: work, stdio: "inherit" });
+    execFileSync(executable("bench_fast"), ["bench10k"], { cwd: work, stdio: "inherit" });
   }
 
   log("PASS");

--- a/packages/core/test/fixtures/bench.zig
+++ b/packages/core/test/fixtures/bench.zig
@@ -125,24 +125,23 @@ fn run1k(alloc: std.mem.Allocator, io: std.Io, out_path: []const u8) !void {
     std.debug.print("run1k wrote {s} ({d} bytes, {d} effect bytes)\n", .{ out_path, out.items.len, eff_len });
 }
 
-// Raw monotonic nanoseconds (darwin). ~41ns granularity on Apple Silicon.
-extern "c" fn clock_gettime_nsec_np(clock_id: c_int) u64;
-const CLOCK_UPTIME_RAW: c_int = 8;
-inline fn nowNs() u64 {
-    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+// Monotonic awake-time nanoseconds. This maps to CLOCK_UPTIME_RAW on macOS
+// while retaining the same benchmark contract on other supported hosts.
+inline fn nowNs(io: std.Io) u64 {
+    return @intCast(@max(std.Io.Timestamp.now(io, .awake).nanoseconds, 0));
 }
 
-fn bench10k(alloc: std.mem.Allocator) !void {
+fn bench10k(alloc: std.mem.Allocator, io: std.Io) !void {
     impl.reset();
     var rng = SplitMix{ .state = 0xdead_beef_cafe_f00d };
     const iters = 10_000;
     const samples = try alloc.alloc(u64, iters);
 
-    const bench_start = nowNs();
+    const bench_start = nowNs(io);
     for (0..iters) |i| {
         // Keystroke-shaped mix: mostly single-char inserts.
         const roll = rng.below(1000);
-        const t0 = nowNs();
+        const t0 = nowNs(io);
         if (roll < 700) {
             impl.pushText(@floatFromInt(0x61 + rng.below(26)));
             _ = impl.dispatch(4, 0, 0, 0, 0, 0);
@@ -159,9 +158,9 @@ fn bench10k(alloc: std.mem.Allocator) !void {
         } else {
             _ = impl.dispatch(3, 0, 0, 0, 0, 0); // clear_done
         }
-        samples[i] = nowNs() - t0;
+        samples[i] = nowNs(io) - t0;
     }
-    const wall_total = nowNs() - bench_start;
+    const wall_total = nowNs(io) - bench_start;
 
     std.mem.sort(u64, samples, {}, std.sort.asc(u64));
     var total: u64 = 0;
@@ -190,15 +189,15 @@ pub fn main(init: std.process.Init) !void {
     const alloc = init.arena.allocator();
     impl.init();
 
-    const argv = init.minimal.args.vector;
-    const mode: []const u8 = if (argv.len > 1) std.mem.span(argv[1]) else "smoke";
+    const args = try init.minimal.args.toSlice(alloc);
+    const mode: []const u8 = if (args.len > 1) args[1] else "smoke";
 
     if (std.mem.eql(u8, mode, "smoke")) {
         try smoke(alloc);
     } else if (std.mem.eql(u8, mode, "run1k")) {
-        try run1k(alloc, init.io, std.mem.span(argv[2]));
+        try run1k(alloc, init.io, args[2]);
     } else if (std.mem.eql(u8, mode, "bench10k")) {
-        try bench10k(alloc);
+        try bench10k(alloc, init.io);
     } else {
         std.debug.print("unknown mode {s}\n", .{mode});
     }


### PR DESCRIPTION
## Summary

- link the generated core shim libraries against libc explicitly
- decode benchmark arguments through Zig's platform-neutral process API
- replace the macOS-only benchmark clock symbol with Zig's monotonic awake clock
- emit and launch benchmark executables with the correct Windows suffix

## Why

`npm --prefix packages/core run gate` could not run on Windows. Its deterministic core gate crossed several platform boundaries that had only been exercised in a Unix/macOS shape:

1. The generated shim uses the C allocator, but both `zig build-lib` commands omitted `-lc`.
2. The benchmark read `init.minimal.args.vector` as C strings, although Windows exposes a UTF-16 native argument vector.
3. Timing linked directly to macOS `clock_gettime_nsec_np`.
4. Explicit extensionless `-femit-bin` names produced PE files that Node could not launch on Windows.

## Implementation

The gate now links libc consistently for ReleaseSafe and ReleaseFast. The benchmark uses `args.toSlice` for UTF-8 arguments and `std.Io.Timestamp.now(io, .awake)` for monotonic timing; `.awake` retains the existing `CLOCK_UPTIME_RAW` mapping on macOS. A shared helper supplies `.exe` to both emitted and executed benchmark names on Windows while leaving Unix names unchanged.

The oracle digest and benchmark workloads are unchanged.

## Validation

- `npm --prefix packages/core run gate`
  - ReleaseSafe and ReleaseFast builds passed
  - run1k digest matched `4e1140c16ba5569ab73db860894f4eba`
  - both 10k benchmarks completed
- `zig build test-ts-core-e2e`
- `scripts/gate.sh fast origin/main` with PR #157 temporarily applied in a detached validation worktree
  - root tests
  - manifest validation
  - frontend examples
  - native examples
  - mobile examples

The temporary application of #157 was needed only because current `main` has the Windows CRLF root-gate failure addressed there. This branch does not contain #157 and remains an independent two-file package-gate change.

No changelog fragment is included because this changes test infrastructure only.
