### PR TITLE
Make image cache tests compile on Windows

### DIFF
--- a/src/runtime/effects.zig
+++ b/src/runtime/effects.zig
@@ -7156,7 +7156,10 @@ test "image cache probe propagates a cancel interruption and reads every other f
             _ = dir;
             _ = sub_path;
             _ = options;
-            return .{ .handle = 0, .flags = .{ .nonblocking = false } };
+            return .{
+                .handle = if (builtin.os.tag == .windows) std.os.windows.INVALID_HANDLE_VALUE else 0,
+                .flags = .{ .nonblocking = false },
+            };
         }
         fn readCanceled(userdata: ?*anyopaque, file: std.Io.File, data: []const []u8, offset: u64) std.Io.File.ReadPositionalError!usize {
             _ = userdata;


### PR DESCRIPTION
## Summary

- use `std.os.windows.INVALID_HANDLE_VALUE` for the fake image-cache file on Windows
- keep the existing integer placeholder on platforms whose `std.Io.File.Handle` is a file descriptor
- leave production file IO and the cancellation behavior unchanged

## Why

On Windows, Zig 0.16 resolves `std.Io.File.Handle` to `windows.HANDLE` (`*anyopaque`). The image-cache cancellation test initialized that field with integer `0`, so `zig build test-desktop-runtime-core` failed to compile on current `main`.

The test vtable intercepts both the positional read and close operations, so the fake file only needs a type-correct sentinel; no operating-system call observes the handle.

## Validation

- `zig fmt --check src/runtime/effects.zig`
- `zig build test-desktop-runtime-core`
- `zig build validate`
- `scripts/gate.sh fast origin/main` with #157 applied: root tests, validation, frontend examples, native examples, and mobile examples all pass

The standalone fast gate on Windows still reaches the existing CRLF and POSIX file-check failures addressed by #157; the focused runtime suite passes with this change, and the combined validation confirms the two fixes compose cleanly.

No changelog fragment is included because this only repairs a test fixture on Windows.
