### PR TITLE
Fix TypeScript integer inference non-convergence

### DIFF
--- a/changelog.d/ts-core-forward-demand-convergence.md
+++ b/changelog.d/ts-core-forward-demand-convergence.md
@@ -1,0 +1,2 @@
+fix: **TypeScript core transpilation convergence**: exported numeric helpers that share an internal callee with comparison-driven message fields no longer leave integer inference spinning indefinitely.
+

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -1,3 +1,4 @@
+
 // R2 integer inference: JS semantics are f64 everywhere, but the emitter may
 // use i64 wherever that is unobservable. A `number` slot (const, local, param,
 // field, return) is emitted as i64 when:
@@ -1408,7 +1409,10 @@ export class IntInference {
           );
           if (hardFed || tentativeFed) {
             demandSlot(s, !hardFed);
-            changed = true;
+            // Comparison-only demand is rejected when this slot touches an
+            // exported host boundary. Iterate again only when the claim
+            // actually landed; otherwise the fixed point never converges.
+            if (s.demanded) changed = true;
           }
         } else if (s.comparisonDemanded && hardFed) {
           demandSlot(s, false);

--- a/packages/core/test/emitter.test.ts
+++ b/packages/core/test/emitter.test.ts
@@ -1,3 +1,4 @@
+
 // Emitter tests: one mapping rule per case — small TS in, the rule's Zig
 // shape out. Substring asserts, not golden files: the shapes are the spec.
 
@@ -22,6 +23,35 @@ export function scale(x: number): number {
 `);
   assert.match(zig, /fn pick\(bytes: \[\]const u8, i: i64\) i64/);
   assert.match(zig, /fn scale\(x: f64\) f64/);
+});
+
+test("R2 forward demand converges when a helper also receives an exported host parameter", () => {
+  const zig = emit(`
+export type Msg =
+  | { readonly kind: "toggle"; readonly id: number }
+  | { readonly kind: "noop" };
+
+function identity(id: number): number { return id; }
+
+export function fromHost(id: number): number {
+  return identity(id);
+}
+
+export function update(msg: Msg): number {
+  switch (msg.kind) {
+    case "toggle":
+      if (msg.id === 0) return 0;
+      return identity(msg.id);
+    case "noop":
+      return 0;
+  }
+}
+`);
+  // The comparison tentatively demands Msg.id while the shared helper also
+  // receives an f64 host-boundary parameter. Rejecting the propagated claim
+  // must settle the fixed point instead of spinning forever.
+  assert.match(zig, /pub fn fromHost\(id: f64\) f64/);
+  assert.match(zig, /pub fn update\(msg: Msg\) f64/);
 });
 
 test("R2 .length widens through jlen", () => {


### PR DESCRIPTION
## Summary

- Stop the forward-demand fixed point from reporting progress when comparison-only demand is rejected at an exported host boundary.
- Add a regression for a shared helper fed by both an exported parameter and a comparison-driven message field.
- Add a changelog fragment for the transpilation fix.

## Root cause

IntInference.resolve unconditionally marked the pass as changed after calling demandSlot. When the slot touched an exported host boundary, demandSlot correctly rejected a comparison-only integer claim, but the outer loop still reported progress and never converged.

## Validation

- npm test --prefix packages/core: 243 tests, 232 passed, 11 skipped.
- scripts/gate.sh fast: zig-test and zig-validate passed.
- Added regression test R2 forward demand converges when a helper also receives an exported host parameter, verifying transpilation terminates and fromHost remains f64.