### PR TITLE
Add an env-gated behavior-parity suite for compiled core archives

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -482,6 +482,15 @@ pub fn build(b: *std.Build) void {
         const sidecar_conformance_run = b.addRunArtifact(ts_core_artifacts.sidecar_conformance);
         const sidecar_conformance_step = b.step("sidecar-conformance", "Prove corewire-generated mirrors fingerprint-identical to transpiler output (requires node)");
         sidecar_conformance_step.dependOn(&sidecar_conformance_run.step);
+        // Skipped unless the caller supplies a compiled-core archive:
+        // the repo builds none, so the step gates on the env var and
+        // `zig build test` stays green without it.
+        const parity_step = b.step("test-external-core-parity", "Run the compiled-core behavior-parity suite (requires node and NATIVE_SDK_EXTERNAL_CORE_ARCHIVE=<link input[" ++ [_]u8{std.fs.path.delimiter} ++ "link input...]>; skipped when unset)");
+        if (ts_core_artifacts.external_core_parity) |parity_tests| {
+            const parity_run = b.addRunArtifact(parity_tests);
+            parity_step.dependOn(&parity_run.step);
+            test_step.dependOn(&parity_run.step);
+        }
         ts_core_e2e_step.dependOn(&host_e2e_run.step);
         ts_core_e2e_step.dependOn(&soundboard_e2e_run.step);
         ts_core_e2e_step.dependOn(&monitor_e2e_run.step);
@@ -2859,6 +2868,12 @@ const TsCoreE2eArtifacts = struct {
     /// mirror — and compared by layout fingerprint and model-contract
     /// artifact.
     sidecar_conformance: *std.Build.Step.Compile,
+    /// Behavior parity against a REAL compiled core: built only when
+    /// NATIVE_SDK_EXTERNAL_CORE_ARCHIVE names the archive(s) to link
+    /// (path-delimiter-separated link inputs exporting the markup
+    /// fixture's attested symbol set); null — the suite is skipped —
+    /// otherwise.
+    external_core_parity: ?*std.Build.Step.Compile,
 };
 
 fn tsCoreE2eArtifact(
@@ -2986,6 +3001,29 @@ fn tsCoreE2eArtifact(
         conformance_mod.addImport(fixture.facade_import, facadeCoreModule(b, target, optimize, node, corewire_exe, sidecar_json));
     }
 
+    // Compiled-core behavior parity (tests/sidecar/
+    // external_core_parity_tests.zig): the executable half of the
+    // conformance story, gated on a caller-supplied compiled-core
+    // archive because the repo builds none itself. The env var carries
+    // one or more link inputs (path-delimiter-separated) that together
+    // export the markup fixture's attested symbol set; the binary pairs
+    // a FRESH generated mirror with them (the conformance binary's
+    // mirror links the stub core's exports — one process cannot carry
+    // both symbol sets).
+    const external_core_parity: ?*std.Build.Step.Compile = if (b.graph.environ_map.get("NATIVE_SDK_EXTERNAL_CORE_ARCHIVE")) |archives| blk: {
+        const parity_mod = module(b, target, optimize, "tests/sidecar/external_core_parity_tests.zig");
+        parity_mod.link_libc = true;
+        parity_mod.addImport("corewire_rt", module(b, target, optimize, "tools/corewire/shim_rt.zig"));
+        parity_mod.addImport("core_abi", module(b, target, optimize, "tools/corewire/core_abi.zig"));
+        parity_mod.addImport("ts_core", markup_fixture_mod);
+        parity_mod.addImport("shim_core", sidecarShimModule(b, target, optimize, corewire_exe, b.path("tests/sidecar/markup_fixture.contract.json")));
+        var inputs = std.mem.tokenizeScalar(u8, archives, std.fs.path.delimiter);
+        while (inputs.next()) |input| {
+            parity_mod.addObjectFile(.{ .cwd_relative = b.dupe(input) });
+        }
+        break :blk filteredTestArtifact(b, parity_mod, "external-core-parity-tests", &.{});
+    } else null;
+
     return .{
         .host = filteredTestArtifact(b, e2e_mod, "ts-core-e2e-tests", &.{}),
         .soundboard = filteredTestArtifact(b, soundboard_mod, "ts-soundboard-e2e-tests", &.{}),
@@ -2993,6 +3031,7 @@ fn tsCoreE2eArtifact(
         .scaffold_ide = filteredTestArtifact(b, scaffold_ide_mod, "ts-scaffold-ide-e2e-tests", &.{}),
         .ai_chat = filteredTestArtifact(b, ai_chat_mod, "ts-ai-chat-e2e-tests", &.{}),
         .sidecar_conformance = filteredTestArtifact(b, conformance_mod, "sidecar-conformance-tests", &.{}),
+        .external_core_parity = external_core_parity,
     };
 }
 

--- a/tests/sidecar/conformance_tests.zig
+++ b/tests/sidecar/conformance_tests.zig
@@ -247,74 +247,9 @@ test "ai-chat: helper methods keep the exported call surface" {
 // facade compile's own number classes are inference-decided and may
 // legally differ; the bytes must not).
 
-/// Convert a value between two structurally-equivalent mirror types by
-/// field/arm/member NAME, normalizing numeric classes and reference
-/// storage (pointers deref on read, re-materialize on write).
-fn convertValue(comptime Target: type, value: anytype, allocator: std.mem.Allocator) !Target {
-    const Source = @TypeOf(value);
-    if (@typeInfo(Source) == .pointer and @typeInfo(Source).pointer.size == .one) {
-        return convertValue(Target, value.*, allocator);
-    }
-    switch (@typeInfo(Target)) {
-        .bool => return value,
-        .int => return switch (@typeInfo(Source)) {
-            .int => @intCast(value),
-            .float => @intFromFloat(value),
-            else => @compileError("cannot convert " ++ @typeName(Source) ++ " to " ++ @typeName(Target)),
-        },
-        .float => return switch (@typeInfo(Source)) {
-            .float => @floatCast(value),
-            .int => @floatFromInt(value),
-            else => @compileError("cannot convert " ++ @typeName(Source) ++ " to " ++ @typeName(Target)),
-        },
-        .@"enum" => {
-            switch (value) {
-                inline else => |tag| return @field(Target, @tagName(tag)),
-            }
-        },
-        .optional => |info| {
-            if (value) |inner| return try convertValue(info.child, inner, allocator);
-            return null;
-        },
-        .pointer => |info| switch (info.size) {
-            .slice => {
-                if (info.child == u8) return allocator.dupe(u8, value);
-                const out = try allocator.alloc(info.child, value.len);
-                for (out, value) |*slot, element| {
-                    slot.* = try convertValue(info.child, element, allocator);
-                }
-                return out;
-            },
-            .one => {
-                const out = try allocator.create(info.child);
-                out.* = try convertValue(info.child, value, allocator);
-                return out;
-            },
-            else => @compileError("no conversion for " ++ @typeName(Target)),
-        },
-        .@"struct" => |info| {
-            var out: Target = undefined;
-            inline for (info.fields) |field| {
-                @field(out, field.name) = try convertValue(field.type, @field(value, field.name), allocator);
-            }
-            return out;
-        },
-        .@"union" => |info| {
-            switch (value) {
-                inline else => |payload, tag| {
-                    inline for (info.fields) |field| {
-                        if (comptime std.mem.eql(u8, field.name, @tagName(tag))) {
-                            if (field.type == void) return @unionInit(Target, field.name, {});
-                            return @unionInit(Target, field.name, try convertValue(field.type, payload, allocator));
-                        }
-                    }
-                    unreachable;
-                },
-            }
-        },
-        else => @compileError("no conversion for " ++ @typeName(Target)),
-    }
-}
+/// Mirror-value conversion by name (tests/sidecar/mirror_value.zig),
+/// shared with the compiled-core behavior-parity suite.
+const convertValue = @import("mirror_value.zig").convertValue;
 
 /// The facade's compiled snapshot encoder must byte-match the canonical
 /// encoder over the sidecar-classed mirror layout, for both the zero

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -1,0 +1,161 @@
+//! Behavior parity against a REAL compiled core: the build links a
+//! caller-supplied compiled-core archive (NATIVE_SDK_EXTERNAL_CORE_ARCHIVE,
+//! one or more link inputs joined by the platform path delimiter, which
+//! together must export the markup fixture's attested symbol set under
+//! the canonical prefix) into this binary, and the suite drives one
+//! scripted message sequence through BOTH lanes:
+//!
+//!   - the transpiler lane: tests/ts-core/markup_fixture.ts emitted by
+//!     the repo's own transpiler (`ts_core`), and
+//!   - the compiled-core lane: corewire's generated mirror
+//!     (`shim_core`) dispatching into the linked archive through the
+//!     C ABI bindings,
+//!
+//! comparing every observable byte surface per cycle: the command
+//! bytes each dispatch returns, the committed-model snapshot (the
+//! archive's raw snapshot bytes against the canonical encoding of the
+//! transpiler lane's committed model), and the subscription bytes.
+//! The suite also pins the ABI's collect invariant on the archive
+//! side: a collect between dispatches leaves the observable snapshot
+//! byte-identical.
+//!
+//! The conformance suite (conformance_tests.zig) proves the two lanes'
+//! REFLECTION surfaces identical with no compiled core present; this
+//! suite is the executable half, and only builds when a caller
+//! supplies the archive — `zig build test` skips it otherwise.
+
+const std = @import("std");
+const corewire_rt = @import("corewire_rt");
+const core_abi = @import("core_abi");
+const convertValue = @import("mirror_value.zig").convertValue;
+
+const ts_core = @import("ts_core");
+const shim_core = @import("shim_core");
+
+const abi = core_abi.Bindings("nsc_core_");
+const testing = std.testing;
+
+/// The archive's raw committed-model snapshot bytes (result-arena
+/// resident: read and compare before any frame reset or collect).
+fn rawSnapshot() []const u8 {
+    var ptr: [*]const u8 = undefined;
+    var len: usize = 0;
+    abi.model_snapshot(&ptr, &len);
+    return ptr[0..len];
+}
+
+fn rawSubscriptions() []const u8 {
+    var ptr: [*]const u8 = undefined;
+    var len: usize = 0;
+    abi.subscriptions(&ptr, &len);
+    return ptr[0..len];
+}
+
+/// The transpiler lane's committed model, re-expressed in the mirror's
+/// sidecar-classed layout and canonically encoded — the reference bytes
+/// the archive's snapshot must equal.
+fn referenceSnapshot(model: *const ts_core.Model, arena: std.mem.Allocator) ![]const u8 {
+    const converted = try convertValue(shim_core.Model, model, arena);
+    return corewire_rt.encodeAlloc(shim_core.Model, converted, arena);
+}
+
+/// The scripted sequence: every dispatch entry class the fixture's
+/// contract declares — bare arms, i64- and f64-classed numbers, bytes,
+/// the text-input union (each payload family), and the three record
+/// arms — plus the one command-producing arm (`stamp`, whose cycle
+/// returns the `now` op's two wire bytes).
+const script = [_]shim_core.Msg{
+    .add,
+    .add,
+    .{ .toggle = 2 },
+    .{ .pick = 2 },
+    .add,
+    .cycle,
+    .{ .banner_set = "parity" },
+    .{ .draft_edit = .{ .insert_text = "hi" } },
+    .{ .draft_edit = .delete_backward },
+    .{ .draft_edit = .{ .move_caret = .{ .direction = .next_word, .extend = true } } },
+    .{ .draft_edit = .{ .set_selection = .{ .anchor = 1, .focus = -2 } } },
+    .{ .draft_edit = .{ .set_composition = .{ .text = "ab", .cursor = 1 } } },
+    .{ .draft_edit = .{ .set_composition = .{ .text = "", .cursor = null } } },
+    .{ .draft_edit = .clear },
+    .{ .canvas_resized = 800 },
+    .{ .zoomed = .{ .factor = 1.25, .windowId = 7, .fromBoard = true } },
+    .{ .appearance_changed = .{ .colorScheme = .dark, .reduceMotion = false, .highContrast = true } },
+    .{ .chrome_changed = .{ .insets = .{ .top = 28, .right = 0, .bottom = 0, .left = 0 }, .buttons = .{ .x = 8, .y = 6, .width = 52, .height = 16 }, .tabsProjected = false } },
+    .stamp,
+    .{ .stamped = 42.5 },
+    .{ .toggle = 1 },
+    .cycle,
+    .clear,
+};
+
+test "a compiled core archive matches the transpiler lane byte-for-byte over the scripted cycle" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Boot both lanes. The mirror's initialModel runs the full boot
+    // fence against the archive (identity getters, sink, init); the
+    // fixture's contract declares no boot command, so the archive's
+    // boot_cmd buffer must be empty.
+    var ts_model = ts_core.commitModelRoot(ts_core.initialModel());
+    var shim_model = shim_core.commitModelRoot(shim_core.initialModel());
+    {
+        var boot_ptr: [*]const u8 = undefined;
+        var boot_len: usize = 0;
+        abi.boot_cmd(&boot_ptr, &boot_len);
+        try testing.expectEqualSlices(u8, "", boot_ptr[0..boot_len]);
+    }
+    try testing.expectEqualSlices(u8, try referenceSnapshot(ts_model, arena), rawSnapshot());
+    // The decoded mirror root re-encodes to the same bytes: decode
+    // fidelity over the boot snapshot.
+    try testing.expectEqualSlices(u8, rawSnapshot(), corewire_rt.encodeAlloc(shim_core.Model, shim_model.*, arena));
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+
+    for (script, 0..) |msg, step| {
+        // One cycle per lane, the host adapter's ordering: update,
+        // commit, consume the command bytes, then frame reset.
+        const ts_msg = try convertValue(ts_core.Msg, msg, arena);
+        const ts_out = ts_core.update(ts_model, ts_msg);
+        ts_model = ts_core.commitModelRoot(ts_out.model);
+        const shim_out = shim_core.update(shim_model, msg);
+        shim_model = shim_core.commitModelRoot(shim_out.model);
+
+        testing.expectEqualSlices(u8, ts_out.cmd, shim_out.cmd) catch |err| {
+            std.debug.print("command bytes diverge at script step {d} ({s})\n", .{ step, @tagName(msg) });
+            return err;
+        };
+        const reference = try referenceSnapshot(ts_model, arena);
+        testing.expectEqualSlices(u8, reference, rawSnapshot()) catch |err| {
+            std.debug.print("snapshot bytes diverge at script step {d} ({s})\n", .{ step, @tagName(msg) });
+            return err;
+        };
+
+        // Between dispatches, a collect must leave the observable model
+        // untouched (the ABI's collect invariant), and the fixture's
+        // contract declares no subscriptions, so the buffer stays empty.
+        if (step % 3 == 2) {
+            abi.collect();
+            testing.expectEqualSlices(u8, reference, rawSnapshot()) catch |err| {
+                std.debug.print("collect changed the observable snapshot at script step {d} ({s})\n", .{ step, @tagName(msg) });
+                return err;
+            };
+        }
+        try testing.expectEqualSlices(u8, "", rawSubscriptions());
+
+        ts_core.rt.frameReset();
+        shim_core.rt.frameReset();
+    }
+
+    // Deterministic re-init: a second boot lands both lanes back on the
+    // boot bytes.
+    ts_core.rt.resetAll();
+    shim_core.rt.resetAll();
+    ts_model = ts_core.commitModelRoot(ts_core.initialModel());
+    shim_model = shim_core.commitModelRoot(shim_core.initialModel());
+    try testing.expectEqualSlices(u8, try referenceSnapshot(ts_model, arena), rawSnapshot());
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+}

--- a/tests/sidecar/mirror_value.zig
+++ b/tests/sidecar/mirror_value.zig
@@ -1,0 +1,76 @@
+//! Value conversion between structurally-equivalent mirror types —
+//! shared by the sidecar suites: the conformance suite converts
+//! transpiled-module values into sidecar-classed shim layouts for the
+//! facade parity axis, and the compiled-core behavior-parity suite
+//! converts scripted messages and reference models the same way.
+
+const std = @import("std");
+
+/// Convert a value between two structurally-equivalent mirror types by
+/// field/arm/member NAME, normalizing numeric classes and reference
+/// storage (pointers deref on read, re-materialize on write).
+pub fn convertValue(comptime Target: type, value: anytype, allocator: std.mem.Allocator) !Target {
+    const Source = @TypeOf(value);
+    if (@typeInfo(Source) == .pointer and @typeInfo(Source).pointer.size == .one) {
+        return convertValue(Target, value.*, allocator);
+    }
+    switch (@typeInfo(Target)) {
+        .bool => return value,
+        .int => return switch (@typeInfo(Source)) {
+            .int => @intCast(value),
+            .float => @intFromFloat(value),
+            else => @compileError("cannot convert " ++ @typeName(Source) ++ " to " ++ @typeName(Target)),
+        },
+        .float => return switch (@typeInfo(Source)) {
+            .float => @floatCast(value),
+            .int => @floatFromInt(value),
+            else => @compileError("cannot convert " ++ @typeName(Source) ++ " to " ++ @typeName(Target)),
+        },
+        .@"enum" => {
+            switch (value) {
+                inline else => |tag| return @field(Target, @tagName(tag)),
+            }
+        },
+        .optional => |info| {
+            if (value) |inner| return try convertValue(info.child, inner, allocator);
+            return null;
+        },
+        .pointer => |info| switch (info.size) {
+            .slice => {
+                if (info.child == u8) return allocator.dupe(u8, value);
+                const out = try allocator.alloc(info.child, value.len);
+                for (out, value) |*slot, element| {
+                    slot.* = try convertValue(info.child, element, allocator);
+                }
+                return out;
+            },
+            .one => {
+                const out = try allocator.create(info.child);
+                out.* = try convertValue(info.child, value, allocator);
+                return out;
+            },
+            else => @compileError("no conversion for " ++ @typeName(Target)),
+        },
+        .@"struct" => |info| {
+            var out: Target = undefined;
+            inline for (info.fields) |field| {
+                @field(out, field.name) = try convertValue(field.type, @field(value, field.name), allocator);
+            }
+            return out;
+        },
+        .@"union" => |info| {
+            switch (value) {
+                inline else => |payload, tag| {
+                    inline for (info.fields) |field| {
+                        if (comptime std.mem.eql(u8, field.name, @tagName(tag))) {
+                            if (field.type == void) return @unionInit(Target, field.name, {});
+                            return @unionInit(Target, field.name, try convertValue(field.type, payload, allocator));
+                        }
+                    }
+                    unreachable;
+                },
+            }
+        },
+        else => @compileError("no conversion for " ++ @typeName(Target)),
+    }
+}


### PR DESCRIPTION
## What

A behavior-parity test suite for compiled app cores: point `NATIVE_SDK_EXTERNAL_CORE_ARCHIVE` at a static archive exporting the core ABI's symbol family and `zig build test-external-core-parity` links it into a test host and drives the full dispatch cycle — init, boot command, scripted dispatches across every payload family, snapshot reads, collect between dispatches, deterministic re-init, and sink-routed trap handling — byte-comparing every observable surface (snapshot bytes, cmd bytes, subscription bytes) against the same fixture running through today's source lane.

- With the env var unset the step skips cleanly; CI and `zig build test` are unaffected.
- A corrupted archive fails the suite at the exact diverging step, so the comparison is falsifiable, not vacuous.
- `tests/sidecar/mirror_value.zig` extracts the mirror-value conversion shared with the existing conformance harness.

## Why

The conformance harness proves the generated bindings are reflection-identical at build time; this suite proves a real compiled core *behaves* identically at run time. Together they make the compiled-core contract testable end to end with one command against any candidate archive.