### PR TITLE
Pair compiled cores with their own sidecars and pin the export attestation order

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3009,14 +3009,23 @@ fn tsCoreE2eArtifact(
     // export the markup fixture's attested symbol set; the binary pairs
     // a FRESH generated mirror with them (the conformance binary's
     // mirror links the stub core's exports — one process cannot carry
-    // both symbol sets).
+    // both symbol sets). A real archive's sidecar carries the compile's
+    // own build_id, which the mirror's boot fence checks against the
+    // identity getters — so the caller supplies the archive's OWN
+    // emitted sidecar through NATIVE_SDK_EXTERNAL_CORE_SIDECAR (the
+    // committed fixture sidecar stays the default for stub-shaped
+    // callers that restate its identity).
     const external_core_parity: ?*std.Build.Step.Compile = if (b.graph.environ_map.get("NATIVE_SDK_EXTERNAL_CORE_ARCHIVE")) |archives| blk: {
         const parity_mod = module(b, target, optimize, "tests/sidecar/external_core_parity_tests.zig");
         parity_mod.link_libc = true;
         parity_mod.addImport("corewire_rt", module(b, target, optimize, "tools/corewire/shim_rt.zig"));
         parity_mod.addImport("core_abi", module(b, target, optimize, "tools/corewire/core_abi.zig"));
         parity_mod.addImport("ts_core", markup_fixture_mod);
-        parity_mod.addImport("shim_core", sidecarShimModule(b, target, optimize, corewire_exe, b.path("tests/sidecar/markup_fixture.contract.json")));
+        const parity_sidecar: std.Build.LazyPath = if (b.graph.environ_map.get("NATIVE_SDK_EXTERNAL_CORE_SIDECAR")) |sidecar|
+            .{ .cwd_relative = b.dupe(sidecar) }
+        else
+            b.path("tests/sidecar/markup_fixture.contract.json");
+        parity_mod.addImport("shim_core", sidecarShimModule(b, target, optimize, corewire_exe, parity_sidecar));
         var inputs = std.mem.tokenizeScalar(u8, archives, std.fs.path.delimiter);
         while (inputs.next()) |input| {
             parity_mod.addObjectFile(.{ .cwd_relative = b.dupe(input) });

--- a/tests/sidecar/markup_fixture.contract.json
+++ b/tests/sidecar/markup_fixture.contract.json
@@ -129,11 +129,11 @@
   },
   "abi": {
     "prefix": "nsc_core_",
-    "exports": ["abi_version", "build_id", "set_panic_sink", "init", "boot_cmd",
-      "dispatch_void", "dispatch_bytes", "dispatch_number", "dispatch_number_bytes",
-      "dispatch_bool", "dispatch_enum", "dispatch_record", "dispatch_text_input",
-      "dispatch_scroll_state", "subscriptions", "frame_reset", "model_snapshot",
-      "helper_call", "collect", "frame_msg", "key_msg", "pinch_msg"],
+    "exports": ["abi_version", "build_id", "set_panic_sink", "init", "collect",
+      "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+      "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+      "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+      "helper_call", "frame_msg", "key_msg", "pinch_msg"],
     "snapshot_format": 1
   },
   "integer_slots": [

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -1418,10 +1418,10 @@ test "a shared authored type spelling like a synthesized name stays a top-level 
         \\  "channels": {"command_msg": false, "frame_msg": false, "key_msg": false, "pinch_msg": false,
         \\    "appearance_msg": null, "chrome_msg": null, "env_msgs": []},
         \\  "abi": {"prefix": "nsc_core_", "exports": ["abi_version", "build_id", "set_panic_sink", "init",
-        \\    "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number", "dispatch_number_bytes",
-        \\    "dispatch_bool", "dispatch_enum", "dispatch_record", "dispatch_text_input",
-        \\    "dispatch_scroll_state", "subscriptions", "frame_reset", "model_snapshot", "helper_call",
-        \\    "collect"], "snapshot_format": 1},
+        \\    "collect", "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+        \\    "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+        \\    "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+        \\    "helper_call"], "snapshot_format": 1},
         \\  "integer_slots": [], "deterministic": true, "async_free": true
         \\}
     ;
@@ -1458,7 +1458,7 @@ test "channel glue speaks the sidecar's message union name" {
     // Rename the union to "Event" and wire the key channel.
     var source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, "\"name\": \"Msg\"", "\"name\": \"Event\"");
     source = try std.mem.replaceOwned(u8, arena, source, "\"key_msg\": false", "\"key_msg\": true");
-    source = try std.mem.replaceOwned(u8, arena, source, "\"collect\"]", "\"collect\", \"key_msg\"]");
+    source = try std.mem.replaceOwned(u8, arena, source, "\"helper_call\"]", "\"helper_call\", \"key_msg\"]");
     const generated = try emitFromJson(arena, source);
     try testing.expect(std.mem.indexOf(u8, generated, "pub const Event = union(enum) {") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "pub fn keyMsg(key: KeyEvent) ?Event {") != null);
@@ -1766,10 +1766,10 @@ test "a chrome arm holding its insets by reference refuses" {
         \\  "channels": {"command_msg": false, "frame_msg": false, "key_msg": false, "pinch_msg": false,
         \\    "appearance_msg": null, "chrome_msg": "chrome_changed", "env_msgs": []},
         \\  "abi": {"prefix": "nsc_core_", "exports": ["abi_version", "build_id", "set_panic_sink", "init",
-        \\    "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number", "dispatch_number_bytes",
-        \\    "dispatch_bool", "dispatch_enum", "dispatch_record", "dispatch_text_input",
-        \\    "dispatch_scroll_state", "subscriptions", "frame_reset", "model_snapshot", "helper_call",
-        \\    "collect"], "snapshot_format": 1},
+        \\    "collect", "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+        \\    "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+        \\    "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+        \\    "helper_call"], "snapshot_format": 1},
         \\  "integer_slots": [], "deterministic": true, "async_free": true
         \\}
     ;

--- a/tools/corewire/extract.zig
+++ b/tools/corewire/extract.zig
@@ -163,11 +163,11 @@ pub fn sidecarJson(comptime core: type, comptime entry: []const u8) []const u8 {
         const has_subscriptions = @hasDecl(core, "subscriptions");
 
         var abi_exports: []const u8 =
-            "\"abi_version\", \"build_id\", \"set_panic_sink\", \"init\", \"boot_cmd\", " ++
-            "\"dispatch_void\", \"dispatch_bytes\", \"dispatch_number\", \"dispatch_number_bytes\", " ++
-            "\"dispatch_bool\", \"dispatch_enum\", \"dispatch_record\", \"dispatch_text_input\", " ++
-            "\"dispatch_scroll_state\", \"subscriptions\", \"frame_reset\", \"model_snapshot\", " ++
-            "\"helper_call\", \"collect\"";
+            "\"abi_version\", \"build_id\", \"set_panic_sink\", \"init\", \"collect\", " ++
+            "\"frame_reset\", \"boot_cmd\", \"dispatch_void\", \"dispatch_bytes\", " ++
+            "\"dispatch_number\", \"dispatch_number_bytes\", \"dispatch_bool\", \"dispatch_enum\", " ++
+            "\"dispatch_record\", \"dispatch_text_input\", \"dispatch_scroll_state\", " ++
+            "\"subscriptions\", \"model_snapshot\", \"helper_call\"";
         if (has_command) abi_exports = abi_exports ++ ", \"command_msg\"";
         if (has_frame) abi_exports = abi_exports ++ ", \"frame_msg\"";
         if (has_key) abi_exports = abi_exports ++ ", \"key_msg\"";

--- a/tools/corewire/sidecar.zig
+++ b/tools/corewire/sidecar.zig
@@ -178,15 +178,20 @@ pub const Sidecar = struct {
 
 // ----------------------------------------------------- ABI vocabulary
 
-/// The unconditional export suffixes of ABI version 1, in the canonical
-/// order the sidecar's `abi.exports` must list them (core_abi.zig binds
-/// the matching extern signatures). The four conditional channel-entry
-/// suffixes follow, present exactly when the matching channel is wired.
+/// The unconditional export suffixes of ABI version 1, in the NORMATIVE
+/// canonical order the sidecar's `abi.exports` must list them: the two
+/// identity getters, then the mode-provided entries (sink registration,
+/// init, collect, result reset), then the program's entry-point map
+/// (core_abi.zig binds the matching extern signatures). The four
+/// conditional channel-entry suffixes follow, present exactly when the
+/// matching channel is wired.
 pub const unconditional_exports = [_][]const u8{
     "abi_version",
     "build_id",
     "set_panic_sink",
     "init",
+    "collect",
+    "frame_reset",
     "boot_cmd",
     "dispatch_void",
     "dispatch_bytes",
@@ -198,10 +203,8 @@ pub const unconditional_exports = [_][]const u8{
     "dispatch_text_input",
     "dispatch_scroll_state",
     "subscriptions",
-    "frame_reset",
     "model_snapshot",
     "helper_call",
-    "collect",
 };
 
 pub const conditional_exports = [_][]const u8{
@@ -1364,15 +1367,17 @@ fn validateChannels(sidecar: Sidecar, diags: *Diagnostics) void {
 
 fn validateAbi(sidecar: Sidecar, diags: *Diagnostics) void {
     // The list must be exactly: every unconditional suffix, then the
-    // wired conditional suffixes, in the profile's canonical order. The
-    // "and the object exports nothing else" half needs the object and
-    // runs at link time.
+    // wired conditional suffixes, in the normative canonical order —
+    // identity getters, mode-provided entries (set_panic_sink, init,
+    // collect, frame_reset), then the entry-point map. The "and the
+    // object exports nothing else" half needs the object and runs at
+    // link time.
     var cursor: usize = 0;
     for (unconditional_exports) |suffix| {
         if (cursor < sidecar.abi.exports.len and std.mem.eql(u8, sidecar.abi.exports[cursor], suffix)) {
             cursor += 1;
         } else {
-            diags.flag(pathOfStatic(diags, "abi.exports[{d}]", .{cursor}), "expected the unconditional export \"{s}\" here — abi.exports lists every unconditional suffix, then the wired channel entries, in the profile's canonical order (V11)", .{suffix});
+            diags.flag(pathOfStatic(diags, "abi.exports[{d}]", .{cursor}), "expected the unconditional export \"{s}\" here — abi.exports lists every unconditional suffix, then the wired channel entries, in the canonical order: identity getters (abi_version, build_id), the mode-provided entries (set_panic_sink, init, collect, frame_reset), then the entry-point map (V11)", .{suffix});
             return;
         }
     }
@@ -1548,11 +1553,11 @@ pub const minimal_valid_json =
     \\  },
     \\  "abi": {
     \\    "prefix": "nsc_core_",
-    \\    "exports": ["abi_version", "build_id", "set_panic_sink", "init", "boot_cmd",
-    \\      "dispatch_void", "dispatch_bytes", "dispatch_number", "dispatch_number_bytes",
-    \\      "dispatch_bool", "dispatch_enum", "dispatch_record", "dispatch_text_input",
-    \\      "dispatch_scroll_state", "subscriptions", "frame_reset", "model_snapshot",
-    \\      "helper_call", "collect"],
+    \\    "exports": ["abi_version", "build_id", "set_panic_sink", "init", "collect",
+    \\      "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+    \\      "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+    \\      "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+    \\      "helper_call"],
     \\    "snapshot_format": 1
     \\  },
     \\  "integer_slots": [
@@ -1878,15 +1883,15 @@ test "V10: an integer_slots entry naming no i64 slot refuses" {
 test "V11: an unknown export suffix refuses" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
-    const source = try replaced(arena_state.allocator(), minimal_valid_json, "\"collect\"]", "\"collect\", \"mystery_entry\"]");
+    const source = try replaced(arena_state.allocator(), minimal_valid_json, "\"helper_call\"]", "\"helper_call\", \"mystery_entry\"]");
     try expectRefusal(source, "abi.exports[19]", "not an export suffix of ABI version 1");
 }
 
 test "V11: a missing unconditional export refuses with the expected suffix" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
-    const source = try replaced(arena_state.allocator(), minimal_valid_json, "\"init\", \"boot_cmd\",", "\"init\",");
-    try expectRefusal(source, "abi.exports[4]", "expected the unconditional export \"boot_cmd\"");
+    const source = try replaced(arena_state.allocator(), minimal_valid_json, "\"init\", \"collect\",", "\"init\",");
+    try expectRefusal(source, "abi.exports[4]", "expected the unconditional export \"collect\"");
 }
 
 test "unknown TypeRef kinds refuse as reader-too-old" {


### PR DESCRIPTION
## What

Two refinements to the compiled-core contract tooling, both surfaced by running the parity suite against a real externally-compiled archive:

1. **`NATIVE_SDK_EXTERNAL_CORE_SIDECAR`** — the behavior-parity suite can now generate its mirror from the caller-supplied archive's own co-emitted contract sidecar instead of the committed fixture sidecar. A real archive's build id can never match the fixture's, so without this the boot-time identity fence correctly refuses the pairing before the suite can run; with it, the fence checks the pairing that actually shipped together.

2. **The export attestation order is now normative.** `abi.exports` previously required "canonical order" without defining it, which let two independent implementations disagree while both believing themselves conformant. The order is now stated and pinned in one place each on the read and write sides: version/identity entries, init, the mode-provided entries, the remaining unconditional suffixes in ABI declaration order, then wired channel entries. The V11 teaching names the expected suffix at the diverging position, and the fixture sidecar and order-asserting tests state the same order.

## Verification

corewire suites, `sidecar-conformance` 23/23, full `zig build test` green, and the parity suite passing end-to-end against an externally compiled archive paired with its own emitted sidecar — including the negative controls (corrupted build id refuses with the pairing teaching; a corrupted message arm diverges at the exact step).