### PR TITLE
Channel entries return the bytes envelope through corewire's ABI seam

### DIFF
--- a/src/runtime/effects_tests.zig
+++ b/src/runtime/effects_tests.zig
@@ -357,7 +357,7 @@ test "a cancel that races the natural exit still reports cancelled and drops lin
     try std.testing.expectEqual(effects_mod.EffectExitReason.cancelled, h.app_state.model.exit_reason.?);
 }
 
-test "queue overflow refuses fed lines loudly and truncates over-long lines" {
+test "queue overflow drops lines with a carried drop count and truncates over-long lines" {
     var h = try Harness.create();
     defer h.destroy();
     const fx = &h.app_state.effects;

--- a/tests/sidecar/conformance_tests.zig
+++ b/tests/sidecar/conformance_tests.zig
@@ -358,6 +358,126 @@ test "ai-chat: facade snapshots byte-match the canonical encoder" {
     try expectSnapshotParity(facade_ai_chat, shim_ai_chat);
 }
 
+// ------------------------------------------- channel envelope axis
+//
+// The channel bytes envelope ([produced u8][tag u8][payload…]): a
+// channel entry's whole result rides one bytes return, the compiled
+// facade packs it, the generated shim unpacks it. Two executable
+// proofs, one per side:
+//
+//   - the facade's packed envelope is [1] ++ the canonical union
+//     encoding of the produced message (the envelope tail IS that
+//     encoding: tag byte = declaration-order arm index, payload = the
+//     arm's canonical bytes) — compared against the host's canonical
+//     encoder over the shim's mirror union;
+//   - the generated shim's channel entries, driven against the stub
+//     core's test-settable envelope, gate on the produced flag and
+//     decode the payload back into the mirror value.
+
+test "markup fixture: facade channel envelopes carry the canonical message bytes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    facade_markup.rt.resetAll();
+    defer facade_markup.rt.resetAll();
+
+    // Nothing produced: exactly the two header bytes.
+    try testing.expectEqualSlices(u8, &.{ 0, 0 }, facade_markup.nsc_core_key_msg(null));
+
+    // Produced arms across the payload families the fixture carries: a
+    // bare arm, an integer-classed number, bytes, a flattened record,
+    // and a flattened record with an enum member.
+    {
+        const envelope = facade_markup.nsc_core_key_msg(facade_markup.nsc_core_msg_add());
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_markup.Msg, .add, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_markup.nsc_core_key_msg(facade_markup.nsc_core_msg_toggle(2));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_markup.Msg, .{ .toggle = 2 }, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_markup.nsc_core_key_msg(facade_markup.nsc_core_msg_banner_set("parity"));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_markup.Msg, .{ .banner_set = "parity" }, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_markup.nsc_core_pinch_msg(facade_markup.nsc_core_msg_zoomed(1.25, 7, true));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_markup.Msg, .{ .zoomed = .{ .factor = 1.25, .windowId = 7, .fromBoard = true } }, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_markup.nsc_core_frame_msg(facade_markup.nsc_core_msg_appearance_changed(.dark, false, true));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_markup.Msg, .{ .appearance_changed = .{ .colorScheme = .dark, .reduceMotion = false, .highContrast = true } }, arena), envelope[1..]);
+    }
+
+    // Every wired entry routes through one packer: identical bytes for
+    // one message, and the unwired command channel stays out of the
+    // facade surface entirely.
+    const msg = facade_markup.nsc_core_msg_toggle(2);
+    try testing.expectEqualSlices(u8, facade_markup.nsc_core_key_msg(msg), facade_markup.nsc_core_frame_msg(msg));
+    try testing.expectEqualSlices(u8, facade_markup.nsc_core_frame_msg(msg), facade_markup.nsc_core_pinch_msg(msg));
+    try testing.expect(!@hasDecl(facade_markup, "nsc_core_command_msg"));
+}
+
+test "soundboard: facade channel envelopes carry the canonical message bytes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    facade_soundboard.rt.resetAll();
+    defer facade_soundboard.rt.resetAll();
+
+    try testing.expectEqualSlices(u8, &.{ 0, 0 }, facade_soundboard.nsc_core_frame_msg(null));
+    {
+        const envelope = facade_soundboard.nsc_core_key_msg(facade_soundboard.nsc_core_msg_toggle_play());
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_soundboard.Msg, .toggle_play, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_soundboard.nsc_core_frame_msg(facade_soundboard.nsc_core_msg_canvas_resized(640));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_soundboard.Msg, .{ .canvas_resized = 640 }, arena), envelope[1..]);
+    }
+}
+
+test "markup fixture: generated channel entries unpack the stub core's envelope" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const saved = stub_core.stub_channel_envelope;
+    defer stub_core.stub_channel_envelope = saved;
+    defer shim_markup.rt.frameReset();
+
+    const key = shim_markup.KeyEvent{ .key = "x", .shift = false, .control = false, .alt = false, .super = false };
+
+    // The stub's default envelope says nothing was produced: the entry
+    // gates to null.
+    try testing.expect(shim_markup.keyMsg(key) == null);
+
+    // A produced bare arm: header only, tag 0 = add.
+    stub_core.stub_channel_envelope = &.{ 1, 0 };
+    try testing.expect(shim_markup.keyMsg(key).? == .add);
+
+    // A produced payload arm: the tail decodes as the arm's canonical
+    // payload (toggle, i64-classed, tag 1).
+    var toggle_envelope: std.ArrayListUnmanaged(u8) = .empty;
+    try toggle_envelope.appendSlice(arena, &.{ 1, 1 });
+    try toggle_envelope.appendSlice(arena, corewire_rt.encodeAlloc(i64, 2, arena));
+    stub_core.stub_channel_envelope = toggle_envelope.items;
+    try testing.expectEqual(@as(i64, 2), shim_markup.keyMsg(key).?.toggle);
+
+    // A flattened record arm through the pinch entry (zoomed, tag 11).
+    var zoom_envelope: std.ArrayListUnmanaged(u8) = .empty;
+    try zoom_envelope.appendSlice(arena, &.{ 1, 11 });
+    try zoom_envelope.appendSlice(arena, corewire_rt.encodeAlloc(@FieldType(shim_markup.Msg, "zoomed"), .{ .factor = 1.25, .windowId = 7, .fromBoard = true }, arena));
+    stub_core.stub_channel_envelope = zoom_envelope.items;
+    const zoomed = shim_markup.pinchMsg(.{ .windowId = 7, .label = "board", .phase = .change, .scale = 0.25, .x = 1, .y = 2 }).?;
+    try testing.expectEqual(@as(f64, 1.25), zoomed.zoomed.factor);
+    try testing.expect(zoomed.zoomed.fromBoard);
+}
+
 /// Reference every public declaration, recursing into declared types
 /// (all of a shim's public type declarations are its own, so the walk
 /// never leaves the generated module).

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -19,6 +19,12 @@
 //! side: a collect between dispatches leaves the observable snapshot
 //! byte-identical.
 //!
+//! The channel entries ride the bytes envelope ([produced u8][tag u8]
+//! [payload…]): the second test drives both lanes' channel functions
+//! over gating and producing events — the archive's entries return the
+//! envelope, the generated mirror unpacks it — and every produced
+//! message dispatches through both lanes as a full cycle.
+//!
 //! The conformance suite (conformance_tests.zig) proves the two lanes'
 //! REFLECTION surfaces identical with no compiled core present; this
 //! suite is the executable half, and only builds when a caller
@@ -158,4 +164,91 @@ test "a compiled core archive matches the transpiler lane byte-for-byte over the
     try testing.expectEqualSlices(u8, try referenceSnapshot(ts_model, arena), rawSnapshot());
     ts_core.rt.frameReset();
     shim_core.rt.frameReset();
+}
+
+/// One dispatch cycle in both lanes over one channel-produced message:
+/// the two lanes' messages must be one value (compared by canonical
+/// bytes in the mirror's layout), and the cycle's command and snapshot
+/// bytes must match — a channel Msg round-trips through the matching
+/// dispatch entry byte-identically.
+fn channelParityCycle(
+    arena: std.mem.Allocator,
+    ts_model: *const ts_core.Model,
+    shim_model: *const shim_core.Model,
+    ts_msg: ts_core.Msg,
+    shim_msg: shim_core.Msg,
+) !struct { ts: *const ts_core.Model, shim: *const shim_core.Model } {
+    const converted = try convertValue(shim_core.Msg, ts_msg, arena);
+    try testing.expectEqualSlices(
+        u8,
+        corewire_rt.encodeAlloc(shim_core.Msg, converted, arena),
+        corewire_rt.encodeAlloc(shim_core.Msg, shim_msg, arena),
+    );
+    const ts_out = ts_core.update(ts_model, ts_msg);
+    const next_ts = ts_core.commitModelRoot(ts_out.model);
+    const shim_out = shim_core.update(shim_model, shim_msg);
+    const next_shim = shim_core.commitModelRoot(shim_out.model);
+    try testing.expectEqualSlices(u8, ts_out.cmd, shim_out.cmd);
+    try testing.expectEqualSlices(u8, try referenceSnapshot(next_ts, arena), rawSnapshot());
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+    return .{ .ts = next_ts, .shim = next_shim };
+}
+
+test "channel entries match the transpiler lane through the bytes envelope" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // A fresh boot in both lanes (init is the deterministic re-init
+    // seam, so this test stands alone).
+    ts_core.rt.resetAll();
+    shim_core.rt.resetAll();
+    var ts_model = ts_core.commitModelRoot(ts_core.initialModel());
+    var shim_model = shim_core.commitModelRoot(shim_core.initialModel());
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+
+    // Gating parity: a chorded key, an unchanged frame, and a begin
+    // pinch produce nothing in either lane (the archive's entry returns
+    // the two-byte nothing-produced envelope).
+    try testing.expect(ts_core.keyMsg(.{ .key = "space", .shift = false, .control = true, .alt = false, .super = false }) == null);
+    try testing.expect(shim_core.keyMsg(.{ .key = "space", .shift = false, .control = true, .alt = false, .super = false }) == null);
+    try testing.expect(ts_core.frameMsg(ts_model, .{ .width = 0, .height = 600, .timestampMs = 16, .intervalMs = 16 }) == null);
+    try testing.expect(shim_core.frameMsg(shim_model, .{ .width = 0, .height = 600, .timestampMs = 16, .intervalMs = 16 }) == null);
+    try testing.expect(ts_core.pinchMsg(.{ .windowId = 7, .label = "ts-markup-canvas", .phase = .begin, .scale = 0, .x = 1, .y = 2 }) == null);
+    try testing.expect(shim_core.pinchMsg(.{ .windowId = 7, .label = "ts-markup-canvas", .phase = .begin, .scale = 0, .x = 1, .y = 2 }) == null);
+
+    // The presented-frame channel produces the resize at boot width,
+    // and the dispatched cycle updates the model so the same frame then
+    // gates (the idle law, proven across the round trip).
+    {
+        const ts_msg = ts_core.frameMsg(ts_model, .{ .width = 800, .height = 600, .timestampMs = 16, .intervalMs = 16 }) orelse return error.TestUnexpectedResult;
+        const shim_msg = shim_core.frameMsg(shim_model, .{ .width = 800, .height = 600, .timestampMs = 16, .intervalMs = 16 }) orelse return error.TestUnexpectedResult;
+        const next = try channelParityCycle(arena, ts_model, shim_model, ts_msg, shim_msg);
+        ts_model = next.ts;
+        shim_model = next.shim;
+        try testing.expect(ts_core.frameMsg(ts_model, .{ .width = 800, .height = 600, .timestampMs = 32, .intervalMs = 16 }) == null);
+        try testing.expect(shim_core.frameMsg(shim_model, .{ .width = 800, .height = 600, .timestampMs = 32, .intervalMs = 16 }) == null);
+    }
+
+    // The key-fallback channel: a bare arm rides the header-only
+    // envelope.
+    {
+        const ts_msg = ts_core.keyMsg(.{ .key = "space", .shift = false, .control = false, .alt = false, .super = false }) orelse return error.TestUnexpectedResult;
+        const shim_msg = shim_core.keyMsg(.{ .key = "space", .shift = false, .control = false, .alt = false, .super = false }) orelse return error.TestUnexpectedResult;
+        const next = try channelParityCycle(arena, ts_model, shim_model, ts_msg, shim_msg);
+        ts_model = next.ts;
+        shim_model = next.shim;
+    }
+
+    // The pinch channel: a flattened record payload (factor, source
+    // identity) crosses the envelope and dispatches.
+    {
+        const ts_msg = ts_core.pinchMsg(.{ .windowId = 7, .label = "ts-markup-canvas", .phase = .change, .scale = 0.25, .x = 1, .y = 2 }) orelse return error.TestUnexpectedResult;
+        const shim_msg = shim_core.pinchMsg(.{ .windowId = 7, .label = "ts-markup-canvas", .phase = .change, .scale = 0.25, .x = 1, .y = 2 }) orelse return error.TestUnexpectedResult;
+        const next = try channelParityCycle(arena, ts_model, shim_model, ts_msg, shim_msg);
+        ts_model = next.ts;
+        shim_model = next.shim;
+    }
 }

--- a/tests/sidecar/stub_core.zig
+++ b/tests/sidecar/stub_core.zig
@@ -4,11 +4,13 @@
 //! shims (dispatch stubs, snapshot decoder, channel forwarders, helper
 //! methods) and still link.
 //!
-//! No compiled core exists yet — the ABI is a draft pending
-//! ratification — so the runtime dispatch paths are compile- and
-//! link-checked here, never executed: every entry that would need a
-//! real core traps. The identity getters and the empty-buffer entries
-//! behave, so the boot fence and lifecycle ordering stay testable.
+//! No compiled core exists in this repo, so the dispatch paths that
+//! would need one are compile- and link-checked here, never executed:
+//! every such entry traps. The identity getters, the empty-buffer
+//! entries, and the channel entries behave — a channel's whole result
+//! is one bytes envelope, so this stub can hand back real envelopes
+//! (nothing-produced by default, test-settable otherwise) and the
+//! generated shims' unpack paths execute for real.
 
 const std = @import("std");
 
@@ -151,40 +153,50 @@ export fn nsc_core_helper_call(helper: u32, args: [*]const u8, args_len: usize, 
 
 export fn nsc_core_collect() void {}
 
-const CoreMsg = extern struct {
-    tag: u8,
-    payload: [*]const u8,
-    payload_len: usize,
-};
+// Channel entries return the bytes envelope ([produced u8][tag u8]
+// [payload…]) on the ordinary out-pointer pair. Unlike the dispatch
+// entries these are EXECUTABLE without a core: the empty envelope is a
+// complete, honest "nothing produced", so the generated shims' unpack
+// paths run for real against this stub.
 
-export fn nsc_core_command_msg(name: [*]const u8, name_len: usize, out: *CoreMsg) u8 {
-    _ = name;
-    _ = name_len;
-    _ = out;
-    return 0;
+/// The two-byte nothing-produced envelope.
+const no_msg_envelope = [2]u8{ 0, 0 };
+
+/// The envelope every channel entry hands back. A test may point it at
+/// a produced envelope (or a malformed one) to drive the generated
+/// shim's unpack path without a compiled core.
+pub var stub_channel_envelope: []const u8 = &no_msg_envelope;
+
+fn channelEnvelopeOut(out: *[*]const u8, out_len: *usize) void {
+    out.* = stub_channel_envelope.ptr;
+    out_len.* = stub_channel_envelope.len;
 }
 
-export fn nsc_core_frame_msg(width: f64, height: f64, timestamp_ms: f64, interval_ms: f64, out: *CoreMsg) u8 {
+export fn nsc_core_command_msg(name: [*]const u8, name_len: usize, out: *[*]const u8, out_len: *usize) void {
+    _ = name;
+    _ = name_len;
+    channelEnvelopeOut(out, out_len);
+}
+
+export fn nsc_core_frame_msg(width: f64, height: f64, timestamp_ms: f64, interval_ms: f64, out: *[*]const u8, out_len: *usize) void {
     _ = width;
     _ = height;
     _ = timestamp_ms;
     _ = interval_ms;
-    _ = out;
-    return 0;
+    channelEnvelopeOut(out, out_len);
 }
 
-export fn nsc_core_key_msg(key: [*]const u8, key_len: usize, shift: u8, control: u8, alt: u8, super_mod: u8, out: *CoreMsg) u8 {
+export fn nsc_core_key_msg(key: [*]const u8, key_len: usize, shift: u8, control: u8, alt: u8, super_mod: u8, out: *[*]const u8, out_len: *usize) void {
     _ = key;
     _ = key_len;
     _ = shift;
     _ = control;
     _ = alt;
     _ = super_mod;
-    _ = out;
-    return 0;
+    channelEnvelopeOut(out, out_len);
 }
 
-export fn nsc_core_pinch_msg(window_id: f64, label: [*]const u8, label_len: usize, phase: u32, scale: f64, x: f64, y: f64, out: *CoreMsg) u8 {
+export fn nsc_core_pinch_msg(window_id: f64, label: [*]const u8, label_len: usize, phase: u32, scale: f64, x: f64, y: f64, out: *[*]const u8, out_len: *usize) void {
     _ = window_id;
     _ = label;
     _ = label_len;
@@ -192,6 +204,5 @@ export fn nsc_core_pinch_msg(window_id: f64, label: [*]const u8, label_len: usiz
     _ = scale;
     _ = x;
     _ = y;
-    _ = out;
-    return 0;
+    channelEnvelopeOut(out, out_len);
 }

--- a/tools/corewire/core_abi.zig
+++ b/tools/corewire/core_abi.zig
@@ -64,15 +64,21 @@ pub const PanicSinkFn = *const fn (
     address: u64,
 ) callconv(.c) void;
 
-/// An encoded message a conditional channel entry hands back: the arm's
-/// declaration-order wire tag plus the arm payload in the encoding of
-/// its descriptor class. Payload bytes are valid until the next core
-/// entry call of any kind.
-pub const CoreMsg = extern struct {
-    tag: u8,
-    payload: [*]const u8,
-    payload_len: usize,
-};
+// A conditional channel entry hands its whole result back as ONE bytes
+// buffer on the ordinary out-pointer slot — the channel bytes envelope:
+//
+//   [produced u8][tag u8][payload…]
+//
+// Byte 0 is 0 (nothing produced; the envelope is exactly two bytes) or
+// 1. Byte 1 is the produced arm's declaration-order wire tag in the
+// sidecar's msg section (meaningless when nothing was produced; the
+// producer emits 0). The remainder is the arm's payload in the
+// canonical value encoding of its mirror payload type (shim_rt.zig; an
+// i64 arm rides as 8-byte two's-complement LE) — so the envelope's tail
+// is byte-identical to the canonical union encoding of the produced
+// message. Envelope bytes are valid until the next core entry call of
+// any kind. One bytes return keeps the one-return-slot rule intact: the
+// multi-value result needs no marshalling shape of its own.
 
 /// The full symbol set of ABI version 1, bound under `prefix`. The
 /// conditional channel entries are declared unconditionally here —
@@ -152,9 +158,12 @@ pub fn Bindings(comptime prefix: []const u8) type {
         pub const collect = Symbol(fn () callconv(.c) void, "collect");
 
         // -------------------------- conditional channel entries
-        pub const command_msg = Symbol(fn (name: [*]const u8, name_len: usize, out: *CoreMsg) callconv(.c) u8, "command_msg");
-        pub const frame_msg = Symbol(fn (width: f64, height: f64, timestamp_ms: f64, interval_ms: f64, out: *CoreMsg) callconv(.c) u8, "frame_msg");
-        pub const key_msg = Symbol(fn (key: [*]const u8, key_len: usize, shift: u8, control: u8, alt: u8, super_mod: u8, out: *CoreMsg) callconv(.c) u8, "key_msg");
-        pub const pinch_msg = Symbol(fn (window_id: f64, label: [*]const u8, label_len: usize, phase: u32, scale: f64, x: f64, y: f64, out: *CoreMsg) callconv(.c) u8, "pinch_msg");
+        //
+        // Each returns the channel bytes envelope (see the module doc
+        // above) through the ordinary out-pointer pair.
+        pub const command_msg = Symbol(fn (name: [*]const u8, name_len: usize, out: *[*]const u8, out_len: *usize) callconv(.c) void, "command_msg");
+        pub const frame_msg = Symbol(fn (width: f64, height: f64, timestamp_ms: f64, interval_ms: f64, out: *[*]const u8, out_len: *usize) callconv(.c) void, "frame_msg");
+        pub const key_msg = Symbol(fn (key: [*]const u8, key_len: usize, shift: u8, control: u8, alt: u8, super_mod: u8, out: *[*]const u8, out_len: *usize) callconv(.c) void, "key_msg");
+        pub const pinch_msg = Symbol(fn (window_id: f64, label: [*]const u8, label_len: usize, phase: u32, scale: f64, x: f64, y: f64, out: *[*]const u8, out_len: *usize) callconv(.c) void, "pinch_msg");
     };
 }

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -176,7 +176,7 @@ const Emitter = struct {
         if (self.sidecar.model_helpers.len > 0) try reserved.append(self.arena, "callHelper");
         const chan = self.sidecar.channels;
         if (chan.command_msg or chan.frame_msg or chan.key_msg or chan.pinch_msg) {
-            try reserved.append(self.arena, "msgFromWire");
+            try reserved.appendSlice(self.arena, &.{ "msgFromEnvelope", "envelope", "header" });
         }
         if (self.sidecar.init_returns_cmd) try reserved.append(self.arena, "InitResult");
         if (self.sidecar.update_returns_cmd) try reserved.append(self.arena, "UpdateResult");
@@ -986,9 +986,10 @@ const Emitter = struct {
                 \\/// Menus, shortcuts, and chrome tabs dispatch through the core's
                 \\/// exported command mapper.
                 \\pub fn commandMsg(name: []const u8) ?{f} {{
-                \\    var out: core_abi.CoreMsg = undefined;
-                \\    if (abi.command_msg(name.ptr, name.len, &out) == 0) return null;
-                \\    return msgFromWire(out.tag, out.payload[0..out.payload_len]);
+                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_len: usize = 0;
+                \\    abi.command_msg(name.ptr, name.len, &out_ptr, &out_len);
+                \\    return msgFromEnvelope(out_ptr[0..out_len]);
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1008,9 +1009,10 @@ const Emitter = struct {
                 \\
                 \\pub fn frameMsg(model: *const {f}, frame: FrameEvent) ?{f} {{
                 \\    _ = model;
-                \\    var out: core_abi.CoreMsg = undefined;
-                \\    if (abi.frame_msg(frame.width, frame.height, frame.timestampMs, frame.intervalMs, &out) == 0) return null;
-                \\    return msgFromWire(out.tag, out.payload[0..out.payload_len]);
+                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_len: usize = 0;
+                \\    abi.frame_msg(frame.width, frame.height, frame.timestampMs, frame.intervalMs, &out_ptr, &out_len);
+                \\    return msgFromEnvelope(out_ptr[0..out_len]);
                 \\}}
                 \\
             , .{ ident(self.sidecar.model), ident(self.sidecar.msg.name) });
@@ -1029,9 +1031,10 @@ const Emitter = struct {
                 \\}};
                 \\
                 \\pub fn keyMsg(key: KeyEvent) ?{f} {{
-                \\    var out: core_abi.CoreMsg = undefined;
-                \\    if (abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out) == 0) return null;
-                \\    return msgFromWire(out.tag, out.payload[0..out.payload_len]);
+                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_len: usize = 0;
+                \\    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);
+                \\    return msgFromEnvelope(out_ptr[0..out_len]);
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1053,9 +1056,10 @@ const Emitter = struct {
                 \\}};
                 \\
                 \\pub fn pinchMsg(pinch: PinchEvent) ?{f} {{
-                \\    var out: core_abi.CoreMsg = undefined;
-                \\    if (abi.pinch_msg(pinch.windowId, pinch.label.ptr, pinch.label.len, @intCast(@intFromEnum(pinch.phase)), pinch.scale, pinch.x, pinch.y, &out) == 0) return null;
-                \\    return msgFromWire(out.tag, out.payload[0..out.payload_len]);
+                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_len: usize = 0;
+                \\    abi.pinch_msg(pinch.windowId, pinch.label.ptr, pinch.label.len, @intCast(@intFromEnum(pinch.phase)), pinch.scale, pinch.x, pinch.y, &out_ptr, &out_len);
+                \\    return msgFromEnvelope(out_ptr[0..out_len]);
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1086,22 +1090,27 @@ const Emitter = struct {
         if (any_fn_channel) {
             try self.print(
                 \\
-                \\/// Decode a channel entry's encoded message: the wire tag picks
-                \\/// the arm, the payload rides the canonical value encoding of
-                \\/// that arm's mirror payload type.
-                \\fn msgFromWire(tag: u8, payload: []const u8) {f} {{
-                \\    switch (tag) {{
+                \\/// Unpack a channel entry's bytes envelope — [produced u8][tag u8]
+                \\/// [payload…]: the header says whether a message was produced, the
+                \\/// wire tag picks the arm, and the payload rides the canonical
+                \\/// value encoding of that arm's mirror payload type. Malformed
+                \\/// framing refuses loudly in shim_rt.channelEnvelope; a tag past
+                \\/// the declared arms refuses here.
+                \\fn msgFromEnvelope(envelope: []const u8) ?{f} {{
+                \\    const header = shim_rt.channelEnvelope(envelope);
+                \\    if (!header.produced) return null;
+                \\    switch (header.tag) {{
                 \\
             , .{ident(self.sidecar.msg.name)});
             for (self.sidecar.msg.arms, 0..) |arm, tag| {
                 if (arm.payload == .void) {
-                    try self.print("        {d} => {{\n            shim_rt.assertVoidPayload(payload);\n            return .{f};\n        }},\n", .{ tag, ident(arm.name) });
+                    try self.print("        {d} => {{\n            shim_rt.assertVoidPayload(header.payload);\n            return .{f};\n        }},\n", .{ tag, ident(arm.name) });
                 } else {
-                    try self.print("        {d} => return .{{ .{f} = shim_rt.decodeExact(@FieldType({f}, \"{f}\"), payload, shim_rt.frameAllocator()) }},\n", .{ tag, ident(arm.name), ident(self.sidecar.msg.name), std.zig.fmtString(arm.name) });
+                    try self.print("        {d} => return .{{ .{f} = shim_rt.decodeExact(@FieldType({f}, \"{f}\"), header.payload, shim_rt.frameAllocator()) }},\n", .{ tag, ident(arm.name), ident(self.sidecar.msg.name), std.zig.fmtString(arm.name) });
                 }
             }
             try self.raw(
-                \\        else => @panic("the compiled core handed back a message tag past the declared arms — the core and its contract sidecar disagree; rebuild the app so both come from one compile"),
+                \\        else => @panic("the compiled core's channel envelope carries a message tag past the declared arms — the core and its contract sidecar disagree; rebuild the app so both come from one compile"),
                 \\    }
                 \\}
                 \\
@@ -1480,8 +1489,15 @@ test "channel glue speaks the sidecar's message union name" {
     const generated = try emitFromJson(arena, source);
     try testing.expect(std.mem.indexOf(u8, generated, "pub const Event = union(enum) {") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "pub fn keyMsg(key: KeyEvent) ?Event {") != null);
-    try testing.expect(std.mem.indexOf(u8, generated, "fn msgFromWire(tag: u8, payload: []const u8) Event {") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "fn msgFromEnvelope(envelope: []const u8) ?Event {") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "@FieldType(Event, \"label_set\")") != null);
+    // The channel entry returns the bytes envelope on the ordinary
+    // out-pointer pair; the wrapper hands the whole buffer to the
+    // unpacker (no status return, no out-record).
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "return msgFromEnvelope(out_ptr[0..out_len]);") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "shim_rt.channelEnvelope(envelope)") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "if (!header.produced) return null;") != null);
     const source_z = try arena.dupeZ(u8, generated);
     const tree = try std.zig.Ast.parse(arena, source_z, .zig);
     try testing.expectEqual(@as(usize, 0), tree.errors.len);

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -989,7 +989,7 @@ const Emitter = struct {
                 \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.command_msg(name.ptr, name.len, &out_ptr, &out_len);
-                \\    return msgFromEnvelope(out_ptr[0..out_len]);
+                \\    return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1012,7 +1012,7 @@ const Emitter = struct {
                 \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.frame_msg(frame.width, frame.height, frame.timestampMs, frame.intervalMs, &out_ptr, &out_len);
-                \\    return msgFromEnvelope(out_ptr[0..out_len]);
+                \\    return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));
                 \\}}
                 \\
             , .{ ident(self.sidecar.model), ident(self.sidecar.msg.name) });
@@ -1034,7 +1034,7 @@ const Emitter = struct {
                 \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);
-                \\    return msgFromEnvelope(out_ptr[0..out_len]);
+                \\    return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1059,7 +1059,7 @@ const Emitter = struct {
                 \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.pinch_msg(pinch.windowId, pinch.label.ptr, pinch.label.len, @intCast(@intFromEnum(pinch.phase)), pinch.scale, pinch.x, pinch.y, &out_ptr, &out_len);
-                \\    return msgFromEnvelope(out_ptr[0..out_len]);
+                \\    return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));
                 \\}}
                 \\
             , .{ident(self.sidecar.msg.name)});
@@ -1497,7 +1497,7 @@ test "channel glue speaks the sidecar's message union name" {
     // DEFINED before the call: an entry that returns without writing
     // yields the zero-length envelope, refused loudly downstream.
     try testing.expect(std.mem.indexOf(u8, generated, "var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;\n    var out_len: usize = 0;\n    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);") != null);
-    try testing.expect(std.mem.indexOf(u8, generated, "return msgFromEnvelope(out_ptr[0..out_len]);") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "shim_rt.channelEnvelope(envelope)") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "if (!header.produced) return null;") != null);
     const source_z = try arena.dupeZ(u8, generated);

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -1094,8 +1094,8 @@ const Emitter = struct {
                 \\/// [payload…]: the header says whether a message was produced, the
                 \\/// wire tag picks the arm, and the payload rides the canonical
                 \\/// value encoding of that arm's mirror payload type. Malformed
-                \\/// framing refuses loudly in shim_rt.channelEnvelope; a tag past
-                \\/// the declared arms refuses here.
+                \\/// framing panics with a teaching in shim_rt.channelEnvelope; a
+                \\/// tag past the declared arms panics here.
                 \\fn msgFromEnvelope(envelope: []const u8) ?{f} {{
                 \\    const header = shim_rt.channelEnvelope(envelope);
                 \\    if (!header.produced) return null;
@@ -1495,7 +1495,8 @@ test "channel glue speaks the sidecar's message union name" {
     // out-pointer pair; the wrapper hands the whole buffer to the
     // unpacker (no status return, no out-record). The out state is
     // DEFINED before the call: an entry that returns without writing
-    // yields the zero-length envelope, refused loudly downstream.
+    // yields the zero-length envelope, which the envelope reader
+    // refuses as short.
     try testing.expect(std.mem.indexOf(u8, generated, "var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;\n    var out_len: usize = 0;\n    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "return msgFromEnvelope(shim_rt.channelEnvelopeBytes(out_ptr, out_len));") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "shim_rt.channelEnvelope(envelope)") != null);

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -986,7 +986,7 @@ const Emitter = struct {
                 \\/// Menus, shortcuts, and chrome tabs dispatch through the core's
                 \\/// exported command mapper.
                 \\pub fn commandMsg(name: []const u8) ?{f} {{
-                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.command_msg(name.ptr, name.len, &out_ptr, &out_len);
                 \\    return msgFromEnvelope(out_ptr[0..out_len]);
@@ -1009,7 +1009,7 @@ const Emitter = struct {
                 \\
                 \\pub fn frameMsg(model: *const {f}, frame: FrameEvent) ?{f} {{
                 \\    _ = model;
-                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.frame_msg(frame.width, frame.height, frame.timestampMs, frame.intervalMs, &out_ptr, &out_len);
                 \\    return msgFromEnvelope(out_ptr[0..out_len]);
@@ -1031,7 +1031,7 @@ const Emitter = struct {
                 \\}};
                 \\
                 \\pub fn keyMsg(key: KeyEvent) ?{f} {{
-                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);
                 \\    return msgFromEnvelope(out_ptr[0..out_len]);
@@ -1056,7 +1056,7 @@ const Emitter = struct {
                 \\}};
                 \\
                 \\pub fn pinchMsg(pinch: PinchEvent) ?{f} {{
-                \\    var out_ptr: [*]const u8 = undefined;
+                \\    var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;
                 \\    var out_len: usize = 0;
                 \\    abi.pinch_msg(pinch.windowId, pinch.label.ptr, pinch.label.len, @intCast(@intFromEnum(pinch.phase)), pinch.scale, pinch.x, pinch.y, &out_ptr, &out_len);
                 \\    return msgFromEnvelope(out_ptr[0..out_len]);
@@ -1493,8 +1493,10 @@ test "channel glue speaks the sidecar's message union name" {
     try testing.expect(std.mem.indexOf(u8, generated, "@FieldType(Event, \"label_set\")") != null);
     // The channel entry returns the bytes envelope on the ordinary
     // out-pointer pair; the wrapper hands the whole buffer to the
-    // unpacker (no status return, no out-record).
-    try testing.expect(std.mem.indexOf(u8, generated, "abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);") != null);
+    // unpacker (no status return, no out-record). The out state is
+    // DEFINED before the call: an entry that returns without writing
+    // yields the zero-length envelope, refused loudly downstream.
+    try testing.expect(std.mem.indexOf(u8, generated, "var out_ptr: [*]const u8 = &shim_rt.channel_out_guard;\n    var out_len: usize = 0;\n    abi.key_msg(key.key.ptr, key.key.len, @intFromBool(key.shift), @intFromBool(key.control), @intFromBool(key.alt), @intFromBool(key.super), &out_ptr, &out_len);") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "return msgFromEnvelope(out_ptr[0..out_len]);") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "shim_rt.channelEnvelope(envelope)") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "if (!header.produced) return null;") != null);

--- a/tools/corewire/emit_facade.zig
+++ b/tools/corewire/emit_facade.zig
@@ -28,6 +28,11 @@
 //!   extractor (exact for every finite double, the infinities, and the
 //!   canonical quiet NaN), exported as `nsc_core_model_snapshot` plus
 //!   the two scalar probes the parity suite drives;
+//! - the channel bytes envelope, one export per wired channel entry
+//!   (`nsc_core_<channel>`): the entry's whole multi-value result rides
+//!   ONE bytes return — [produced u8][tag u8][payload…] — packed here
+//!   from a produced message or null, so the compile mode's channel
+//!   exports run the author's channel function and forward the result;
 //! - the identity constants, the sidecar's unbound-list declarations
 //!   (authors declare nothing; the generator carries them), and
 //!   deterministic zero/sample model builders so a compiled facade can
@@ -126,6 +131,7 @@ const FacadeEmitter = struct {
         try self.msgConstructors();
         try self.sampleBuilders();
         try self.encoders();
+        try self.channelEntries();
     }
 
     // ------------------------------------------------------- fencing
@@ -1021,6 +1027,104 @@ const FacadeEmitter = struct {
         , .{ self.sidecar.abi.snapshot_format, self.sidecar.model });
     }
 
+    // ------------------------------------------------ channel entries
+
+    /// The channel bytes envelope: a channel entry's whole result rides
+    /// one bytes return — [produced u8][tag u8][payload…] — so the
+    /// multi-value result (produced?, which arm, payload bytes) needs no
+    /// marshalling shape of its own. Byte 0 is 0 (nothing produced; the
+    /// envelope is exactly two bytes) or 1; byte 1 is the produced arm's
+    /// declaration-order wire tag (meaningless when nothing was
+    /// produced; this packer emits 0); the payload is the arm's
+    /// canonical value encoding — the envelope's tail is byte-identical
+    /// to the canonical union encoding of the produced message. The
+    /// compile mode's channel exports run the author's channel function
+    /// and hand its `Msg | null` result to the wired entry here.
+    fn channelEntries(self: *FacadeEmitter) Error!void {
+        const chan = self.sidecar.channels;
+        const entries = [_]struct { wired: bool, suffix: []const u8 }{
+            .{ .wired = chan.command_msg, .suffix = "command_msg" },
+            .{ .wired = chan.frame_msg, .suffix = "frame_msg" },
+            .{ .wired = chan.key_msg, .suffix = "key_msg" },
+            .{ .wired = chan.pinch_msg, .suffix = "pinch_msg" },
+        };
+        var any_wired = false;
+        for (entries) |entry| {
+            if (entry.wired) any_wired = true;
+        }
+        if (!any_wired) return;
+
+        try self.raw(
+            \\
+            \\// ----------------------------------------------------------------
+            \\// The channel bytes envelope: a channel entry's whole result rides
+            \\// one bytes return — [produced u8][tag u8][payload...]. Byte 0 is 0
+            \\// (nothing produced; the envelope is exactly two bytes) or 1; byte 1
+            \\// is the produced arm's declaration-order wire tag (0 when nothing
+            \\// was produced); the payload is the arm's canonical value encoding.
+            \\
+            \\function nscfMsgEnvelope(value: Msg): Uint8Array {
+            \\
+        );
+        for (self.sidecar.msg.arms, 0..) |arm, tag| {
+            try self.print("  if (value.kind === \"{s}\") {{\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte({d})];\n", .{ try tsString(self.arena, arm.name), tag });
+            try self.msgPayloadEncodeStatements(arm);
+            try self.raw("    return nscfCat(parts);\n  }\n");
+        }
+        try self.raw("  throw { kind: \"nscf_contract\", teaching: asciiBytes(\"a channel produced a message outside the declared union — the value and the contract disagree\") } as NscfContractError;\n}\n");
+
+        for (entries) |entry| {
+            if (!entry.wired) continue;
+            try self.print(
+                \\
+                \\export function nsc_core_{s}(msg: Msg | null): Uint8Array {{
+                \\  const nscfMsg = msg;
+                \\  if (nscfMsg === null) {{
+                \\    const parts: Uint8Array[] = [nscfByte(0), nscfByte(0)];
+                \\    return nscfCat(parts);
+                \\  }} else {{
+                \\    return nscfMsgEnvelope(nscfMsg);
+                \\  }}
+                \\}}
+                \\
+            , .{entry.suffix});
+        }
+    }
+
+    /// Statements appending one message arm's canonical payload bytes to
+    /// `parts`, off the narrowed arm value — the payload-descriptor twin
+    /// of the union encoder's per-arm body. The bytes must decode
+    /// against the arm's MIRROR payload type, so field order and number
+    /// classes follow the sidecar exactly.
+    fn msgPayloadEncodeStatements(self: *FacadeEmitter, arm: sidecar_mod.MsgArm) Error!void {
+        switch (arm.payload) {
+            .void => {},
+            .bytes => try self.fieldEncodeStatements(.bytes, "value.value", 2, 0),
+            .number => |class| try self.fieldEncodeStatements(numberRef(class), "value.value", 2, 0),
+            .number_bytes => |desc| {
+                // The mirror declares the number field first (the
+                // emitted convention of every producer of this shape —
+                // SCHEMA-GAPS.md), so the number's bytes lead.
+                try self.fieldEncodeStatements(numberRef(desc.number_class), try tsAccess(self.arena, "value", desc.number_field), 2, 0);
+                try self.fieldEncodeStatements(.bytes, try tsAccess(self.arena, "value", desc.bytes_field), 2, 8);
+            },
+            .record => |name| {
+                if (self.synthesizedRecordOf(recordPayloadRef(arm.payload), self.sidecar.msg.name, arm.name)) |record| {
+                    // Flattened beside `kind`: encode the record's
+                    // fields off the narrowed arm in declaration order.
+                    for (record.fields, 0..) |field, field_index| {
+                        try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 2, field_index * 8);
+                    }
+                } else {
+                    try self.fieldEncodeStatements(.{ .value = name }, "value.value", 2, 0);
+                }
+            },
+            .union_ref => |name| try self.fieldEncodeStatements(.{ .union_ref = name }, "value.value", 2, 0),
+            .enum_ref => |name| try self.fieldEncodeStatements(.{ .enum_ref = name }, "value.value", 2, 0),
+            .scalar => |ref| try self.fieldEncodeStatements(ref, "value.value", 2, 0),
+        }
+    }
+
     fn encoderNameFor(self: *FacadeEmitter, name: []const u8) Error![]const u8 {
         return std.fmt.allocPrint(self.arena, "nscfEncode{s}", .{name});
     }
@@ -1087,6 +1191,14 @@ fn recordPayloadRef(payload: sidecar_mod.Payload) TypeRef {
     return switch (payload) {
         .record => |name| .{ .value = name },
         else => unreachable,
+    };
+}
+
+/// A number class as the TypeRef the field-encoder authority takes.
+fn numberRef(class: sidecar_mod.NumberClass) TypeRef {
+    return switch (class) {
+        .f64 => .f64,
+        .i64 => .i64,
     };
 }
 
@@ -1297,6 +1409,62 @@ test "facade emission is deterministic and carries the projection surface" {
     try testing.expect(std.mem.indexOf(u8, first, "function nscfF64(value: number): Uint8Array {") != null);
     // The unbound list rides the facade (the author declares nothing).
     try testing.expect(std.mem.indexOf(u8, first, "export const viewUnbound = [\n  \"label_set\",\n] as const;") != null);
+}
+
+test "wired channels emit envelope-packing exports" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, "\"key_msg\": false", "\"key_msg\": true");
+    source = try std.mem.replaceOwned(u8, arena, source, "\"helper_call\"]", "\"helper_call\", \"key_msg\"]");
+    const generated = try facadeFromJson(arena, source);
+    // One export per wired channel, none for the unwired rest.
+    try testing.expect(std.mem.indexOf(u8, generated, "export function nsc_core_key_msg(msg: Msg | null): Uint8Array {") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "nsc_core_frame_msg") == null);
+    try testing.expect(std.mem.indexOf(u8, generated, "nsc_core_command_msg") == null);
+    try testing.expect(std.mem.indexOf(u8, generated, "nsc_core_pinch_msg") == null);
+    // The nothing-produced envelope is exactly [0, 0]; a produced arm
+    // leads with [1, tag] and appends the arm's canonical payload.
+    try testing.expect(std.mem.indexOf(u8, generated, "const parts: Uint8Array[] = [nscfByte(0), nscfByte(0)];") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "function nscfMsgEnvelope(value: Msg): Uint8Array {") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "if (value.kind === \"bump\") {\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte(0)];\n    return nscfCat(parts);\n  }") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "if (value.kind === \"label_set\") {\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte(1)];\n    parts[parts.length] = nscfBytes(value.value);\n    return nscfCat(parts);\n  }") != null);
+}
+
+test "unwired channels leave the envelope surface out of the facade" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const generated = try facadeFromJson(arena, sidecar_mod.minimal_valid_json);
+    try testing.expect(std.mem.indexOf(u8, generated, "nscfMsgEnvelope") == null);
+    try testing.expect(std.mem.indexOf(u8, generated, "nsc_core_key_msg") == null);
+}
+
+test "envelope payloads follow the sidecar's classes and flattened orders" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // An i64-classed number arm and a synthesized flattened record arm,
+    // with the frame channel wired.
+    var source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, "\"structs\": [", "\"structs\": [\n      {\"name\": \"Msg_loaded\", \"fields\": [{\"name\": \"status\", \"type\": {\"kind\": \"f64\"}}, {\"name\": \"ok\", \"type\": {\"kind\": \"bool\"}}]},");
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"number\", \"class\": \"i64\"}}, {\"name\": \"loaded\", \"payload\": {\"kind\": \"record\", \"name\": \"Msg_loaded\"}}",
+    );
+    source = try std.mem.replaceOwned(u8, arena, source, "\"frame_msg\": false", "\"frame_msg\": true");
+    source = try std.mem.replaceOwned(u8, arena, source, "\"helper_call\"]", "\"helper_call\", \"frame_msg\"]");
+    source = try std.mem.replaceOwned(u8, arena, source, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Msg.bump\", \"class\": \"i64\"}");
+    const generated = try facadeFromJson(arena, source);
+    // The i64 class picks the two's-complement encoder, never the f64
+    // bit pattern.
+    try testing.expect(std.mem.indexOf(u8, generated, "if (value.kind === \"bump\") {\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte(0)];\n    parts[parts.length] = nscfI64(value.value);\n    return nscfCat(parts);\n  }") != null);
+    // The flattened record encodes its fields off the narrowed arm in
+    // declaration order, exactly as the arm's mirror payload decodes.
+    try testing.expect(std.mem.indexOf(u8, generated, "if (value.kind === \"loaded\") {\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte(1)];\n    parts[parts.length] = nscfF64(value.status);\n    parts[parts.length] = nscfByte(value.ok ? 1 : 0);\n    return nscfCat(parts);\n  }") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "export function nsc_core_frame_msg(msg: Msg | null): Uint8Array {") != null);
 }
 
 test "composite slice elements parenthesize in the projection" {

--- a/tools/corewire/shim_rt.zig
+++ b/tools/corewire/shim_rt.zig
@@ -366,11 +366,12 @@ pub fn assertVoidPayload(payload: []const u8) void {
 pub const channel_out_guard = [1]u8{0};
 
 /// Assemble a channel entry's returned envelope from the out pair,
-/// closing every non-writing shape loudly BEFORE a slice forms: an
-/// entry that wrote neither slot yields the guard at length zero
-/// (refused downstream as a short envelope), and an entry that wrote a
-/// length without a pointer — the guard address with a nonzero length —
-/// refuses here, never an out-of-bounds read of the guard.
+/// closing every non-writing shape BEFORE a slice forms: an entry that
+/// wrote neither slot yields the guard at length zero (refused
+/// downstream as a short envelope), and an entry that wrote a length
+/// without a pointer — the guard address with a nonzero length —
+/// panics here with a teaching, never an out-of-bounds read of the
+/// guard.
 pub fn channelEnvelopeBytes(ptr: [*]const u8, len: usize) []const u8 {
     if (len != 0 and ptr == @as([*]const u8, @ptrCast(&channel_out_guard))) {
         @panic("a channel entry wrote an envelope length without an envelope pointer — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");
@@ -390,11 +391,11 @@ pub const ChannelEnvelope = struct {
 
 /// Split a channel entry's bytes envelope — [produced u8][tag u8]
 /// [payload…]. A malformed envelope is a contract violation, never a
-/// silent no-message, so every framing fault refuses loudly: fewer than
-/// the two header bytes, a produced byte past 1, or payload bytes
-/// behind a nothing-produced header. (The tag byte is meaningless when
-/// nothing was produced; a tag past the declared arms is the generated
-/// unpacker's refusal — it owns the arm table.)
+/// silent no-message, so every framing fault panics with a teaching:
+/// fewer than the two header bytes, a produced byte past 1, or payload
+/// bytes behind a nothing-produced header. (The tag byte is meaningless
+/// when nothing was produced; a tag past the declared arms is the
+/// generated unpacker's refusal — it owns the arm table.)
 pub fn channelEnvelope(bytes: []const u8) ChannelEnvelope {
     if (bytes.len < 2) {
         @panic("a channel entry returned fewer than the envelope's two header bytes ([produced u8][tag u8]) — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");

--- a/tools/corewire/shim_rt.zig
+++ b/tools/corewire/shim_rt.zig
@@ -360,11 +360,23 @@ pub fn assertVoidPayload(payload: []const u8) void {
 
 /// The defined pre-call state for a channel entry's out-pointer pair:
 /// the generated wrappers point at this byte with length zero before
-/// calling, so an entry that returns without writing both slots — a
-/// contract violation — yields a zero-length envelope that
-/// channelEnvelope refuses with its short-buffer teaching, never a
-/// slice of an undefined pointer.
+/// calling, so an entry that returns without writing — a contract
+/// violation — can never hand back a slice of undefined memory.
+/// channelEnvelopeBytes reads the pair back.
 pub const channel_out_guard = [1]u8{0};
+
+/// Assemble a channel entry's returned envelope from the out pair,
+/// closing every non-writing shape loudly BEFORE a slice forms: an
+/// entry that wrote neither slot yields the guard at length zero
+/// (refused downstream as a short envelope), and an entry that wrote a
+/// length without a pointer — the guard address with a nonzero length —
+/// refuses here, never an out-of-bounds read of the guard.
+pub fn channelEnvelopeBytes(ptr: [*]const u8, len: usize) []const u8 {
+    if (len != 0 and ptr == @as([*]const u8, @ptrCast(&channel_out_guard))) {
+        @panic("a channel entry wrote an envelope length without an envelope pointer — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");
+    }
+    return ptr[0..len];
+}
 
 /// A channel entry's split bytes envelope: whether a message was
 /// produced, the produced arm's declaration-order wire tag, and the arm
@@ -514,6 +526,17 @@ test "void union arms ride as the bare arm index" {
     try testing.expect(decoded == .clear);
     // A bare arm's canonical payload is zero bytes exactly.
     assertVoidPayload(&.{});
+}
+
+test "channel out pairs assemble through the guard-aware reader" {
+    // A written pair passes through untouched.
+    const written = [_]u8{ 1, 0 };
+    try testing.expectEqualSlices(u8, &written, channelEnvelopeBytes(&written, written.len));
+    // The untouched pre-call state (guard pointer, zero length) reads
+    // as the empty buffer — refused downstream as a short envelope,
+    // never an undefined slice.
+    const untouched = channelEnvelopeBytes(@ptrCast(&channel_out_guard), 0);
+    try testing.expectEqual(@as(usize, 0), untouched.len);
 }
 
 test "channel envelopes split into produced flag, tag, and payload" {

--- a/tools/corewire/shim_rt.zig
+++ b/tools/corewire/shim_rt.zig
@@ -358,6 +358,36 @@ pub fn assertVoidPayload(payload: []const u8) void {
     }
 }
 
+/// A channel entry's split bytes envelope: whether a message was
+/// produced, the produced arm's declaration-order wire tag, and the arm
+/// payload bytes (canonical value encoding of the arm's mirror payload
+/// type).
+pub const ChannelEnvelope = struct {
+    produced: bool,
+    tag: u8,
+    payload: []const u8,
+};
+
+/// Split a channel entry's bytes envelope — [produced u8][tag u8]
+/// [payload…]. A malformed envelope is a contract violation, never a
+/// silent no-message, so every framing fault refuses loudly: fewer than
+/// the two header bytes, a produced byte past 1, or payload bytes
+/// behind a nothing-produced header. (The tag byte is meaningless when
+/// nothing was produced; a tag past the declared arms is the generated
+/// unpacker's refusal — it owns the arm table.)
+pub fn channelEnvelope(bytes: []const u8) ChannelEnvelope {
+    if (bytes.len < 2) {
+        @panic("a channel entry returned fewer than the envelope's two header bytes ([produced u8][tag u8]) — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");
+    }
+    if (bytes[0] > 1) {
+        @panic("a channel envelope's produced byte is past 1 — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");
+    }
+    if (bytes[0] == 0 and bytes.len != 2) {
+        @panic("a channel envelope carries payload bytes behind a nothing-produced header — the compiled core and the generated shim disagree about the channel contract; rebuild the app so both come from one compile");
+    }
+    return .{ .produced = bytes[0] == 1, .tag = bytes[1], .payload = bytes[2..] };
+}
+
 // --------------------------------------------------------------- tests
 
 const testing = std.testing;
@@ -476,4 +506,22 @@ test "void union arms ride as the bare arm index" {
     try testing.expect(decoded == .clear);
     // A bare arm's canonical payload is zero bytes exactly.
     assertVoidPayload(&.{});
+}
+
+test "channel envelopes split into produced flag, tag, and payload" {
+    // Nothing produced: exactly the two header bytes, tag ignored.
+    const none = channelEnvelope(&.{ 0, 0 });
+    try testing.expect(!none.produced);
+    try testing.expectEqual(@as(usize, 0), none.payload.len);
+    // A produced bare arm: header only, empty payload.
+    const bare = channelEnvelope(&.{ 1, 3 });
+    try testing.expect(bare.produced);
+    try testing.expectEqual(@as(u8, 3), bare.tag);
+    try testing.expectEqual(@as(usize, 0), bare.payload.len);
+    // A produced payload arm: the tail is the arm's canonical payload
+    // bytes, untouched.
+    const produced = channelEnvelope(&.{ 1, 1, 2, 0, 0, 0, 0, 0, 0, 0 });
+    try testing.expect(produced.produced);
+    try testing.expectEqual(@as(u8, 1), produced.tag);
+    try testing.expectEqualSlices(u8, &.{ 2, 0, 0, 0, 0, 0, 0, 0 }, produced.payload);
 }

--- a/tools/corewire/shim_rt.zig
+++ b/tools/corewire/shim_rt.zig
@@ -358,6 +358,14 @@ pub fn assertVoidPayload(payload: []const u8) void {
     }
 }
 
+/// The defined pre-call state for a channel entry's out-pointer pair:
+/// the generated wrappers point at this byte with length zero before
+/// calling, so an entry that returns without writing both slots — a
+/// contract violation — yields a zero-length envelope that
+/// channelEnvelope refuses with its short-buffer teaching, never a
+/// slice of an undefined pointer.
+pub const channel_out_guard = [1]u8{0};
+
 /// A channel entry's split bytes envelope: whether a message was
 /// produced, the produced arm's declaration-order wire tag, and the arm
 /// payload bytes (canonical value encoding of the arm's mirror payload


### PR DESCRIPTION
## What

Conditional channel entries (`command_msg`, `frame_msg`, `key_msg`, `pinch_msg`) now hand their result back as one bytes buffer on the ordinary out-pointer slot — the channel bytes envelope `[produced u8][tag u8][payload…]` — replacing the out-record struct and its bespoke marshalling shape.

- **ABI bindings** (`tools/corewire/core_abi.zig`): channel externs rebind to the bytes-return out-pointer pair; the pre-envelope `CoreMsg` out-record is deleted. The envelope format is documented at the binding site.
- **Facade emitter** (`tools/corewire/emit_facade.zig`): wired channels export `nsc_core_<channel>(msg: Msg | null): Uint8Array`, packing the envelope with each arm's payload in the sidecar's classes and flattened field orders; null packs exactly `[0, 0]`. Unwired sidecars carry no envelope surface.
- **Generated shims** (`tools/corewire/emit.zig`, `tools/corewire/shim_rt.zig`): `msgFromEnvelope` unpacks produced/tag/payload; malformed framing (short buffer, produced byte past 1, payload behind a nothing-produced header, length-without-pointer writes) panics with a teaching before any slice forms, and wrappers pre-point the out pair at a guard so an entry that never writes yields the refusable zero-length envelope.

## Why

One bytes return keeps the one-return-slot rule intact: the multi-value channel result needs no marshalling shape of its own, and the envelope's tail is byte-identical to the canonical union encoding of the produced message — the same encoding the dispatch family already consumes.

## Proof

- Conformance: facade-packed envelopes equal `[1] ++` the canonical Msg encoding across bare, i64, bytes, flattened-record, and enum payload families; null gates pack `[0, 0]`; generated channel entries execute against the stub core's test-settable envelopes.
- Parity: both lanes run full channel round-trip cycles — null gating agrees, produced messages compare by canonical bytes, and each dispatches to a byte-identical committed snapshot.
- `zig build test`, `sidecar-conformance`, and `test-ts-core-e2e` green on this branch rebased onto current main.