### PR TITLE
Validate integer-class attestations and decode boundary slots by class

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2985,8 +2985,10 @@ fn tsCoreE2eArtifact(
     conformance_mod.addImport("facade_markup_core", facadeCoreModule(b, target, optimize, node, corewire_exe, b.path("tests/sidecar/markup_fixture.contract.json")));
     // The integer-class fixture: a hand-written sidecar attesting mixed
     // i64/u64 slot classes, so the suite drives boundary and full-range
-    // integer values through a generated mirror's decode paths.
+    // integer values through a generated mirror's decode paths and
+    // holds the compiled facade's integer encoders to the same bytes.
     conformance_mod.addImport("shim_integer_core", sidecarShimModule(b, target, optimize, corewire_exe, b.path("tests/sidecar/integer_fixture.contract.json")));
+    conformance_mod.addImport("facade_integer_core", facadeCoreModule(b, target, optimize, node, corewire_exe, b.path("tests/sidecar/integer_fixture.contract.json")));
     const conformance_fixtures = [_]struct {
         ts_import: []const u8,
         shim_import: []const u8,

--- a/build.zig
+++ b/build.zig
@@ -2983,6 +2983,10 @@ fn tsCoreE2eArtifact(
     conformance_mod.addImport("ts_markup_core", markup_fixture_mod);
     conformance_mod.addImport("shim_markup_core", sidecarShimModule(b, target, optimize, corewire_exe, b.path("tests/sidecar/markup_fixture.contract.json")));
     conformance_mod.addImport("facade_markup_core", facadeCoreModule(b, target, optimize, node, corewire_exe, b.path("tests/sidecar/markup_fixture.contract.json")));
+    // The integer-class fixture: a hand-written sidecar attesting mixed
+    // i64/u64 slot classes, so the suite drives boundary and full-range
+    // integer values through a generated mirror's decode paths.
+    conformance_mod.addImport("shim_integer_core", sidecarShimModule(b, target, optimize, corewire_exe, b.path("tests/sidecar/integer_fixture.contract.json")));
     const conformance_fixtures = [_]struct {
         ts_import: []const u8,
         shim_import: []const u8,
@@ -3031,7 +3035,17 @@ fn tsCoreE2eArtifact(
         while (inputs.next()) |input| {
             parity_mod.addObjectFile(.{ .cwd_relative = b.dupe(input) });
         }
-        break :blk filteredTestArtifact(b, parity_mod, "external-core-parity-tests", &.{});
+        const parity_tests = filteredTestArtifact(b, parity_mod, "external-core-parity-tests", &.{});
+        // Run the checker over the supplied sidecar explicitly (the
+        // shim generation above validates too, but the checker tier —
+        // both projections, integer_slots structural rules included —
+        // is the surface an external compile is verified against).
+        const check_sidecar = b.addRunArtifact(corewire_exe);
+        check_sidecar.addArg("--sidecar");
+        check_sidecar.addFileArg(parity_sidecar);
+        check_sidecar.addArg("--check");
+        parity_tests.step.dependOn(&check_sidecar.step);
+        break :blk parity_tests;
     } else null;
 
     return .{

--- a/src/runtime/effects.zig
+++ b/src/runtime/effects.zig
@@ -7806,8 +7806,8 @@ pub fn Effects(comptime Msg: type) type {
             const event = self.applyAudioEvent(.{
                 .key = 0,
                 .kind = kind,
-                .position_ms = platform_event.position_ms,
-                .duration_ms = platform_event.duration_ms,
+                .position_ms = clampAudioScalar(platform_event.position_ms),
+                .duration_ms = clampAudioScalar(platform_event.duration_ms),
                 .playing = platform_event.playing,
                 .buffering = platform_event.buffering,
                 .bands = platform_event.bands,
@@ -7875,8 +7875,8 @@ pub fn Effects(comptime Msg: type) type {
                 .event = .{
                     .key = self.audio.key,
                     .kind = kind,
-                    .position_ms = position_ms,
-                    .duration_ms = duration_ms,
+                    .position_ms = clampAudioScalar(position_ms),
+                    .duration_ms = clampAudioScalar(duration_ms),
                     .playing = playing,
                     .buffering = buffering,
                 },
@@ -7896,8 +7896,8 @@ pub fn Effects(comptime Msg: type) type {
                 .event = .{
                     .key = self.audio.key,
                     .kind = .spectrum,
-                    .position_ms = position_ms,
-                    .duration_ms = duration_ms,
+                    .position_ms = clampAudioScalar(position_ms),
+                    .duration_ms = clampAudioScalar(duration_ms),
                     .playing = true,
                     .bands = bands,
                 },
@@ -11217,6 +11217,16 @@ pub fn Effects(comptime Msg: type) type {
         /// One video scalar into the exact-integer delivery window
         /// (see `max_effect_video_scalar_exclusive`).
         fn clampVideoScalar(value: u64) u64 {
+            return @min(value, max_effect_video_scalar_exclusive - 1);
+        }
+
+        /// Audio's twin of the video scalar clamp: positions and
+        /// durations clamp into the same exact-integer delivery window
+        /// at every entry (live platform events and the fed
+        /// fake/replay path alike), whatever a host reports — so the
+        /// mirrors, the journal, and integer-classed Msg fields only
+        /// ever see values below 2^53.
+        fn clampAudioScalar(value: u64) u64 {
             return @min(value, max_effect_video_scalar_exclusive - 1);
         }
 

--- a/src/runtime/session_journal.zig
+++ b/src/runtime/session_journal.zig
@@ -128,7 +128,13 @@ pub const format_fingerprint: u64 = layout_fingerprint.hash(formatLayoutDescript
 /// touch-source stamp (`platform.touch_pointer_id_bit`) — same bytes,
 /// and an older recording whose host happened to emit ids with that
 /// bit set would replay with hover-proof semantics it never had.
-pub const format_semantic_epoch: u32 = 4;
+/// Epoch 5: audio positions and durations clamp into the exact-integer
+/// window (below 2^53) at every delivery entry, and replay refuses an
+/// out-of-window audio record as journal damage — an older recording
+/// could journal a wider value the old feed paths accepted, which
+/// would now be misreported as damage instead of refusing as a
+/// different generation.
+pub const format_semantic_epoch: u32 = 5;
 
 /// The canonical description `format_fingerprint` hashes: everything
 /// that defines the on-disk record layout. Reflection covers the record

--- a/src/runtime/session_replay.zig
+++ b/src/runtime/session_replay.zig
@@ -256,6 +256,18 @@ pub fn replaySession(
                     );
                     return error.ReplayDamagedRecord;
                 }
+                // Audio scalars obey the recorder the same way (the
+                // delivery boundary clamps them into the exact-integer
+                // window before anything journals), so an out-of-window
+                // value is journal damage — refuse it rather than
+                // silently reshaping the recorded stream at the feed.
+                if (effect.kind == .audio and audioScalarsDamaged(effect)) {
+                    std.debug.print(
+                        "replay refused after event {d}: audio record for key {d} carries a millisecond value at or past 2^53 - recorded playback scalars ride the exact-integer window every delivery tier can carry, so the journal is damaged or hand-edited; re-record the session\n",
+                        .{ report.events_replayed, effect.key },
+                    );
+                    return error.ReplayDamagedRecord;
+                }
                 // Provenance consistency, gated BEFORE the regeneration
                 // skip below: a `.rejected` stamped onto a delivered
                 // record (nonzero token) would be skipped there and its
@@ -574,6 +586,15 @@ fn videoScalarsDamaged(record: journal.EffectResultRecord) bool {
         record.video_height >= max_exact;
 }
 
+/// The audio twin: positions and durations clamp into the exact-integer
+/// window at every delivery entry before they journal, so a recorded
+/// value at or past 2^53 can only be a damaged or hand-edited journal.
+fn audioScalarsDamaged(record: journal.EffectResultRecord) bool {
+    const max_exact: u64 = runtime_effects.max_effect_video_scalar_exclusive;
+    return record.audio_position_ms >= max_exact or
+        record.audio_duration_ms >= max_exact;
+}
+
 /// A `.video_load` record's `video_kind` is the load's OUTCOME, and the
 /// recorder writes exactly two values: `.loaded` on a resolved cascade
 /// and `.failed` on a synchronous refusal. Any other kind steers
@@ -757,6 +778,27 @@ test "exit records outside the transport's producible ranges are damaged" {
     try std.testing.expect(ptyRecordDamaged(record));
     record.pty_signal = -9;
     try std.testing.expect(ptyRecordDamaged(record));
+}
+
+test "audio records outside the exact-integer scalar window are damaged" {
+    // The delivery boundary clamps positions and durations below 2^53
+    // before anything journals, so every in-window value passes and
+    // every out-of-window value can only be journal damage.
+    var record: journal.EffectResultRecord = .{
+        .kind = .audio,
+        .key = 1,
+        .audio_kind = .position,
+        .audio_position_ms = 0,
+        .audio_duration_ms = 183_000,
+    };
+    try std.testing.expect(!audioScalarsDamaged(record));
+    record.audio_position_ms = runtime_effects.max_effect_video_scalar_exclusive - 1;
+    try std.testing.expect(!audioScalarsDamaged(record));
+    record.audio_position_ms = runtime_effects.max_effect_video_scalar_exclusive;
+    try std.testing.expect(audioScalarsDamaged(record));
+    record.audio_position_ms = 0;
+    record.audio_duration_ms = std.math.maxInt(u64);
+    try std.testing.expect(audioScalarsDamaged(record));
 }
 
 /// Debug aid: `NATIVE_SDK_SESSION_REPLAY_DUMP=<dir>` writes each

--- a/src/runtime/ts_core_host.zig
+++ b/src/runtime/ts_core_host.zig
@@ -2273,7 +2273,7 @@ pub fn TsCoreHost(comptime core: type) type {
         /// transpiler validates the shape, so field names stay the
         /// app's). The bytes copy into the core's frame arena like
         /// every routed payload; the number widens into its field the
-        /// way the subset's number model classes it (i64 or f64).
+        /// way the subset's number model classes it (i64, u64, or f64).
         fn msgFromTagNumberBytes(comptime what: []const u8, comptime shape: []const u8, tag: u8, number: anytype, bytes: []const u8) Msg {
             inline for (msg_arms, 0..) |arm, index| {
                 if (tag == index) {
@@ -2286,7 +2286,7 @@ pub fn TsCoreHost(comptime core: type) type {
                             var number_fields = 0;
                             for (fields) |f| {
                                 if (f.type == []const u8) bytes_fields += 1;
-                                if (f.type == i64 or f.type == f64) number_fields += 1;
+                                if (f.type == i64 or f.type == u64 or f.type == f64) number_fields += 1;
                             }
                             break :blk bytes_fields == 1 and number_fields == 1;
                         };
@@ -2327,7 +2327,7 @@ pub fn TsCoreHost(comptime core: type) type {
                 if (std.mem.eql(u8, f.name, "state")) {
                     if (@typeInfo(f.type) != .@"enum") ok = false;
                 } else if (std.mem.eql(u8, f.name, "positionMs") or std.mem.eql(u8, f.name, "durationMs")) {
-                    if (f.type != i64 and f.type != f64) ok = false;
+                    if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else if (std.mem.eql(u8, f.name, "playing") or std.mem.eql(u8, f.name, "buffering")) {
                     if (f.type != bool) ok = false;
                 } else if (std.mem.eql(u8, f.name, "bands")) {
@@ -2354,7 +2354,7 @@ pub fn TsCoreHost(comptime core: type) type {
         /// engine event, by field name. The band bytes copy into the
         /// core's frame arena like every routed bytes payload; the
         /// millisecond fields widen the way the subset's number model
-        /// classes them (i64 or f64).
+        /// classes them (i64, u64, or f64).
         fn msgFromTagAudio(tag: u8, event: runtime_effects.EffectAudio) Msg {
             inline for (msg_arms, 0..) |arm, index| {
                 if (tag == index) {
@@ -2403,7 +2403,7 @@ pub fn TsCoreHost(comptime core: type) type {
                 } else if (std.mem.eql(u8, f.name, "positionMs") or std.mem.eql(u8, f.name, "durationMs") or
                     std.mem.eql(u8, f.name, "width") or std.mem.eql(u8, f.name, "height"))
                 {
-                    if (f.type != i64 and f.type != f64) ok = false;
+                    if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else if (std.mem.eql(u8, f.name, "playing") or std.mem.eql(u8, f.name, "buffering")) {
                     if (f.type != bool) ok = false;
                 } else {
@@ -2426,7 +2426,7 @@ pub fn TsCoreHost(comptime core: type) type {
         /// Build the seven-field video event arm at index `tag` from an
         /// engine event, by field name. The millisecond and dimension
         /// fields widen the way the subset's number model classes them
-        /// (i64 or f64).
+        /// (i64, u64, or f64).
         fn msgFromTagVideo(tag: u8, event: runtime_effects.EffectVideo) Msg {
             inline for (msg_arms, 0..) |arm, index| {
                 if (tag == index) {
@@ -2470,7 +2470,7 @@ pub fn TsCoreHost(comptime core: type) type {
                 if (std.mem.eql(u8, f.name, "state")) {
                     if (@typeInfo(f.type) != .@"enum") ok = false;
                 } else if (std.mem.eql(u8, f.name, "id") or std.mem.eql(u8, f.name, "width") or std.mem.eql(u8, f.name, "height") or std.mem.eql(u8, f.name, "status")) {
-                    if (f.type != i64 and f.type != f64) ok = false;
+                    if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else {
                     ok = false;
                 }
@@ -2535,7 +2535,7 @@ pub fn TsCoreHost(comptime core: type) type {
                 } else if (std.mem.eql(u8, f.name, "bytes")) {
                     if (f.type != []const u8) ok = false;
                 } else if (std.mem.eql(u8, f.name, "key") or std.mem.eql(u8, f.name, "droppedPending") or std.mem.eql(u8, f.name, "droppedTotal")) {
-                    if (f.type != i64 and f.type != f64) ok = false;
+                    if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else {
                     ok = false;
                 }
@@ -2614,7 +2614,7 @@ pub fn TsCoreHost(comptime core: type) type {
                 } else if (std.mem.eql(u8, f.name, "bytes") or std.mem.eql(u8, f.name, "key")) {
                     if (f.type != []const u8) ok = false;
                 } else if (std.mem.eql(u8, f.name, "code") or std.mem.eql(u8, f.name, "signal") or std.mem.eql(u8, f.name, "droppedWrites")) {
-                    if (f.type != i64 and f.type != f64) ok = false;
+                    if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else {
                     ok = false;
                 }
@@ -2704,14 +2704,15 @@ pub fn TsCoreHost(comptime core: type) type {
         }
 
         /// Build the Msg arm at index `tag` carrying one number (`now`
-        /// timestamps and timer fires; an i64-classed arm truncates the
-        /// way the subset's number model does at index sites).
+        /// timestamps and timer fires; an integer-classed arm — i64 or
+        /// its unsigned twin — truncates the way the subset's number
+        /// model does at index sites).
         fn msgFromTagNumber(tag: u8, value: f64) Msg {
             inline for (msg_arms, 0..) |arm, index| {
                 if (tag == index) {
                     if (comptime arm.type == f64) {
                         return @unionInit(Msg, arm.name, value);
-                    } else if (comptime arm.type == i64) {
+                    } else if (comptime arm.type == i64 or arm.type == u64) {
                         return @unionInit(Msg, arm.name, @intFromFloat(value));
                     }
                     @panic("ts core host: a timestamp targets Msg arm '" ++ arm.name ++ "', whose payload is not a number");

--- a/src/runtime/ts_core_host.zig
+++ b/src/runtime/ts_core_host.zig
@@ -2300,6 +2300,17 @@ pub fn TsCoreHost(comptime core: type) type {
                                 } else if (comptime f.type == f64) {
                                     @field(payload, f.name) = @floatFromInt(number);
                                 } else {
+                                    // Exit codes carry -1 sentinels by
+                                    // contract: a negative host number
+                                    // into an unsigned field has no
+                                    // honest value, so the crossing
+                                    // teaches instead of faulting in
+                                    // the cast.
+                                    if (comptime f.type == u64) {
+                                        if (number < 0) {
+                                            @panic("ts core host: a negative number reached the u64-classed field '" ++ f.name ++ "' of Msg arm '" ++ arm.name ++ "' — the unsigned class cannot carry it; declare the field i64 or f64");
+                                        }
+                                    }
                                     @field(payload, f.name) = @intCast(number);
                                 }
                             }
@@ -2718,7 +2729,17 @@ pub fn TsCoreHost(comptime core: type) type {
                 if (tag == index) {
                     if (comptime arm.type == f64) {
                         return @unionInit(Msg, arm.name, value);
-                    } else if (comptime arm.type == i64 or arm.type == u64) {
+                    } else if (comptime arm.type == i64) {
+                        return @unionInit(Msg, arm.name, @intFromFloat(value));
+                    } else if (comptime arm.type == u64) {
+                        // Clocks are signed by contract (a pre-epoch or
+                        // skewed wall clock is a legal reading): when
+                        // one reaches an unsigned arm there is no
+                        // honest value, so the crossing teaches instead
+                        // of faulting in the cast.
+                        if (value < 0) {
+                            @panic("ts core host: a negative number reached the u64-classed Msg arm '" ++ arm.name ++ "' — the unsigned class cannot carry it; declare the arm i64 or f64");
+                        }
                         return @unionInit(Msg, arm.name, @intFromFloat(value));
                     }
                     @panic("ts core host: a timestamp targets Msg arm '" ++ arm.name ++ "', whose payload is not a number");

--- a/src/runtime/ts_core_host.zig
+++ b/src/runtime/ts_core_host.zig
@@ -2613,12 +2613,13 @@ pub fn TsCoreHost(comptime core: type) type {
                     if (@typeInfo(f.type) != .@"enum") ok = false;
                 } else if (std.mem.eql(u8, f.name, "bytes") or std.mem.eql(u8, f.name, "key")) {
                     if (f.type != []const u8) ok = false;
-                } else if (std.mem.eql(u8, f.name, "code") or std.mem.eql(u8, f.name, "signal")) {
-                    // Non-exited terminals deliver -1 sentinels in both
-                    // slots: signed by contract, so the unsigned class
-                    // cannot carry them.
+                } else if (std.mem.eql(u8, f.name, "code")) {
+                    // Non-exited terminals deliver the -1 code sentinel:
+                    // signed by contract, so the unsigned class cannot
+                    // carry it. `signal` stays zero-or-positive (the
+                    // fatal signal number, else 0) and takes any class.
                     if (f.type != i64 and f.type != f64) ok = false;
-                } else if (std.mem.eql(u8, f.name, "droppedWrites")) {
+                } else if (std.mem.eql(u8, f.name, "signal") or std.mem.eql(u8, f.name, "droppedWrites")) {
                     if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else {
                     ok = false;

--- a/src/runtime/ts_core_host.zig
+++ b/src/runtime/ts_core_host.zig
@@ -2613,7 +2613,12 @@ pub fn TsCoreHost(comptime core: type) type {
                     if (@typeInfo(f.type) != .@"enum") ok = false;
                 } else if (std.mem.eql(u8, f.name, "bytes") or std.mem.eql(u8, f.name, "key")) {
                     if (f.type != []const u8) ok = false;
-                } else if (std.mem.eql(u8, f.name, "code") or std.mem.eql(u8, f.name, "signal") or std.mem.eql(u8, f.name, "droppedWrites")) {
+                } else if (std.mem.eql(u8, f.name, "code") or std.mem.eql(u8, f.name, "signal")) {
+                    // Non-exited terminals deliver -1 sentinels in both
+                    // slots: signed by contract, so the unsigned class
+                    // cannot carry them.
+                    if (f.type != i64 and f.type != f64) ok = false;
+                } else if (std.mem.eql(u8, f.name, "droppedWrites")) {
                     if (f.type != i64 and f.type != u64 and f.type != f64) ok = false;
                 } else {
                     ok = false;

--- a/src/runtime/ts_core_host_tests.zig
+++ b/src/runtime/ts_core_host_tests.zig
@@ -142,6 +142,9 @@ const mini_core = struct {
         // Second-arm mirrors (the replaced-load straggler probe).
         video2_state: VideoState,
         video2_events: i64,
+        // Unsigned-class mirrors (u64-classed arm routing).
+        ustamp_ms: u64,
+        ucode: u64,
     };
 
     pub const Msg = union(enum) {
@@ -281,6 +284,11 @@ const mini_core = struct {
             droppedWrites: f64,
         },
         dup_pty, // 78: two pty spawns under one key in one batch
+        ustamp, // 79: Cmd.now -> .ustamped (unsigned integer class)
+        ustamped: u64, // 80: now arm, u64-classed
+        uget, // 81: fetch "uget" -> ufetched/failed
+        ufetched: struct { status: u64, body: []const u8 }, // 82: fetch ok
+        // record with a u64-classed number field
     };
 
     pub const InitResult = struct { model: *const Model, cmd: []const u8 };
@@ -343,6 +351,8 @@ const mini_core = struct {
                 .video_events = 0,
                 .video2_state = .rejected,
                 .video2_events = 0,
+                .ustamp_ms = 0,
+                .ucode = 0,
             }),
             .cmd = cmdRequest("status.read", "status", 7, 8, "boot"),
         };
@@ -432,6 +442,19 @@ const mini_core = struct {
             .stamped => |at| {
                 const out = frameCreate(model.*);
                 out.stamp_ms = at;
+                return .{ .model = out, .cmd = "" };
+            },
+            .ustamp => return .{ .model = model, .cmd = cmdNow(80) },
+            .ustamped => |at| {
+                const out = frameCreate(model.*);
+                out.ustamp_ms = at;
+                return .{ .model = out, .cmd = "" };
+            },
+            .uget => return .{ .model = model, .cmd = cmdFetch("uget", 82, 8, 1, 0, "https://status.test/u", &.{}, "") },
+            .ufetched => |response| {
+                const out = frameCreate(model.*);
+                out.ucode = response.status;
+                out.status = response.body;
                 return .{ .model = out, .cmd = "" };
             },
             .run_lines => return .{ .model = model, .cmd = cmdSpawn("job", 25, 26, 8, 0, &.{ "/bin/probe", "--fast" }, "feed me") },
@@ -1150,6 +1173,28 @@ test "Cmd.now dispatches synchronously with the journaled clock" {
     try std.testing.expectEqual(@as(f64, 1_234), Host.model().stamp_ms);
     try std.testing.expectEqual(@as(usize, 1), Capture.count);
     try std.testing.expectEqual(effects_mod.EffectResultKind.clock, Capture.kinds[0]);
+}
+
+test "u64-classed arms route the number and number_bytes dispatch paths" {
+    const fx = freshChannel();
+    defer fx.deinit();
+    var clock = runtime_clock.TestClock{};
+    clock.setWallMs(1_234);
+    fx.clock = clock.clock();
+    Host.init(fx);
+
+    // Cmd.now into a u64-classed arm: the fire time narrows into the
+    // unsigned class the way an i64-classed arm narrows.
+    Host.dispatch(fx, .ustamp);
+    try std.testing.expectEqual(@as(u64, 1_234), Host.model().ustamp_ms);
+
+    // A fetch ok record whose number field is u64-classed still matches
+    // the { number, bytes } shape by type and routes whole.
+    Host.dispatch(fx, .uget);
+    try fx.feedResponse(load_effect_key, 404, "missing");
+    Host.drain(fx);
+    try std.testing.expectEqual(@as(u64, 404), Host.model().ucode);
+    try std.testing.expectEqualStrings("missing", Host.model().status);
 }
 
 test "fire-and-forget records ride the host-call binding in wire order" {

--- a/src/runtime/ts_core_host_tests.zig
+++ b/src/runtime/ts_core_host_tests.zig
@@ -1768,13 +1768,21 @@ test "audio_play decodes whole and events route the six-field arm by name" {
     try std.testing.expectEqual(@as(usize, 32), Host.model().bands.len);
     try std.testing.expectEqualSlices(u8, full[0..32], Host.model().bands);
 
+    // Audio scalars clamp into the exact-integer delivery window at the
+    // feed boundary (the video clamp's twin): whatever a host reports,
+    // integer-classed Msg fields and the mirrors only ever see values
+    // below 2^53.
+    try fx.feedAudioEvent(.position, std.math.maxInt(u64), 183_000, true);
+    Host.drain(fx);
+    try std.testing.expectEqual(@as(f64, 9007199254740991), Host.model().position_ms);
+
     // completed does NOT close the stream (apps start the next track
     // from it); the entry keeps routing.
     try fx.feedAudioEvent(.completed, 183_000, 183_000, false);
     Host.drain(fx);
     try std.testing.expectEqual(mini_core.AudioState.completed, Host.model().audio_state);
     try std.testing.expect(!Host.model().playing);
-    try std.testing.expectEqual(@as(i64, 5), Host.model().audio_events);
+    try std.testing.expectEqual(@as(i64, 6), Host.model().audio_events);
 }
 
 test "audio_ctl verbs drive the engine channel, gated by the wire key" {

--- a/src/runtime/ts_ui_app.zig
+++ b/src/runtime/ts_ui_app.zig
@@ -323,7 +323,7 @@ pub fn TsUiApp(comptime core: type) type {
                 @compileError("TsUiApp: frameMsg must take (model: Model, frame: FrameEvent) - regenerate the core");
             }
             const FrameArg = params[1].type.?;
-            comptime validateChannelRecord(FrameArg, &.{ "width", "height", "timestampMs", "intervalMs" }, "frameMsg's FrameEvent", true);
+            comptime validateChannelRecord(FrameArg, &.{ "width", "height", "timestampMs", "intervalMs" }, "frameMsg's FrameEvent", &.{});
             var arg: FrameArg = undefined;
             inline for (@typeInfo(FrameArg).@"struct".fields) |field| {
                 const value: f64 = if (comptime std.mem.eql(u8, field.name, "width"))
@@ -481,11 +481,11 @@ pub fn TsUiApp(comptime core: type) type {
             @compileError("TsUiApp: " ++ channel ++ " names '" ++ tag ++ "', which is not an arm of Msg");
         }
 
-        /// `allow_unsigned` says whether u64 fields may appear: the
-        /// frame record's values (sizes, clocks) are non-negative, but
-        /// chrome geometry rides signed content coordinates that the
-        /// unsigned class cannot carry.
-        fn validateChannelRecord(comptime T: type, comptime names: []const []const u8, comptime what: []const u8, comptime allow_unsigned: bool) void {
+        /// `signed_names` lists the fields the host supplies signed
+        /// (positions in content coordinates): those may not take the
+        /// unsigned class, while extents, sizes, and clocks — always
+        /// non-negative from the host — take any numeric class.
+        fn validateChannelRecord(comptime T: type, comptime names: []const []const u8, comptime what: []const u8, comptime signed_names: []const []const u8) void {
             const info = @typeInfo(T);
             if (info != .@"struct" or info.@"struct".fields.len != names.len) {
                 @compileError("TsUiApp: " ++ what ++ " record has the wrong field set");
@@ -496,10 +496,15 @@ pub fn TsUiApp(comptime core: type) type {
                 }
             }
             for (info.@"struct".fields) |field| {
-                const unsigned_ok = allow_unsigned and field.type == u64;
-                if (field.type != i64 and field.type != f64 and field.type != f32 and !unsigned_ok) {
-                    @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' must be a number" ++
-                        (if (allow_unsigned) "" else " (signed: the host reports signed content coordinates here)"));
+                if (field.type == u64) {
+                    for (signed_names) |signed| {
+                        if (std.mem.eql(u8, field.name, signed)) {
+                            @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' rides signed content coordinates, which u64 cannot carry - declare it i64 or f64");
+                        }
+                    }
+                }
+                if (field.type != i64 and field.type != u64 and field.type != f64 and field.type != f32) {
+                    @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' must be a number");
                 }
             }
         }
@@ -522,8 +527,8 @@ pub fn TsUiApp(comptime core: type) type {
             if (info != .@"struct" or info.@"struct".fields.len != 3) @compileError(teaching);
             if (!@hasField(T, "insets") or !@hasField(T, "buttons") or !@hasField(T, "tabsProjected")) @compileError(teaching);
             if (@FieldType(T, "tabsProjected") != bool) @compileError(teaching);
-            validateChannelRecord(@FieldType(T, "insets"), &.{ "top", "right", "bottom", "left" }, "chromeMsg's insets", false);
-            validateChannelRecord(@FieldType(T, "buttons"), &.{ "x", "y", "width", "height" }, "chromeMsg's buttons", false);
+            validateChannelRecord(@FieldType(T, "insets"), &.{ "top", "right", "bottom", "left" }, "chromeMsg's insets", &.{});
+            validateChannelRecord(@FieldType(T, "buttons"), &.{ "x", "y", "width", "height" }, "chromeMsg's buttons", &.{ "x", "y" });
         }
 
         /// `Options.update_fx`: one full core dispatch cycle, then the

--- a/src/runtime/ts_ui_app.zig
+++ b/src/runtime/ts_ui_app.zig
@@ -323,7 +323,7 @@ pub fn TsUiApp(comptime core: type) type {
                 @compileError("TsUiApp: frameMsg must take (model: Model, frame: FrameEvent) - regenerate the core");
             }
             const FrameArg = params[1].type.?;
-            comptime validateChannelRecord(FrameArg, &.{ "width", "height", "timestampMs", "intervalMs" }, "frameMsg's FrameEvent");
+            comptime validateChannelRecord(FrameArg, &.{ "width", "height", "timestampMs", "intervalMs" }, "frameMsg's FrameEvent", true);
             var arg: FrameArg = undefined;
             inline for (@typeInfo(FrameArg).@"struct".fields) |field| {
                 const value: f64 = if (comptime std.mem.eql(u8, field.name, "width"))
@@ -481,7 +481,11 @@ pub fn TsUiApp(comptime core: type) type {
             @compileError("TsUiApp: " ++ channel ++ " names '" ++ tag ++ "', which is not an arm of Msg");
         }
 
-        fn validateChannelRecord(comptime T: type, comptime names: []const []const u8, comptime what: []const u8) void {
+        /// `allow_unsigned` says whether u64 fields may appear: the
+        /// frame record's values (sizes, clocks) are non-negative, but
+        /// chrome geometry rides signed content coordinates that the
+        /// unsigned class cannot carry.
+        fn validateChannelRecord(comptime T: type, comptime names: []const []const u8, comptime what: []const u8, comptime allow_unsigned: bool) void {
             const info = @typeInfo(T);
             if (info != .@"struct" or info.@"struct".fields.len != names.len) {
                 @compileError("TsUiApp: " ++ what ++ " record has the wrong field set");
@@ -492,8 +496,10 @@ pub fn TsUiApp(comptime core: type) type {
                 }
             }
             for (info.@"struct".fields) |field| {
-                if (field.type != i64 and field.type != u64 and field.type != f64 and field.type != f32) {
-                    @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' must be a number");
+                const unsigned_ok = allow_unsigned and field.type == u64;
+                if (field.type != i64 and field.type != f64 and field.type != f32 and !unsigned_ok) {
+                    @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' must be a number" ++
+                        (if (allow_unsigned) "" else " (signed: the host reports signed content coordinates here)"));
                 }
             }
         }
@@ -516,8 +522,8 @@ pub fn TsUiApp(comptime core: type) type {
             if (info != .@"struct" or info.@"struct".fields.len != 3) @compileError(teaching);
             if (!@hasField(T, "insets") or !@hasField(T, "buttons") or !@hasField(T, "tabsProjected")) @compileError(teaching);
             if (@FieldType(T, "tabsProjected") != bool) @compileError(teaching);
-            validateChannelRecord(@FieldType(T, "insets"), &.{ "top", "right", "bottom", "left" }, "chromeMsg's insets");
-            validateChannelRecord(@FieldType(T, "buttons"), &.{ "x", "y", "width", "height" }, "chromeMsg's buttons");
+            validateChannelRecord(@FieldType(T, "insets"), &.{ "top", "right", "bottom", "left" }, "chromeMsg's insets", false);
+            validateChannelRecord(@FieldType(T, "buttons"), &.{ "x", "y", "width", "height" }, "chromeMsg's buttons", false);
         }
 
         /// `Options.update_fx`: one full core dispatch cycle, then the

--- a/src/runtime/ts_ui_app.zig
+++ b/src/runtime/ts_ui_app.zig
@@ -492,7 +492,7 @@ pub fn TsUiApp(comptime core: type) type {
                 }
             }
             for (info.@"struct".fields) |field| {
-                if (field.type != i64 and field.type != f64 and field.type != f32) {
+                if (field.type != i64 and field.type != u64 and field.type != f64 and field.type != f32) {
                     @compileError("TsUiApp: " ++ what ++ " field '" ++ field.name ++ "' must be a number");
                 }
             }

--- a/tests/sidecar/conformance_tests.zig
+++ b/tests/sidecar/conformance_tests.zig
@@ -45,6 +45,7 @@ const corewire_rt = @import("corewire_rt");
 const ts_markup = @import("ts_markup_core");
 const shim_markup = @import("shim_markup_core");
 const facade_markup = @import("facade_markup_core");
+const shim_integer = @import("shim_integer_core");
 const ts_host = @import("ts_host_core");
 const shim_host = @import("shim_host_core");
 const facade_host = @import("facade_host_core");
@@ -478,6 +479,109 @@ test "markup fixture: generated channel entries unpack the stub core's envelope"
     try testing.expect(zoomed.zoomed.fromBoard);
 }
 
+// ---------------------------------------------- integer-class fixture
+//
+// A hand-written sidecar attesting mixed integer classes
+// (tests/sidecar/integer_fixture.contract.json): the generated mirror
+// must decode each slot per its attested class — two's complement for
+// i64, the unsigned twin for u64, f64 for every non-attested slot —
+// over the compiler-provable extremes (+-(2^53 - 1)) and the full
+// 8-byte wire range alike (the wire type is 8 bytes; the decoder is
+// total over it).
+
+test "integer fixture: mirror slots spell their attested classes" {
+    try testing.expectEqual(i64, @FieldType(shim_integer.Model, "count"));
+    try testing.expectEqual(u64, @FieldType(shim_integer.Model, "id"));
+    try testing.expectEqual(f64, @FieldType(shim_integer.Model, "ratio"));
+    try testing.expectEqual(?u64, @FieldType(shim_integer.Model, "cursor"));
+    try testing.expectEqual(i64, @FieldType(shim_integer.Msg, "count_set"));
+    try testing.expectEqual(u64, @FieldType(shim_integer.Msg, "id_set"));
+    try testing.expectEqual(f64, @FieldType(shim_integer.Msg, "ratio_set"));
+    try testing.expectEqual(u64, @FieldType(@FieldType(shim_integer.Msg, "sized"), "size"));
+}
+
+test "integer fixture: envelope payloads decode boundary and full-range integers" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const saved = stub_core.stub_channel_envelope;
+    defer stub_core.stub_channel_envelope = saved;
+    defer shim_integer.rt.frameReset();
+
+    const key = shim_integer.KeyEvent{ .key = "x", .shift = false, .control = false, .alt = false, .super = false };
+
+    const Case = struct { envelope: []const u8, expected: shim_integer.Msg };
+    const cases = [_]Case{
+        // The compiler-provable extremes cross the i64-classed arm
+        // (tag 1) exactly, sign included.
+        .{ .envelope = &.{ 1, 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00 }, .expected = .{ .count_set = 9007199254740991 } },
+        .{ .envelope = &.{ 1, 1, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xff }, .expected = .{ .count_set = -9007199254740991 } },
+        // The u64-attested arm (tag 2) reads the same 8 bytes unsigned:
+        // the all-ones pattern is u64 max, never -1.
+        .{ .envelope = &.{ 1, 2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00 }, .expected = .{ .id_set = 9007199254740991 } },
+        .{ .envelope = &.{ 1, 2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, .expected = .{ .id_set = 18446744073709551615 } },
+        // The number_bytes number field follows its own attestation.
+        .{ .envelope = &.{ 1, 4, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00, 3, 0, 0, 0, 'r', 'o', 'w' }, .expected = .{ .sized = .{ .size = 9007199254740991, .label = "row" } } },
+    };
+    for (cases) |case| {
+        stub_core.stub_channel_envelope = case.envelope;
+        const decoded = shim_integer.keyMsg(key) orelse return error.TestUnexpectedResult;
+        // Decoded value and re-encoded bytes both match: the mirror
+        // round-trips the wire exactly.
+        try testing.expectEqualSlices(
+            u8,
+            corewire_rt.encodeAlloc(shim_integer.Msg, case.expected, arena),
+            corewire_rt.encodeAlloc(shim_integer.Msg, decoded, arena),
+        );
+        try testing.expectEqualSlices(u8, case.envelope[1..], corewire_rt.encodeAlloc(shim_integer.Msg, decoded, arena));
+    }
+}
+
+test "integer fixture: dispatch payloads encode byte-exactly against hand-computed vectors" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The canonical union encoding ([arm u8][payload…]) of each
+    // integer-carrying arm, against hand-computed little-endian bytes.
+    try testing.expectEqualSlices(
+        u8,
+        &.{ 1, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xff },
+        corewire_rt.encodeAlloc(shim_integer.Msg, .{ .count_set = -9007199254740991 }, arena),
+    );
+    try testing.expectEqualSlices(
+        u8,
+        &.{ 2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+        corewire_rt.encodeAlloc(shim_integer.Msg, .{ .id_set = 18446744073709551615 }, arena),
+    );
+    try testing.expectEqualSlices(
+        u8,
+        &.{ 4, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00, 2, 0, 0, 0, 'i', 'd' },
+        corewire_rt.encodeAlloc(shim_integer.Msg, .{ .sized = .{ .size = 9007199254740991, .label = "id" } }, arena),
+    );
+}
+
+test "integer fixture: model snapshots decode per-slot classes from raw bytes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A hand-laid snapshot of the fixture's model (count i64, id u64,
+    // ratio f64, cursor optional u64), decoded through the mirror's own
+    // declared types: each slot reads its 8 bytes per its class.
+    const snapshot = [_]u8{
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xff, // count = -(2^53 - 1)
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // id = u64 max
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x3f, // ratio = 1.5
+        0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00, // cursor = 2^53 - 1
+    };
+    const model = corewire_rt.decodeExact(shim_integer.Model, &snapshot, arena);
+    try testing.expectEqual(@as(i64, -9007199254740991), model.count);
+    try testing.expectEqual(@as(u64, 18446744073709551615), model.id);
+    try testing.expectEqual(@as(f64, 1.5), model.ratio);
+    try testing.expectEqual(@as(?u64, 9007199254740991), model.cursor);
+    // Re-encoding reproduces the wire bytes exactly.
+    try testing.expectEqualSlices(u8, &snapshot, corewire_rt.encodeAlloc(shim_integer.Model, model, arena));
+}
+
 /// Reference every public declaration, recursing into declared types
 /// (all of a shim's public type declarations are its own, so the walk
 /// never leaves the generated module).
@@ -495,6 +599,7 @@ fn refAllDeclsRecursive(comptime T: type) void {
 
 test "every generated shim fully analyzes and links against the ABI" {
     refAllDeclsRecursive(shim_markup);
+    refAllDeclsRecursive(shim_integer);
     refAllDeclsRecursive(shim_host);
     refAllDeclsRecursive(shim_soundboard);
     refAllDeclsRecursive(shim_monitor);

--- a/tests/sidecar/conformance_tests.zig
+++ b/tests/sidecar/conformance_tests.zig
@@ -46,6 +46,7 @@ const ts_markup = @import("ts_markup_core");
 const shim_markup = @import("shim_markup_core");
 const facade_markup = @import("facade_markup_core");
 const shim_integer = @import("shim_integer_core");
+const facade_integer = @import("facade_integer_core");
 const ts_host = @import("ts_host_core");
 const shim_host = @import("shim_host_core");
 const facade_host = @import("facade_host_core");
@@ -558,6 +559,34 @@ test "integer fixture: dispatch payloads encode byte-exactly against hand-comput
         &.{ 4, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00, 2, 0, 0, 0, 'i', 'd' },
         corewire_rt.encodeAlloc(shim_integer.Msg, .{ .sized = .{ .size = 9007199254740991, .label = "id" } }, arena),
     );
+}
+
+test "integer fixture: facade snapshots byte-match the canonical encoder" {
+    // The compiled facade routes u64-attested slots through its
+    // unsigned encoder; both the zero and sample models must land on
+    // the exact bytes the mirror's decoder expects.
+    try expectSnapshotParity(facade_integer, shim_integer);
+}
+
+test "integer fixture: facade channel envelopes carry mixed-class message bytes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    facade_integer.rt.resetAll();
+    defer facade_integer.rt.resetAll();
+
+    // The signed and unsigned arms encode per their own attestations,
+    // byte-identical to the canonical encoding of the mirror value.
+    {
+        const envelope = facade_integer.nsc_core_key_msg(facade_integer.nsc_core_msg_count_set(-42));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_integer.Msg, .{ .count_set = -42 }, arena), envelope[1..]);
+    }
+    {
+        const envelope = facade_integer.nsc_core_key_msg(facade_integer.nsc_core_msg_id_set(9007199254740991));
+        try testing.expectEqual(@as(u8, 1), envelope[0]);
+        try testing.expectEqualSlices(u8, corewire_rt.encodeAlloc(shim_integer.Msg, .{ .id_set = 9007199254740991 }, arena), envelope[1..]);
+    }
 }
 
 test "integer fixture: model snapshots decode per-slot classes from raw bytes" {

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -195,6 +195,69 @@ fn channelParityCycle(
     return .{ .ts = next_ts, .shim = next_shim };
 }
 
+/// One dispatch cycle in both lanes over one message, comparing the
+/// command and snapshot byte surfaces.
+fn parityCycle(
+    arena: std.mem.Allocator,
+    ts_model: *const ts_core.Model,
+    shim_model: *const shim_core.Model,
+    msg: shim_core.Msg,
+) !struct { ts: *const ts_core.Model, shim: *const shim_core.Model } {
+    const ts_msg = try convertValue(ts_core.Msg, msg, arena);
+    const ts_out = ts_core.update(ts_model, ts_msg);
+    const next_ts = ts_core.commitModelRoot(ts_out.model);
+    const shim_out = shim_core.update(shim_model, msg);
+    const next_shim = shim_core.commitModelRoot(shim_out.model);
+    try testing.expectEqualSlices(u8, ts_out.cmd, shim_out.cmd);
+    try testing.expectEqualSlices(u8, try referenceSnapshot(next_ts, arena), rawSnapshot());
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+    return .{ .ts = next_ts, .shim = next_shim };
+}
+
+test "integer-classed slots cross the compiler-provable extremes exactly" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // A fresh boot in both lanes. When the archive rides a
+    // compiler-emitted sidecar with a populated integer_slots section,
+    // this test is the executable proof of the attested classes: the
+    // i64-classed arms carry the +-(2^53 - 1) extremes through a real
+    // dispatch, the archive's snapshot bytes must equal the canonical
+    // encoding of the transpiler lane's model, and the generated
+    // mirror's decode of those bytes must hold the exact integers.
+    ts_core.rt.resetAll();
+    shim_core.rt.resetAll();
+    var ts_model = ts_core.commitModelRoot(ts_core.initialModel());
+    var shim_model = shim_core.commitModelRoot(shim_core.initialModel());
+    ts_core.rt.frameReset();
+    shim_core.rt.frameReset();
+
+    const max_exact: i64 = 9007199254740991; // 2^53 - 1
+    const boundary_script = [_]shim_core.Msg{
+        .{ .canvas_resized = max_exact },
+        .{ .toggle = max_exact },
+        .{ .toggle = -max_exact },
+        .{ .canvas_resized = -max_exact },
+        .{ .canvas_resized = 0 },
+    };
+    for (boundary_script, 0..) |msg, step| {
+        const next = parityCycle(arena, ts_model, shim_model, msg) catch |err| {
+            std.debug.print("integer boundary parity diverges at step {d} ({s})\n", .{ step, @tagName(msg) });
+            return err;
+        };
+        ts_model = next.ts;
+        shim_model = next.shim;
+        // The mirror decoded the committed snapshot: its integer slot
+        // holds the exact crossing value.
+        switch (msg) {
+            .canvas_resized => |value| try testing.expectEqual(value, shim_model.canvasWidth),
+            else => {},
+        }
+    }
+}
+
 test "channel entries match the transpiler lane through the bytes envelope" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -234,15 +234,25 @@ test "integer-classed slots cross the compiler-provable extremes exactly" {
     ts_core.rt.frameReset();
     shim_core.rt.frameReset();
 
-    const max_exact: i64 = 9007199254740991; // 2^53 - 1
-    const boundary_script = [_]shim_core.Msg{
-        .{ .canvas_resized = max_exact },
-        .{ .toggle = max_exact },
-        .{ .toggle = -max_exact },
-        .{ .canvas_resized = -max_exact },
-        .{ .canvas_resized = 0 },
+    // The extremes follow each slot's ATTESTED class in the supplied
+    // sidecar: an i64-classed arm also crosses the negative extreme, a
+    // u64-classed one stays within its unsigned range.
+    const max_exact = 9007199254740991; // 2^53 - 1
+    const boundary_script = comptime blk: {
+        var msgs: []const shim_core.Msg = &.{
+            .{ .canvas_resized = max_exact },
+            .{ .toggle = max_exact },
+        };
+        if (@typeInfo(@FieldType(shim_core.Msg, "toggle")).int.signedness == .signed) {
+            msgs = msgs ++ [_]shim_core.Msg{.{ .toggle = -max_exact }};
+        }
+        if (@typeInfo(@FieldType(shim_core.Msg, "canvas_resized")).int.signedness == .signed) {
+            msgs = msgs ++ [_]shim_core.Msg{.{ .canvas_resized = -max_exact }};
+        }
+        msgs = msgs ++ [_]shim_core.Msg{.{ .canvas_resized = 0 }};
+        break :blk msgs;
     };
-    for (boundary_script, 0..) |msg, step| {
+    inline for (boundary_script, 0..) |msg, step| {
         const next = parityCycle(arena, ts_model, shim_model, msg) catch |err| {
             std.debug.print("integer boundary parity diverges at step {d} ({s})\n", .{ step, @tagName(msg) });
             return err;
@@ -250,9 +260,10 @@ test "integer-classed slots cross the compiler-provable extremes exactly" {
         ts_model = next.ts;
         shim_model = next.shim;
         // The mirror decoded the committed snapshot: its integer slot
-        // holds the exact crossing value.
+        // holds the exact crossing value (compared class-agnostically —
+        // the arm and the field each follow their own attestation).
         switch (msg) {
-            .canvas_resized => |value| try testing.expectEqual(value, shim_model.canvasWidth),
+            .canvas_resized => |value| try testing.expectEqual(@as(i128, value), @as(i128, shim_model.canvasWidth)),
             else => {},
         }
     }

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -234,19 +234,21 @@ test "integer-classed slots cross the compiler-provable extremes exactly" {
     ts_core.rt.frameReset();
     shim_core.rt.frameReset();
 
-    // The extremes follow each slot's ATTESTED class in the supplied
-    // sidecar: an i64-classed arm also crosses the negative extreme, a
-    // u64-classed one stays within its unsigned range.
+    // The extremes follow each slot's class in the supplied sidecar: a
+    // signed slot (i64-attested, or f64 in a sidecar predating integer
+    // attestation) also crosses the negative extreme; a u64-attested
+    // one stays within its unsigned range. Every crossing value sits
+    // within +-(2^53 - 1), so each class carries it exactly.
     const max_exact = 9007199254740991; // 2^53 - 1
     const boundary_script = comptime blk: {
         var msgs: []const shim_core.Msg = &.{
             .{ .canvas_resized = max_exact },
             .{ .toggle = max_exact },
         };
-        if (@typeInfo(@FieldType(shim_core.Msg, "toggle")).int.signedness == .signed) {
+        if (carriesNegatives(@FieldType(shim_core.Msg, "toggle"))) {
             msgs = msgs ++ [_]shim_core.Msg{.{ .toggle = -max_exact }};
         }
-        if (@typeInfo(@FieldType(shim_core.Msg, "canvas_resized")).int.signedness == .signed) {
+        if (carriesNegatives(@FieldType(shim_core.Msg, "canvas_resized"))) {
             msgs = msgs ++ [_]shim_core.Msg{.{ .canvas_resized = -max_exact }};
         }
         msgs = msgs ++ [_]shim_core.Msg{.{ .canvas_resized = 0 }};
@@ -259,14 +261,35 @@ test "integer-classed slots cross the compiler-provable extremes exactly" {
         };
         ts_model = next.ts;
         shim_model = next.shim;
-        // The mirror decoded the committed snapshot: its integer slot
+        // The mirror decoded the committed snapshot: its numeric slot
         // holds the exact crossing value (compared class-agnostically —
-        // the arm and the field each follow their own attestation).
+        // the arm and the field each follow their own class, and every
+        // crossing value is f64-exact).
         switch (msg) {
-            .canvas_resized => |value| try testing.expectEqual(@as(i128, value), @as(i128, shim_model.canvasWidth)),
+            .canvas_resized => |value| try testing.expectEqual(exactValue(value), exactValue(shim_model.canvasWidth)),
             else => {},
         }
     }
+}
+
+/// Whether a mirror slot's class carries negative values: signed
+/// integers and f64 do; the unsigned class does not.
+fn carriesNegatives(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .int => |info| info.signedness == .signed,
+        .float => true,
+        else => @compileError("not a numeric mirror slot: " ++ @typeName(T)),
+    };
+}
+
+/// A class-agnostic exact comparison value: every crossing this suite
+/// drives sits within +-(2^53 - 1), where f64 carries integers exactly.
+fn exactValue(value: anytype) f64 {
+    return switch (@typeInfo(@TypeOf(value))) {
+        .int => @floatFromInt(value),
+        .float => value,
+        else => @compileError("not a numeric mirror slot: " ++ @typeName(@TypeOf(value))),
+    };
 }
 
 test "channel entries match the transpiler lane through the bytes envelope" {

--- a/tests/sidecar/external_core_parity_tests.zig
+++ b/tests/sidecar/external_core_parity_tests.zig
@@ -65,6 +65,17 @@ fn referenceSnapshot(model: *const ts_core.Model, arena: std.mem.Allocator) ![]c
     return corewire_rt.encodeAlloc(shim_core.Model, converted, arena);
 }
 
+/// The selection sample follows the supplied sidecar's classes: a
+/// signed focus keeps the negative-value coverage, an unsigned one
+/// exercises a backward selection (anchor past focus) instead.
+const selection_sample = blk: {
+    const Selection = @FieldType(@FieldType(shim_core.Msg, "draft_edit"), "set_selection");
+    if (carriesNegatives(@FieldType(Selection, "focus"))) {
+        break :blk Selection{ .anchor = 1, .focus = -2 };
+    }
+    break :blk Selection{ .anchor = 3, .focus = 1 };
+};
+
 /// The scripted sequence: every dispatch entry class the fixture's
 /// contract declares — bare arms, i64- and f64-classed numbers, bytes,
 /// the text-input union (each payload family), and the three record
@@ -81,7 +92,7 @@ const script = [_]shim_core.Msg{
     .{ .draft_edit = .{ .insert_text = "hi" } },
     .{ .draft_edit = .delete_backward },
     .{ .draft_edit = .{ .move_caret = .{ .direction = .next_word, .extend = true } } },
-    .{ .draft_edit = .{ .set_selection = .{ .anchor = 1, .focus = -2 } } },
+    .{ .draft_edit = .{ .set_selection = selection_sample } },
     .{ .draft_edit = .{ .set_composition = .{ .text = "ab", .cursor = 1 } } },
     .{ .draft_edit = .{ .set_composition = .{ .text = "", .cursor = null } } },
     .{ .draft_edit = .clear },

--- a/tests/sidecar/integer_fixture.contract.json
+++ b/tests/sidecar/integer_fixture.contract.json
@@ -1,0 +1,66 @@
+{
+  "format": 1,
+  "wire_version": 3,
+  "abi_version": 1,
+  "compiler_version": "0.0.1",
+  "entry": "tests/sidecar/integer_fixture.ts",
+  "source_hash": "5eedc0de00000002",
+  "build_id": "b11d1d0000000002",
+  "types": {
+    "structs": [
+      {"name": "Model", "fields": [
+        {"name": "count", "type": {"kind": "i64"}},
+        {"name": "id", "type": {"kind": "i64"}},
+        {"name": "ratio", "type": {"kind": "f64"}},
+        {"name": "cursor", "type": {"kind": "optional", "inner": {"kind": "i64"}}}
+      ]}
+    ],
+    "enums": [],
+    "unions": []
+  },
+  "model": "Model",
+  "model_helpers": [],
+  "model_unbound": [],
+  "msg": {
+    "name": "Msg",
+    "arms": [
+      {"name": "noop", "payload": {"kind": "void"}},
+      {"name": "count_set", "payload": {"kind": "number", "class": "i64"}},
+      {"name": "id_set", "payload": {"kind": "number", "class": "i64"}},
+      {"name": "ratio_set", "payload": {"kind": "number", "class": "f64"}},
+      {"name": "sized", "payload": {"kind": "number_bytes", "number_field": "size", "number_class": "i64", "bytes_field": "label"}}
+    ],
+    "unbound": []
+  },
+  "init_returns_cmd": false,
+  "update_returns_cmd": true,
+  "has_subscriptions": false,
+  "channels": {
+    "command_msg": false,
+    "frame_msg": false,
+    "key_msg": true,
+    "pinch_msg": false,
+    "appearance_msg": null,
+    "chrome_msg": null,
+    "env_msgs": []
+  },
+  "abi": {
+    "prefix": "nsc_core_",
+    "exports": ["abi_version", "build_id", "set_panic_sink", "init", "collect",
+      "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+      "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+      "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+      "helper_call", "key_msg"],
+    "snapshot_format": 1
+  },
+  "integer_slots": [
+    {"slot": "Model.count", "class": "i64"},
+    {"slot": "Model.id", "class": "u64"},
+    {"slot": "Model.cursor", "class": "u64"},
+    {"slot": "Msg.count_set", "class": "i64"},
+    {"slot": "Msg.id_set", "class": "u64"},
+    {"slot": "Msg.sized.size", "class": "u64"}
+  ],
+  "deterministic": true,
+  "async_free": true
+}

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -12,7 +12,10 @@
 //! tell the two lanes apart:
 //!
 //! - bytes spell `[]const u8`; numbers spell `f64` or `i64` per the
-//!   sidecar's per-slot class; enums are `enum(u8)` with explicit
+//!   sidecar's per-slot class — `u64` where the slot's integer_slots
+//!   attestation refines the i64 spelling to the unsigned class, so the
+//!   decoder reads the slot's 8 wire bytes unsigned; every non-attested
+//!   numeric slot stays f64. Enums are `enum(u8)` with explicit
 //!   declaration-order values; node references spell `*const T`.
 //! - The message union is `union(enum)` in sidecar arm order — the arm
 //!   index IS the wire tag.
@@ -464,6 +467,57 @@ const Emitter = struct {
         });
     }
 
+    // ------------------------------------------- attested integer class
+    //
+    // The sidecar's one integer TypeRef spelling is i64; the matching
+    // integer_slots entry may refine it to the u64 class, and the
+    // mirror must decode what the attestation says (8-byte unsigned LE
+    // instead of two's complement). The reader validates the bijection
+    // before emission ever runs, so a lookup miss here simply means the
+    // slot keeps its i64 spelling.
+
+    fn attestedClass(self: *Emitter, slot: []const u8) ?sidecar_mod.IntegerClass {
+        for (self.sidecar.integer_slots) |entry| {
+            if (std.mem.eql(u8, entry.slot, slot)) return entry.class;
+        }
+        return null;
+    }
+
+    /// The Zig spelling of an i64-spelled slot, per its attestation.
+    fn integerSpelling(self: *Emitter, slot: ?[]const u8) []const u8 {
+        const path = slot orelse return "i64";
+        const class = self.attestedClass(path) orelse return "i64";
+        return @tagName(class);
+    }
+
+    /// The exact-crossing conversion for an integer-classed dispatch
+    /// payload (the scalar entries carry f64): the signed guard or its
+    /// unsigned twin, per the slot's attested class.
+    fn exactCall(self: *Emitter, slot: []const u8, inner: []const u8) Error![]const u8 {
+        const converter = if (self.attestedClass(slot) == .u64) "exactF64Unsigned" else "exactF64";
+        return std.fmt.allocPrint(self.arena, "shim_rt.{s}({s})", .{ converter, inner });
+    }
+
+    /// A slot path in the sidecar's grammar: `<Container>.<member>`.
+    fn slotPath(self: *Emitter, container: []const u8, member: []const u8) Error![]const u8 {
+        return std.fmt.allocPrint(self.arena, "{s}.{s}", .{ container, member });
+    }
+
+    /// A number_bytes arm's number-field slot path:
+    /// `<msgName>.<arm>.<field>`.
+    fn numberBytesSlot(self: *Emitter, arm: []const u8, field: []const u8) Error![]const u8 {
+        return std.fmt.allocPrint(self.arena, "{s}.{s}.{s}", .{ self.sidecar.msg.name, arm, field });
+    }
+
+    /// The Zig spelling of a number descriptor's payload, per class and
+    /// attestation.
+    fn numberSpelling(self: *Emitter, class: sidecar_mod.NumberClass, slot: []const u8) Error![]const u8 {
+        return switch (class) {
+            .f64 => "f64",
+            .i64 => self.integerSpelling(slot),
+        };
+    }
+
     // --------------------------------------------------- mirror types
 
     /// Inline a table entry only when the pattern matches AND the entry
@@ -491,7 +545,7 @@ const Emitter = struct {
             if (nameListed(inlined, entry.name)) continue;
             try self.print("\npub const {f} = struct {{", .{ident(entry.name)});
             for (entry.fields) |field| {
-                try self.print("\n    {f}: {s},", .{ ident(field.name), try self.spellRef(field.type, entry.name, field.name) });
+                try self.print("\n    {f}: {s},", .{ ident(field.name), try self.spellRef(field.type, entry.name, field.name, try self.slotPath(entry.name, field.name)) });
             }
             try self.raw("\n};\n");
         }
@@ -502,7 +556,7 @@ const Emitter = struct {
                 if (arm.payload == .void) {
                     try self.print("\n    {f},", .{ident(arm.name)});
                 } else {
-                    try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.spellRef(arm.payload, entry.name, arm.name) });
+                    try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.spellRef(arm.payload, entry.name, arm.name, try self.slotPath(entry.name, arm.name)) });
                 }
             }
             try self.raw("\n};\n");
@@ -510,16 +564,20 @@ const Emitter = struct {
     }
 
     /// The one TypeRef-to-Zig-spelling authority. `container`/`member`
-    /// name the reference site so synthesized entries inline here.
-    fn spellRef(self: *Emitter, ref: TypeRef, container: []const u8, member: []const u8) Error![]const u8 {
+    /// name the reference site so synthesized entries inline here;
+    /// `slot` is the site's slot path in the sidecar's grammar (null
+    /// where no path form exists), consulted for the attested integer
+    /// class. Slice elements have no slot path — the format-1 grammar
+    /// cannot attest them, so they always keep the i64 spelling.
+    fn spellRef(self: *Emitter, ref: TypeRef, container: []const u8, member: []const u8, slot: ?[]const u8) Error![]const u8 {
         return switch (ref) {
             .bool => "bool",
             .f64 => "f64",
-            .i64 => "i64",
+            .i64 => self.integerSpelling(slot),
             .bytes => "[]const u8",
             .void => "void",
-            .optional => |inner| try std.fmt.allocPrint(self.arena, "?{s}", .{try self.spellRef(inner.*, container, member)}),
-            .slice => |elem| try std.fmt.allocPrint(self.arena, "[]const {s}", .{try self.spellRef(elem.*, container, member)}),
+            .optional => |inner| try std.fmt.allocPrint(self.arena, "?{s}", .{try self.spellRef(inner.*, container, member, slot)}),
+            .slice => |elem| try std.fmt.allocPrint(self.arena, "[]const {s}", .{try self.spellRef(elem.*, container, member, null)}),
             .node => |name| try std.fmt.allocPrint(self.arena, "*const {s}", .{try self.spellNamed(name, container, member)}),
             .value => |name| try self.spellNamed(name, container, member),
             .enum_ref, .union_ref => |name| try std.fmt.allocPrint(self.arena, "{f}", .{ident(name)}),
@@ -536,7 +594,7 @@ const Emitter = struct {
         try text.appendSlice(self.arena, "struct {");
         for (entry.fields, 0..) |field, index| {
             if (index > 0) try text.appendSlice(self.arena, ",");
-            const piece = try std.fmt.allocPrint(self.arena, " {f}: {s}", .{ ident(field.name), try self.spellRef(field.type, entry.name, field.name) });
+            const piece = try std.fmt.allocPrint(self.arena, " {f}: {s}", .{ ident(field.name), try self.spellRef(field.type, entry.name, field.name, try self.slotPath(entry.name, field.name)) });
             try text.appendSlice(self.arena, piece);
         }
         try text.appendSlice(self.arena, " }");
@@ -552,11 +610,11 @@ const Emitter = struct {
         };
         try self.print("\npub const {f} = struct {{", .{ident(model.name)});
         for (model.fields) |field| {
-            try self.print("\n    {f}: {s},", .{ ident(field.name), try self.spellRef(field.type, model.name, field.name) });
+            try self.print("\n    {f}: {s},", .{ ident(field.name), try self.spellRef(field.type, model.name, field.name, try self.slotPath(model.name, field.name)) });
         }
         if (self.sidecar.model_helpers.len > 0) try self.raw("\n");
         for (self.sidecar.model_helpers, 0..) |helper, index| {
-            const returns = try self.spellRef(helper.returns, "helpers", helper.name);
+            const returns = try self.spellRef(helper.returns, "helpers", helper.name, try std.fmt.allocPrint(self.arena, "helpers.{s}.return", .{helper.name}));
             if (helper.arena) {
                 // The build-arena scalar form: the view build hands its
                 // arena; the decoded result lives there.
@@ -575,7 +633,7 @@ const Emitter = struct {
                 var params: std.ArrayListUnmanaged(u8) = .empty;
                 var tuple: std.ArrayListUnmanaged(u8) = .empty;
                 for (helper.params, 0..) |param, param_index| {
-                    const spelled = try self.spellRef(param, "helpers", helper.name);
+                    const spelled = try self.spellRef(param, "helpers", helper.name, try std.fmt.allocPrint(self.arena, "helpers.{s}.params[{d}]", .{ helper.name, param_index }));
                     try params.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, ", p{d}: {s}", .{ param_index, spelled }));
                     if (param_index > 0) try tuple.appendSlice(self.arena, ", ");
                     try tuple.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "p{d}", .{param_index}));
@@ -605,17 +663,17 @@ const Emitter = struct {
             switch (arm.payload) {
                 .void => try self.print("\n    {f},", .{ident(arm.name)}),
                 .bytes => try self.print("\n    {f}: []const u8,", .{ident(arm.name)}),
-                .number => |class| try self.print("\n    {f}: {s},", .{ ident(arm.name), @tagName(class) }),
+                .number => |class| try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.numberSpelling(class, try self.slotPath(self.sidecar.msg.name, arm.name)) }),
                 // The two-field family carries no field-order fact; the
                 // mirror declares the number field first, the emitted
                 // convention of every producer of this shape. A record
                 // declared bytes-first must ride the record family (its
                 // table entry carries order explicitly) — see
                 // SCHEMA-GAPS.md.
-                .number_bytes => |desc| try self.print("\n    {f}: struct {{ {f}: {s}, {f}: []const u8 }},", .{ ident(arm.name), ident(desc.number_field), @tagName(desc.number_class), ident(desc.bytes_field) }),
+                .number_bytes => |desc| try self.print("\n    {f}: struct {{ {f}: {s}, {f}: []const u8 }},", .{ ident(arm.name), ident(desc.number_field), try self.numberSpelling(desc.number_class, try self.numberBytesSlot(arm.name, desc.number_field)), ident(desc.bytes_field) }),
                 .record => |name| try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.spellNamed(name, self.sidecar.msg.name, arm.name) }),
                 .union_ref, .enum_ref => |name| try self.print("\n    {f}: {f},", .{ ident(arm.name), ident(name) }),
-                .scalar => |ref| try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.spellRef(ref, self.sidecar.msg.name, arm.name) }),
+                .scalar => |ref| try self.print("\n    {f}: {s},", .{ ident(arm.name), try self.spellRef(ref, self.sidecar.msg.name, arm.name, try self.slotPath(self.sidecar.msg.name, arm.name)) }),
             }
         }
         try self.unboundDecl(self.sidecar.msg.unbound);
@@ -798,12 +856,12 @@ const Emitter = struct {
             .bytes => try self.print("        .{s} => |payload| abi.dispatch_bytes({d}, payload.ptr, payload.len, &cmd_ptr, &cmd_len),\n", .{ name, tag }),
             .number => |class| switch (class) {
                 .f64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, payload, &cmd_ptr, &cmd_len),\n", .{ name, tag }),
-                .i64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, shim_rt.exactF64(payload), &cmd_ptr, &cmd_len),\n", .{ name, tag }),
+                .i64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, {s}, &cmd_ptr, &cmd_len),\n", .{ name, tag, try self.exactCall(try self.slotPath(self.sidecar.msg.name, arm.name), "payload") }),
             },
             .number_bytes => |desc| {
                 const number_expr = switch (desc.number_class) {
                     .f64 => try std.fmt.allocPrint(self.arena, "payload.{f}", .{ident(desc.number_field)}),
-                    .i64 => try std.fmt.allocPrint(self.arena, "shim_rt.exactF64(payload.{f})", .{ident(desc.number_field)}),
+                    .i64 => try self.exactCall(try self.numberBytesSlot(arm.name, desc.number_field), try std.fmt.allocPrint(self.arena, "payload.{f}", .{ident(desc.number_field)})),
                 };
                 try self.print("        .{s} => |payload| abi.dispatch_number_bytes({d}, {s}, payload.{f}.ptr, payload.{f}.len, &cmd_ptr, &cmd_len),\n", .{ name, tag, number_expr, ident(desc.bytes_field), ident(desc.bytes_field) });
             },
@@ -822,7 +880,7 @@ const Emitter = struct {
                         if (index > 0) try scalars.appendSlice(self.arena, ", ");
                         const record = sidecar_mod.findStruct(self.sidecar.types, type_name).?;
                         const expr = switch (record.fields[field].type) {
-                            .i64 => try std.fmt.allocPrint(self.arena, "shim_rt.exactF64(payload.{f})", .{ident(record.fields[field].name)}),
+                            .i64 => try self.exactCall(try self.slotPath(type_name, record.fields[field].name), try std.fmt.allocPrint(self.arena, "payload.{f}", .{ident(record.fields[field].name)})),
                             else => try std.fmt.allocPrint(self.arena, "payload.{f}", .{ident(record.fields[field].name)}),
                         };
                         try scalars.appendSlice(self.arena, expr);
@@ -835,7 +893,7 @@ const Emitter = struct {
             .scalar => |ref| switch (ref) {
                 .bool => try self.print("        .{s} => |payload| abi.dispatch_bool({d}, @intFromBool(payload), &cmd_ptr, &cmd_len),\n", .{ name, tag }),
                 .f64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, payload, &cmd_ptr, &cmd_len),\n", .{ name, tag }),
-                .i64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, shim_rt.exactF64(payload), &cmd_ptr, &cmd_len),\n", .{ name, tag }),
+                .i64 => try self.print("        .{s} => |payload| abi.dispatch_number({d}, {s}, &cmd_ptr, &cmd_len),\n", .{ name, tag, try self.exactCall(try self.slotPath(self.sidecar.msg.name, arm.name), "payload") }),
                 .bytes => try self.print("        .{s} => |payload| abi.dispatch_bytes({d}, payload.ptr, payload.len, &cmd_ptr, &cmd_len),\n", .{ name, tag }),
                 else => self.diags.flag("msg.arms", "arm \"{s}\": ABI version 1 has no dispatch entry for this scalar shape (bool, number, and bytes scalars only)", .{arm.name}),
             },
@@ -1387,6 +1445,87 @@ test "emission is deterministic and carries the mirror surface" {
     // A bare-model init emits the pointer-returning shape.
     try testing.expect(std.mem.indexOf(u8, first, "pub fn initialModel() *const Model {") != null);
     try testing.expect(std.mem.indexOf(u8, first, "pub const UpdateResult = struct { model: *const Model, cmd: rt.Cmd };") != null);
+}
+
+test "u64-attested slots generate the unsigned twin; i64 and f64 slots are untouched" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // Every slot-path form the grammar can attest, classes mixed: the
+    // attested class decides the mirror's decode width per slot, and
+    // nothing leaks across slots.
+    var source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        sidecar_mod.minimal_valid_json,
+        "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}}",
+        "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}},\n        {\"name\": \"delta\", \"type\": {\"kind\": \"i64\"}},\n        {\"name\": \"ratio\", \"type\": {\"kind\": \"f64\"}}",
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"tick\", \"payload\": {\"kind\": \"number\", \"class\": \"i64\"}},\n      {\"name\": \"stepped\", \"payload\": {\"kind\": \"number\", \"class\": \"i64\"}},\n      {\"name\": \"fetched\", \"payload\": {\"kind\": \"number_bytes\", \"number_field\": \"status\", \"number_class\": \"i64\", \"bytes_field\": \"body\"}}",
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "\"model_helpers\": []",
+        "\"model_helpers\": [{\"name\": \"peak\", \"params\": [], \"returns\": {\"kind\": \"i64\"}, \"arena\": false}]",
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        \\{"slot": "Model.count", "class": "u64"},
+        \\    {"slot": "Model.delta", "class": "i64"},
+        \\    {"slot": "Msg.tick", "class": "u64"},
+        \\    {"slot": "Msg.stepped", "class": "i64"},
+        \\    {"slot": "Msg.fetched.status", "class": "u64"},
+        \\    {"slot": "helpers.peak.return", "class": "u64"}
+        ,
+    );
+    const generated = try emitFromJson(arena, source);
+    // Mirror spellings follow the attestation, slot by slot.
+    try testing.expect(std.mem.indexOf(u8, generated, "count: u64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "delta: i64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "ratio: f64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "tick: u64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "stepped: i64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "fetched: struct { status: u64, body: []const u8 },") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "pub fn peak(self: *const Model) u64 {") != null);
+    // Dispatch narrows through the matching exactness guard.
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_number(0, shim_rt.exactF64Unsigned(payload), &cmd_ptr, &cmd_len)") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_number(1, shim_rt.exactF64(payload), &cmd_ptr, &cmd_len)") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_number_bytes(2, shim_rt.exactF64Unsigned(payload.status), payload.body.ptr, payload.body.len, &cmd_ptr, &cmd_len)") != null);
+    // The generated module stays valid Zig.
+    const source_z = try arena.dupeZ(u8, generated);
+    const tree = try std.zig.Ast.parse(arena, source_z, .zig);
+    try testing.expectEqual(@as(usize, 0), tree.errors.len);
+}
+
+test "the empty integer_slots list decodes nothing differently" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The f64-only sequencing: every numeric slot spelled f64, the
+    // empty list attested — the mirror carries f64 slots and no
+    // integer narrowing anywhere.
+    var source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}}", "{\"name\": \"count\", \"type\": {\"kind\": \"f64\"}}");
+    source = try std.mem.replaceOwned(u8, arena, source, "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}", "{\"name\": \"picked\", \"payload\": {\"kind\": \"number\", \"class\": \"f64\"}}");
+    source = try std.mem.replaceOwned(u8, arena, source, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "");
+    const generated = try emitFromJson(arena, source);
+    try testing.expect(std.mem.indexOf(u8, generated, "count: f64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "picked: f64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_number(0, payload, &cmd_ptr, &cmd_len)") != null);
+    // No integer narrowing and no integer-spelled mirror slot anywhere
+    // (the identity constants' own u64 plumbing is not a mirror slot).
+    try testing.expect(std.mem.indexOf(u8, generated, "exactF64") == null);
+    try testing.expect(std.mem.indexOf(u8, generated, ": i64,") == null);
+    try testing.expect(std.mem.indexOf(u8, generated, ": u64,") == null);
 }
 
 test "the emitted shim parses as Zig" {

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -521,14 +521,17 @@ const Emitter = struct {
 
     // ------------------------------------ host-supplied signed slots
     //
-    // Some structural vocabularies are filled by the HOST with values
-    // that go negative: scroll offsets and velocities during
-    // rubber-banding and upward flicks, and window-chrome geometry in
-    // signed content coordinates. A u64 attestation on such a slot
-    // could never carry those values — the generated wiring would trap
-    // converting them — so the checker refuses the attestation at tool
-    // time instead. Extents (viewport, content) and selection bounds
-    // stay attestable: the host only ever supplies them non-negative.
+    // Two structural vocabularies carry slots the HOST fills with
+    // values that go negative: a scroll arm's offsets and velocities
+    // (rubber-banding, upward flicks) and the window-control cluster's
+    // position (signed content coordinates). A u64 attestation on such
+    // a slot could never carry those values — the generated wiring
+    // would trap converting them — so the checker refuses the
+    // attestation at tool time instead. Everything the host supplies
+    // non-negative stays attestable: scroll extents, selection bounds,
+    // chrome insets and cluster sizes — and a scroll-shaped record the
+    // host never dispatches into (a model-only metrics record) is not
+    // this rule's business at all.
 
     /// The scroll-state axes the host supplies signed, in both
     /// spellings (the TS mirror's and the canvas core's).
@@ -538,8 +541,15 @@ const Emitter = struct {
     };
 
     fn validateIntegerAttestations(self: *Emitter) Error!void {
-        for (self.sidecar.types.structs) |entry| {
-            if (self.scrollStateFields(entry.name) == null) continue;
+        // Only records a message arm routes through the scroll entry
+        // receive host scroll values.
+        for (self.sidecar.msg.arms) |arm| {
+            const record_name = switch (arm.payload) {
+                .record => |name| name,
+                else => continue,
+            };
+            if (self.scrollStateFields(record_name) == null) continue;
+            const entry = sidecar_mod.findStruct(self.sidecar.types, record_name) orelse continue;
             for (entry.fields) |field| {
                 if (field.type != .i64) continue;
                 if (!nameListed(&signed_scroll_axes, field.name)) continue;
@@ -552,12 +562,16 @@ const Emitter = struct {
         if (self.sidecar.channels.chrome_msg) |arm_name| {
             if (self.channelArmRecord(arm_name)) |record| {
                 for (record.fields) |field| {
+                    // Insets and cluster sizes are non-negative overlay
+                    // extents; only the cluster's position is signed.
+                    if (!std.mem.eql(u8, field.name, "buttons")) continue;
                     const nested = self.recordOf(field.type) orelse continue;
                     for (nested.fields) |geometry| {
                         if (geometry.type != .i64) continue;
+                        if (!std.mem.eql(u8, geometry.name, "x") and !std.mem.eql(u8, geometry.name, "y")) continue;
                         const slot = try self.slotPath(nested.name, geometry.name);
                         if (self.attestedClass(slot) == .u64) {
-                            self.diags.flag("integer_slots", "\"{s}\" is window-chrome geometry, and embedders report signed content coordinates — the u64 class cannot carry them; keep chrome geometry i64 or f64", .{slot});
+                            self.diags.flag("integer_slots", "\"{s}\" is the window-control cluster's position, reported in signed content coordinates — the u64 class cannot carry it; keep buttons x and y i64 or f64", .{slot});
                         }
                     }
                 }
@@ -1609,6 +1623,26 @@ test "u64 attestations on host-supplied signed slots refuse at check time" {
     extent_source = try std.mem.replaceOwned(u8, arena, extent_source, "{\"slot\": \"Scroll.offsetY\", \"class\": \"u64\"}", "{\"slot\": \"Scroll.viewportExtentY\", \"class\": \"u64\"}");
     const extent_generated = try emitFromJson(arena, extent_source);
     try testing.expect(std.mem.indexOf(u8, extent_generated, "shim_rt.exactF64Unsigned(payload.viewportExtentY)") != null);
+
+    // A scroll-shaped record no message arm routes is not scroll state
+    // to the host: a model-only metrics record keeps its unsigned
+    // attestation even on an axis-named field.
+    var model_only = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}},\n      {\"name\": \"scrolled\", \"payload\": {\"kind\": \"record\", \"name\": \"Scroll\"}}",
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+    );
+    model_only = try std.mem.replaceOwned(
+        u8,
+        arena,
+        model_only,
+        "{\"name\": \"label\", \"type\": {\"kind\": \"bytes\"}}",
+        "{\"name\": \"label\", \"type\": {\"kind\": \"bytes\"}}, {\"name\": \"metrics\", \"type\": {\"kind\": \"value\", \"name\": \"Scroll\"}}",
+    );
+    const model_only_generated = try emitFromJson(arena, model_only);
+    try testing.expect(std.mem.indexOf(u8, model_only_generated, "offsetY: u64,") != null);
 }
 
 test "a u64 attestation on chrome geometry refuses at check time" {
@@ -1663,9 +1697,20 @@ test "a u64 attestation on chrome geometry refuses at check time" {
     try testing.expectError(error.Refused, emit(arena, parsed, &diags));
     var found = false;
     for (diags.list.items) |item| {
-        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "window-chrome geometry") != null) found = true;
+        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "window-control cluster's position") != null) found = true;
     }
     try testing.expect(found);
+
+    // Insets and cluster sizes are non-negative overlay extents: the
+    // unsigned class carries them.
+    var arena_state2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state2.deinit();
+    const arena2 = arena_state2.allocator();
+    var extents = try std.mem.replaceOwned(u8, arena2, source, "{\"name\": \"x\", \"type\": {\"kind\": \"i64\"}}", "{\"name\": \"x\", \"type\": {\"kind\": \"f64\"}}");
+    extents = try std.mem.replaceOwned(u8, arena2, extents, "{\"name\": \"top\", \"type\": {\"kind\": \"f64\"}}", "{\"name\": \"top\", \"type\": {\"kind\": \"i64\"}}");
+    extents = try std.mem.replaceOwned(u8, arena2, extents, "{\"slot\": \"Buttons.x\", \"class\": \"u64\"}", "{\"slot\": \"Insets.top\", \"class\": \"u64\"}");
+    const generated = try emitFromJson(arena2, extents);
+    try testing.expect(std.mem.indexOf(u8, generated, "top: u64,") != null);
 }
 
 test "u64 attestations on selection bounds are accepted (the host supplies unsigned offsets)" {

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -522,34 +522,43 @@ const Emitter = struct {
     // ------------------------------------ host-supplied signed slots
     //
     // Some structural vocabularies are filled by the HOST with values
-    // that go negative: scroll axes during rubber-banding and upward
-    // flicks (offsets, velocities), and selection bounds during
-    // backward selections. A u64 attestation on such a slot could
-    // never carry those values — the generated wiring would trap
+    // that go negative: scroll offsets and velocities during
+    // rubber-banding and upward flicks, and window-chrome geometry in
+    // signed content coordinates. A u64 attestation on such a slot
+    // could never carry those values — the generated wiring would trap
     // converting them — so the checker refuses the attestation at tool
-    // time instead.
+    // time instead. Extents (viewport, content) and selection bounds
+    // stay attestable: the host only ever supplies them non-negative.
+
+    /// The scroll-state axes the host supplies signed, in both
+    /// spellings (the TS mirror's and the canvas core's).
+    const signed_scroll_axes = [_][]const u8{
+        "offsetX",  "offsetY",  "velocityX",  "velocityY",
+        "offset_x", "offset_y", "velocity_x", "velocity_y",
+    };
 
     fn validateIntegerAttestations(self: *Emitter) Error!void {
         for (self.sidecar.types.structs) |entry| {
             if (self.scrollStateFields(entry.name) == null) continue;
             for (entry.fields) |field| {
                 if (field.type != .i64) continue;
+                if (!nameListed(&signed_scroll_axes, field.name)) continue;
                 const slot = try self.slotPath(entry.name, field.name);
                 if (self.attestedClass(slot) == .u64) {
-                    self.diags.flag("integer_slots", "\"{s}\" is a scroll-state axis, and scroll translation supplies signed values (offsets and velocities go negative) — the u64 class cannot carry them; keep scroll-state fields i64 or f64", .{slot});
+                    self.diags.flag("integer_slots", "\"{s}\" is a signed scroll-state axis (offsets and velocities go negative during rubber-banding and upward flicks) — the u64 class cannot carry those values; keep offset and velocity fields i64 or f64", .{slot});
                 }
             }
         }
-        for (self.sidecar.types.unions) |entry| {
-            if (!self.isTextInputUnion(entry.name)) continue;
-            for (entry.arms) |arm| {
-                if (!std.mem.eql(u8, arm.name, "set_selection")) continue;
-                const record = self.recordOf(arm.payload) orelse continue;
+        if (self.sidecar.channels.chrome_msg) |arm_name| {
+            if (self.channelArmRecord(arm_name)) |record| {
                 for (record.fields) |field| {
-                    if (field.type != .i64) continue;
-                    const slot = try self.slotPath(record.name, field.name);
-                    if (self.attestedClass(slot) == .u64) {
-                        self.diags.flag("integer_slots", "\"{s}\" is a text-selection bound, and backward selections carry signed values — the u64 class cannot carry them; keep selection fields i64 or f64", .{slot});
+                    const nested = self.recordOf(field.type) orelse continue;
+                    for (nested.fields) |geometry| {
+                        if (geometry.type != .i64) continue;
+                        const slot = try self.slotPath(nested.name, geometry.name);
+                        if (self.attestedClass(slot) == .u64) {
+                            self.diags.flag("integer_slots", "\"{s}\" is window-chrome geometry, and embedders report signed content coordinates — the u64 class cannot carry them; keep chrome geometry i64 or f64", .{slot});
+                        }
                     }
                 }
             }
@@ -1592,14 +1601,81 @@ test "u64 attestations on host-supplied signed slots refuse at check time" {
     const signed = try std.mem.replaceOwned(u8, arena, source, "{\"slot\": \"Scroll.offsetY\", \"class\": \"u64\"}", "{\"slot\": \"Scroll.offsetY\", \"class\": \"i64\"}");
     const generated = try emitFromJson(arena, signed);
     try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_scroll_state(1,") != null);
+
+    // Extents stay attestable: the host only ever supplies viewport and
+    // content sizes non-negative, so the unsigned class carries them.
+    var extent_source = try std.mem.replaceOwned(u8, arena, source, "{\"name\": \"offsetY\", \"type\": {\"kind\": \"i64\"}}", "{\"name\": \"offsetY\", \"type\": {\"kind\": \"f64\"}}");
+    extent_source = try std.mem.replaceOwned(u8, arena, extent_source, "{\"name\": \"viewportExtentY\", \"type\": {\"kind\": \"f64\"}}", "{\"name\": \"viewportExtentY\", \"type\": {\"kind\": \"i64\"}}");
+    extent_source = try std.mem.replaceOwned(u8, arena, extent_source, "{\"slot\": \"Scroll.offsetY\", \"class\": \"u64\"}", "{\"slot\": \"Scroll.viewportExtentY\", \"class\": \"u64\"}");
+    const extent_generated = try emitFromJson(arena, extent_source);
+    try testing.expect(std.mem.indexOf(u8, extent_generated, "shim_rt.exactF64Unsigned(payload.viewportExtentY)") != null);
 }
 
-test "a u64 attestation on a selection bound refuses at check time" {
+test "a u64 attestation on chrome geometry refuses at check time" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A wired chrome arm whose buttons record attests x as u64:
+    // embedders report signed content coordinates, which the unsigned
+    // class cannot carry.
+    const source =
+        \\{
+        \\  "format": 1, "wire_version": 3, "abi_version": 1,
+        \\  "compiler_version": "0.0.1", "entry": "src/core.ts",
+        \\  "source_hash": "00000000c0ffee00", "build_id": "00000000b01dface",
+        \\  "types": {
+        \\    "structs": [
+        \\      {"name": "Model", "fields": [{"name": "chromeTop", "type": {"kind": "f64"}}]},
+        \\      {"name": "Insets", "fields": [
+        \\        {"name": "top", "type": {"kind": "f64"}}, {"name": "right", "type": {"kind": "f64"}},
+        \\        {"name": "bottom", "type": {"kind": "f64"}}, {"name": "left", "type": {"kind": "f64"}}
+        \\      ]},
+        \\      {"name": "Buttons", "fields": [
+        \\        {"name": "x", "type": {"kind": "i64"}}, {"name": "y", "type": {"kind": "f64"}},
+        \\        {"name": "width", "type": {"kind": "f64"}}, {"name": "height", "type": {"kind": "f64"}}
+        \\      ]},
+        \\      {"name": "Msg_chrome_changed", "fields": [
+        \\        {"name": "insets", "type": {"kind": "value", "name": "Insets"}},
+        \\        {"name": "buttons", "type": {"kind": "value", "name": "Buttons"}},
+        \\        {"name": "tabsProjected", "type": {"kind": "bool"}}
+        \\      ]}
+        \\    ],
+        \\    "enums": [], "unions": []
+        \\  },
+        \\  "model": "Model", "model_helpers": [], "model_unbound": [],
+        \\  "msg": {"name": "Msg", "arms": [
+        \\    {"name": "chrome_changed", "payload": {"kind": "record", "name": "Msg_chrome_changed"}}
+        \\  ], "unbound": []},
+        \\  "init_returns_cmd": false, "update_returns_cmd": true, "has_subscriptions": false,
+        \\  "channels": {"command_msg": false, "frame_msg": false, "key_msg": false, "pinch_msg": false,
+        \\    "appearance_msg": null, "chrome_msg": "chrome_changed", "env_msgs": []},
+        \\  "abi": {"prefix": "nsc_core_", "exports": ["abi_version", "build_id", "set_panic_sink", "init",
+        \\    "collect", "frame_reset", "boot_cmd", "dispatch_void", "dispatch_bytes", "dispatch_number",
+        \\    "dispatch_number_bytes", "dispatch_bool", "dispatch_enum", "dispatch_record",
+        \\    "dispatch_text_input", "dispatch_scroll_state", "subscriptions", "model_snapshot",
+        \\    "helper_call"], "snapshot_format": 1},
+        \\  "integer_slots": [{"slot": "Buttons.x", "class": "u64"}],
+        \\  "deterministic": true, "async_free": true
+        \\}
+    ;
+    var diags = sidecar_mod.Diagnostics{ .arena = arena };
+    const parsed = try sidecar_mod.read(arena, source, &diags);
+    try testing.expectError(error.Refused, emit(arena, parsed, &diags));
+    var found = false;
+    for (diags.list.items) |item| {
+        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "window-chrome geometry") != null) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "u64 attestations on selection bounds are accepted (the host supplies unsigned offsets)" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     // The full text-input vocabulary with a u64-attested selection
-    // anchor: backward selections carry signed bounds.
+    // anchor: the engine's selection bounds are unsigned offsets (a
+    // backward selection is anchor > focus, never a negative index), so
+    // the unsigned class carries every host-supplied value.
     const records =
         \\      {"name": "Move", "fields": [
         \\        {"name": "direction", "type": {"kind": "enum", "name": "Dir"}},
@@ -1644,16 +1720,15 @@ test "a u64 attestation on a selection bound refuses at check time" {
         arena,
         source,
         "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
-        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Sel.anchor\", \"class\": \"u64\"}, {\"slot\": \"Sel.focus\", \"class\": \"i64\"}, {\"slot\": \"Comp.cursor\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Sel.anchor\", \"class\": \"u64\"}, {\"slot\": \"Sel.focus\", \"class\": \"u64\"}, {\"slot\": \"Comp.cursor\", \"class\": \"u64\"}",
     );
-    var diags = sidecar_mod.Diagnostics{ .arena = arena };
-    const parsed = try sidecar_mod.read(arena, source, &diags);
-    try testing.expectError(error.Refused, emit(arena, parsed, &diags));
-    var found = false;
-    for (diags.list.items) |item| {
-        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "text-selection bound") != null) found = true;
-    }
-    try testing.expect(found);
+    const generated = try emitFromJson(arena, source);
+    // The mirror spells the attested classes and the union still routes
+    // through the text-input entry (recognition is spelling-level).
+    try testing.expect(std.mem.indexOf(u8, generated, "anchor: u64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "focus: u64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "cursor: ?u64,") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_text_input(0,") != null);
 }
 
 test "the empty integer_slots list decodes nothing differently" {

--- a/tools/corewire/emit.zig
+++ b/tools/corewire/emit.zig
@@ -112,6 +112,7 @@ const Emitter = struct {
         try self.validateEmissionNames();
         self.validateChannelShapes();
         try self.validateArmStorage();
+        try self.validateIntegerAttestations();
         if (self.diags.hasErrors()) return;
         self.inlined = try self.inlinedNames();
         try self.header();
@@ -516,6 +517,43 @@ const Emitter = struct {
             .f64 => "f64",
             .i64 => self.integerSpelling(slot),
         };
+    }
+
+    // ------------------------------------ host-supplied signed slots
+    //
+    // Some structural vocabularies are filled by the HOST with values
+    // that go negative: scroll axes during rubber-banding and upward
+    // flicks (offsets, velocities), and selection bounds during
+    // backward selections. A u64 attestation on such a slot could
+    // never carry those values — the generated wiring would trap
+    // converting them — so the checker refuses the attestation at tool
+    // time instead.
+
+    fn validateIntegerAttestations(self: *Emitter) Error!void {
+        for (self.sidecar.types.structs) |entry| {
+            if (self.scrollStateFields(entry.name) == null) continue;
+            for (entry.fields) |field| {
+                if (field.type != .i64) continue;
+                const slot = try self.slotPath(entry.name, field.name);
+                if (self.attestedClass(slot) == .u64) {
+                    self.diags.flag("integer_slots", "\"{s}\" is a scroll-state axis, and scroll translation supplies signed values (offsets and velocities go negative) — the u64 class cannot carry them; keep scroll-state fields i64 or f64", .{slot});
+                }
+            }
+        }
+        for (self.sidecar.types.unions) |entry| {
+            if (!self.isTextInputUnion(entry.name)) continue;
+            for (entry.arms) |arm| {
+                if (!std.mem.eql(u8, arm.name, "set_selection")) continue;
+                const record = self.recordOf(arm.payload) orelse continue;
+                for (record.fields) |field| {
+                    if (field.type != .i64) continue;
+                    const slot = try self.slotPath(record.name, field.name);
+                    if (self.attestedClass(slot) == .u64) {
+                        self.diags.flag("integer_slots", "\"{s}\" is a text-selection bound, and backward selections carry signed values — the u64 class cannot carry them; keep selection fields i64 or f64", .{slot});
+                    }
+                }
+            }
+        }
     }
 
     // --------------------------------------------------- mirror types
@@ -1505,6 +1543,117 @@ test "u64-attested slots generate the unsigned twin; i64 and f64 slots are untou
     const source_z = try arena.dupeZ(u8, generated);
     const tree = try std.zig.Ast.parse(arena, source_z, .zig);
     try testing.expectEqual(@as(usize, 0), tree.errors.len);
+}
+
+test "u64 attestations on host-supplied signed slots refuse at check time" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A scroll-state record with a u64-attested axis: scroll translation
+    // supplies negative offsets and velocities, which the unsigned class
+    // cannot carry — refused before any wiring generates.
+    const scroll_struct =
+        \\      {"name": "Scroll", "fields": [
+        \\        {"name": "offsetX", "type": {"kind": "f64"}},
+        \\        {"name": "offsetY", "type": {"kind": "i64"}},
+        \\        {"name": "velocityX", "type": {"kind": "f64"}},
+        \\        {"name": "velocityY", "type": {"kind": "f64"}},
+        \\        {"name": "viewportExtentX", "type": {"kind": "f64"}},
+        \\        {"name": "viewportExtentY", "type": {"kind": "f64"}},
+        \\        {"name": "contentExtentX", "type": {"kind": "f64"}},
+        \\        {"name": "contentExtentY", "type": {"kind": "f64"}}
+        \\      ]},
+    ;
+    var source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        sidecar_mod.minimal_valid_json,
+        "\"structs\": [\n",
+        try std.fmt.allocPrint(arena, "\"structs\": [\n{s}\n", .{scroll_struct}),
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}},\n      {\"name\": \"scrolled\", \"payload\": {\"kind\": \"record\", \"name\": \"Scroll\"}}",
+    );
+    source = try std.mem.replaceOwned(u8, arena, source, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Scroll.offsetY\", \"class\": \"u64\"}");
+    var diags = sidecar_mod.Diagnostics{ .arena = arena };
+    const parsed = try sidecar_mod.read(arena, source, &diags);
+    try testing.expectError(error.Refused, emit(arena, parsed, &diags));
+    var found = false;
+    for (diags.list.items) |item| {
+        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "scroll-state axis") != null) found = true;
+    }
+    try testing.expect(found);
+    // The same record i64-attested generates: only the unsigned class
+    // is incoherent with the host's signed values.
+    const signed = try std.mem.replaceOwned(u8, arena, source, "{\"slot\": \"Scroll.offsetY\", \"class\": \"u64\"}", "{\"slot\": \"Scroll.offsetY\", \"class\": \"i64\"}");
+    const generated = try emitFromJson(arena, signed);
+    try testing.expect(std.mem.indexOf(u8, generated, "abi.dispatch_scroll_state(1,") != null);
+}
+
+test "a u64 attestation on a selection bound refuses at check time" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The full text-input vocabulary with a u64-attested selection
+    // anchor: backward selections carry signed bounds.
+    const records =
+        \\      {"name": "Move", "fields": [
+        \\        {"name": "direction", "type": {"kind": "enum", "name": "Dir"}},
+        \\        {"name": "extend", "type": {"kind": "bool"}}
+        \\      ]},
+        \\      {"name": "Sel", "fields": [
+        \\        {"name": "anchor", "type": {"kind": "i64"}},
+        \\        {"name": "focus", "type": {"kind": "i64"}}
+        \\      ]},
+        \\      {"name": "Comp", "fields": [
+        \\        {"name": "text", "type": {"kind": "bytes"}},
+        \\        {"name": "cursor", "type": {"kind": "optional", "inner": {"kind": "i64"}}}
+        \\      ]},
+    ;
+    const union_entry =
+        \\"unions": [{"name": "Edit", "arms": [
+        \\      {"name": "insert_text", "payload": {"kind": "bytes"}},
+        \\      {"name": "delete_backward", "payload": {"kind": "void"}},
+        \\      {"name": "delete_forward", "payload": {"kind": "void"}},
+        \\      {"name": "delete_word_backward", "payload": {"kind": "void"}},
+        \\      {"name": "delete_word_forward", "payload": {"kind": "void"}},
+        \\      {"name": "clear", "payload": {"kind": "void"}},
+        \\      {"name": "move_caret", "payload": {"kind": "value", "name": "Move"}},
+        \\      {"name": "set_selection", "payload": {"kind": "value", "name": "Sel"}},
+        \\      {"name": "set_composition", "payload": {"kind": "value", "name": "Comp"}},
+        \\      {"name": "commit_composition", "payload": {"kind": "void"}},
+        \\      {"name": "cancel_composition", "payload": {"kind": "void"}}
+        \\    ]}]
+    ;
+    var source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, "\"structs\": [\n", try std.fmt.allocPrint(arena, "\"structs\": [\n{s}\n", .{records}));
+    source = try std.mem.replaceOwned(u8, arena, source, "\"enums\": []", "\"enums\": [{\"name\": \"Dir\", \"members\": [\"previous\", \"next\", \"previous_word\", \"next_word\", \"start\", \"end\"]}]");
+    source = try std.mem.replaceOwned(u8, arena, source, "\"unions\": []", union_entry);
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"edited\", \"payload\": {\"kind\": \"union\", \"name\": \"Edit\"}}",
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Sel.anchor\", \"class\": \"u64\"}, {\"slot\": \"Sel.focus\", \"class\": \"i64\"}, {\"slot\": \"Comp.cursor\", \"class\": \"i64\"}",
+    );
+    var diags = sidecar_mod.Diagnostics{ .arena = arena };
+    const parsed = try sidecar_mod.read(arena, source, &diags);
+    try testing.expectError(error.Refused, emit(arena, parsed, &diags));
+    var found = false;
+    for (diags.list.items) |item| {
+        if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, "text-selection bound") != null) found = true;
+    }
+    try testing.expect(found);
 }
 
 test "the empty integer_slots list decodes nothing differently" {

--- a/tools/corewire/emit_facade.zig
+++ b/tools/corewire/emit_facade.zig
@@ -471,6 +471,31 @@ const FacadeEmitter = struct {
         }
     }
 
+    /// Whether the slot at `slot` carries a u64 attestation: the
+    /// unsigned class picks the unsigned encoder, so a negative value
+    /// refuses instead of silently encoding bytes the mirror would read
+    /// as a huge unsigned value. Slice elements pass null — the
+    /// format-1 grammar cannot attest them.
+    fn attestedU64(self: *FacadeEmitter, slot: ?[]const u8) bool {
+        const path = slot orelse return false;
+        for (self.sidecar.integer_slots) |entry| {
+            if (entry.class == .u64 and std.mem.eql(u8, entry.slot, path)) return true;
+        }
+        return false;
+    }
+
+    fn anyU64(self: *FacadeEmitter) bool {
+        for (self.sidecar.integer_slots) |entry| {
+            if (entry.class == .u64) return true;
+        }
+        return false;
+    }
+
+    /// A slot path in the sidecar's grammar: `<Container>.<member>`.
+    fn slotOf(self: *FacadeEmitter, container: []const u8, member: []const u8) Error![]const u8 {
+        return std.fmt.allocPrint(self.arena, "{s}.{s}", .{ container, member });
+    }
+
     /// The one TypeRef-to-TypeScript-spelling authority (the facade twin
     /// of the Zig mirror's spellRef).
     fn spellRef(self: *FacadeEmitter, ref: TypeRef, container: []const u8, member: []const u8) Error![]const u8 {
@@ -561,7 +586,7 @@ const FacadeEmitter = struct {
         // them in (FACADE-GAPS records the subset rules that keep the
         // forwarders out of this module today).
         var zero = std.ArrayListUnmanaged(u8).empty;
-        try self.zeroValue(&zero, .{ .value = self.sidecar.model }, 1);
+        try self.zeroValue(&zero, .{ .value = self.sidecar.model }, 1, null);
         try self.print(
             \\
             \\export function initialModel(): Model {{
@@ -637,7 +662,7 @@ const FacadeEmitter = struct {
     fn sampleBuilders(self: *FacadeEmitter) Error!void {
         var sample = std.ArrayListUnmanaged(u8).empty;
         self.sample_ordinal = 0;
-        try self.sampleValue(&sample, .{ .value = self.sidecar.model }, 1);
+        try self.sampleValue(&sample, .{ .value = self.sidecar.model }, 1, null);
         try self.print(
             \\
             \\/// A deterministic, non-trivial model value (every field populated,
@@ -657,7 +682,8 @@ const FacadeEmitter = struct {
         return text;
     }
 
-    fn zeroValue(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize) Error!void {
+    fn zeroValue(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize, slot: ?[]const u8) Error!void {
+        _ = slot;
         switch (ref) {
             .bool => try out.appendSlice(self.arena, "false"),
             .f64, .i64 => try out.appendSlice(self.arena, "0"),
@@ -680,14 +706,14 @@ const FacadeEmitter = struct {
         }
     }
 
-    const FieldValueFn = *const fn (self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize) Error!void;
+    const FieldValueFn = *const fn (self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize, slot: ?[]const u8) Error!void;
 
-    fn zeroField(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize) Error!void {
-        try self.zeroValue(out, ref, depth);
+    fn zeroField(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize, slot: ?[]const u8) Error!void {
+        try self.zeroValue(out, ref, depth, slot);
     }
 
-    fn sampleField(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize) Error!void {
-        try self.sampleValue(out, ref, depth);
+    fn sampleField(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize, slot: ?[]const u8) Error!void {
+        try self.sampleValue(out, ref, depth, slot);
     }
 
     fn recordValue(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), entry: *const sidecar_mod.Struct, depth: usize, field_value: FieldValueFn) Error!void {
@@ -695,7 +721,7 @@ const FacadeEmitter = struct {
         for (entry.fields) |field| {
             try out.appendSlice(self.arena, try self.indentText(depth + 1));
             try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "{s}: ", .{try tsProp(self.arena, field.name)}));
-            try field_value(self, out, field.type, depth + 1);
+            try field_value(self, out, field.type, depth + 1, try self.slotOf(entry.name, field.name));
             try out.appendSlice(self.arena, ",\n");
         }
         try out.appendSlice(self.arena, try self.indentText(depth));
@@ -712,22 +738,29 @@ const FacadeEmitter = struct {
             try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "{{ kind: \"{s}\"", .{try tsString(self.arena, arm.name)}));
             for (record.fields) |field| {
                 try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, ", {s}: ", .{try tsProp(self.arena, field.name)}));
-                try field_value(self, out, field.type, depth);
+                try field_value(self, out, field.type, depth, try self.slotOf(record.name, field.name));
             }
             try out.appendSlice(self.arena, " }");
             return;
         }
         try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "{{ kind: \"{s}\", value: ", .{try tsString(self.arena, arm.name)}));
-        try field_value(self, out, arm.payload, depth);
+        try field_value(self, out, arm.payload, depth, try self.slotOf(entry.name, arm.name));
         try out.appendSlice(self.arena, " }");
     }
 
-    fn sampleValue(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize) Error!void {
+    fn sampleValue(self: *FacadeEmitter, out: *std.ArrayListUnmanaged(u8), ref: TypeRef, depth: usize, slot: ?[]const u8) Error!void {
         self.sample_ordinal += 1;
         const n: i64 = @intCast(self.sample_ordinal);
         switch (ref) {
             .bool => try out.appendSlice(self.arena, if (@rem(n, 2) == 0) "true" else "false"),
-            .i64 => try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "{d}", .{n * 7 - 12})),
+            .i64 => {
+                // A u64-attested slot's sample stays non-negative (the
+                // unsigned encoder refuses negatives); the magnitude
+                // keeps the per-ordinal variety.
+                const varied = n * 7 - 12;
+                const value = if (self.attestedU64(slot) and varied < 0) -varied else varied;
+                try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "{d}", .{value}));
+            },
             .f64 => {
                 // Varied signs and fractions (quarters stay exact in
                 // binary, so both encoders see identical values).
@@ -736,7 +769,7 @@ const FacadeEmitter = struct {
             },
             .bytes => try out.appendSlice(self.arena, try std.fmt.allocPrint(self.arena, "asciiBytes(\"sample-{d}\")", .{n})),
             .void => try out.appendSlice(self.arena, "undefined"),
-            .optional => |inner| try self.sampleValue(out, inner.*, depth),
+            .optional => |inner| try self.sampleValue(out, inner.*, depth, slot),
             .slice => |elem| {
                 // Two elements at the outermost level exercise ordering;
                 // nested levels take one so deeply nested sequence types
@@ -747,7 +780,7 @@ const FacadeEmitter = struct {
                 try out.appendSlice(self.arena, "[\n");
                 for (0..element_count) |_| {
                     try out.appendSlice(self.arena, try self.indentText(depth + 1));
-                    try self.sampleValue(out, elem.*, depth + 1);
+                    try self.sampleValue(out, elem.*, depth + 1, null);
                     try out.appendSlice(self.arena, ",\n");
                 }
                 try out.appendSlice(self.arena, try self.indentText(depth));
@@ -990,6 +1023,39 @@ const FacadeEmitter = struct {
             \\
         );
 
+        // The unsigned twin, emitted only when a slot attests the u64
+        // class: 8-byte unsigned LE, refusing negatives — a negative
+        // value has no honest unsigned bytes, and encoding one anyway
+        // would decode host-side as a huge unsigned value.
+        if (self.anyU64()) {
+            try self.raw(
+                \\
+                \\// u64, unsigned LE — the unsigned twin for u64-attested integer
+                \\// slots. Values are whole and within [0, 2^53 - 1] by the number
+                \\// model; the same 53-bit scan as nscfI64's non-negative path.
+                \\function nscfU64(value: number): Uint8Array {
+                \\  if (value !== Math.floor(value) || value > 9007199254740991 || value < 0) {
+                \\    throw { kind: "nscf_contract", teaching: asciiBytes("an unsigned integer slot carries a non-integer, negative, or out-of-range value — the u64 encoding has no honest bytes for it; keep unsigned integer slots whole and within 0..(2^53 - 1)") } as NscfContractError;
+                \\  }
+                \\  const bits = new Uint8Array(64);
+                \\  for (let i = 0; i < 64; i++) {
+                \\    bits[i] = 0;
+                \\  }
+                \\  let rest = value;
+                \\  let p = 4503599627370496;
+                \\  for (let i = 0; i < 53; i++) {
+                \\    if (rest >= p) {
+                \\      bits[11 + i] = 1;
+                \\      rest = rest - p;
+                \\    }
+                \\    p = p / 2;
+                \\  }
+                \\  return nscfBitsToBytes(bits, 8);
+                \\}
+                \\
+            );
+        }
+
         for (self.sidecar.types.enums) |entry| {
             try self.print("\nfunction nscfIndex{s}(value: {s}): number {{\n", .{ entry.name, entry.name });
             for (entry.members, 0..) |member, index| {
@@ -1099,29 +1165,29 @@ const FacadeEmitter = struct {
     fn msgPayloadEncodeStatements(self: *FacadeEmitter, arm: sidecar_mod.MsgArm) Error!void {
         switch (arm.payload) {
             .void => {},
-            .bytes => try self.fieldEncodeStatements(.bytes, "value.value", 2, 0),
-            .number => |class| try self.fieldEncodeStatements(numberRef(class), "value.value", 2, 0),
+            .bytes => try self.fieldEncodeStatements(.bytes, "value.value", 2, 0, null),
+            .number => |class| try self.fieldEncodeStatements(numberRef(class), "value.value", 2, 0, try self.slotOf(self.sidecar.msg.name, arm.name)),
             .number_bytes => |desc| {
                 // The mirror declares the number field first (the
                 // emitted convention of every producer of this shape —
                 // SCHEMA-GAPS.md), so the number's bytes lead.
-                try self.fieldEncodeStatements(numberRef(desc.number_class), try tsAccess(self.arena, "value", desc.number_field), 2, 0);
-                try self.fieldEncodeStatements(.bytes, try tsAccess(self.arena, "value", desc.bytes_field), 2, 8);
+                try self.fieldEncodeStatements(numberRef(desc.number_class), try tsAccess(self.arena, "value", desc.number_field), 2, 0, try std.fmt.allocPrint(self.arena, "{s}.{s}.{s}", .{ self.sidecar.msg.name, arm.name, desc.number_field }));
+                try self.fieldEncodeStatements(.bytes, try tsAccess(self.arena, "value", desc.bytes_field), 2, 8, null);
             },
             .record => |name| {
                 if (self.synthesizedRecordOf(recordPayloadRef(arm.payload), self.sidecar.msg.name, arm.name)) |record| {
                     // Flattened beside `kind`: encode the record's
                     // fields off the narrowed arm in declaration order.
                     for (record.fields, 0..) |field, field_index| {
-                        try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 2, field_index * 8);
+                        try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 2, field_index * 8, try self.slotOf(record.name, field.name));
                     }
                 } else {
-                    try self.fieldEncodeStatements(.{ .value = name }, "value.value", 2, 0);
+                    try self.fieldEncodeStatements(.{ .value = name }, "value.value", 2, 0, null);
                 }
             },
-            .union_ref => |name| try self.fieldEncodeStatements(.{ .union_ref = name }, "value.value", 2, 0),
-            .enum_ref => |name| try self.fieldEncodeStatements(.{ .enum_ref = name }, "value.value", 2, 0),
-            .scalar => |ref| try self.fieldEncodeStatements(ref, "value.value", 2, 0),
+            .union_ref => |name| try self.fieldEncodeStatements(.{ .union_ref = name }, "value.value", 2, 0, null),
+            .enum_ref => |name| try self.fieldEncodeStatements(.{ .enum_ref = name }, "value.value", 2, 0, null),
+            .scalar => |ref| try self.fieldEncodeStatements(ref, "value.value", 2, 0, try self.slotOf(self.sidecar.msg.name, arm.name)),
         }
     }
 
@@ -1135,7 +1201,7 @@ const FacadeEmitter = struct {
             // Temp names seed per field: every statement shares one
             // function scope, and optional/slice nesting takes the +1
             // steps within the field's own range.
-            try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 1, index * 8);
+            try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 1, index * 8, try self.slotOf(entry.name, field.name));
         }
         try self.raw("  return nscfCat(parts);\n}\n");
     }
@@ -1146,12 +1212,13 @@ const FacadeEmitter = struct {
             try self.print("  if (value.kind === \"{s}\") {{\n    const parts: Uint8Array[] = [nscfByte({d})];\n", .{ try tsString(self.arena, arm.name), index });
             if (self.synthesizedRecordOf(arm.payload, entry.name, arm.name)) |record| {
                 // Flattened beside `kind`: encode the record's fields
-                // off the narrowed arm in declaration order.
+                // off the narrowed arm in declaration order (the record
+                // is tabled, so its fields carry its own slot paths).
                 for (record.fields, 0..) |field, field_index| {
-                    try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 2, field_index * 8);
+                    try self.fieldEncodeStatements(field.type, try tsAccess(self.arena, "value", field.name), 2, field_index * 8, try self.slotOf(record.name, field.name));
                 }
             } else if (arm.payload != .void) {
-                try self.fieldEncodeStatements(arm.payload, "value.value", 2, 0);
+                try self.fieldEncodeStatements(arm.payload, "value.value", 2, 0, try self.slotOf(entry.name, arm.name));
             }
             try self.raw("    return nscfCat(parts);\n  }\n");
         }
@@ -1159,24 +1226,26 @@ const FacadeEmitter = struct {
     }
 
     /// Statements appending `expr`'s canonical encoding to `parts`.
-    fn fieldEncodeStatements(self: *FacadeEmitter, ref: TypeRef, expr: []const u8, depth: usize, temp_seed: usize) Error!void {
+    /// `slot` is the site's slot path (null where no path form exists),
+    /// consulted for the attested integer class.
+    fn fieldEncodeStatements(self: *FacadeEmitter, ref: TypeRef, expr: []const u8, depth: usize, temp_seed: usize, slot: ?[]const u8) Error!void {
         const pad = try self.indentText(depth);
         switch (ref) {
             .bool => try self.print("{s}parts[parts.length] = nscfByte({s} ? 1 : 0);\n", .{ pad, expr }),
-            .i64 => try self.print("{s}parts[parts.length] = nscfI64({s});\n", .{ pad, expr }),
+            .i64 => try self.print("{s}parts[parts.length] = {s}({s});\n", .{ pad, if (self.attestedU64(slot)) "nscfU64" else "nscfI64", expr }),
             .f64 => try self.print("{s}parts[parts.length] = nscfF64({s});\n", .{ pad, expr }),
             .bytes => try self.print("{s}parts[parts.length] = nscfBytes({s});\n", .{ pad, expr }),
             .void => {},
             .optional => |inner| {
                 const temp = try std.fmt.allocPrint(self.arena, "nscfOpt{d}", .{temp_seed});
                 try self.print("{s}const {s} = {s};\n{s}if ({s} === null) {{\n{s}  parts[parts.length] = nscfByte(0);\n{s}}} else {{\n{s}  parts[parts.length] = nscfByte(1);\n", .{ pad, temp, expr, pad, temp, pad, pad, pad });
-                try self.fieldEncodeStatements(inner.*, temp, depth + 1, temp_seed + 1);
+                try self.fieldEncodeStatements(inner.*, temp, depth + 1, temp_seed + 1, slot);
                 try self.print("{s}}}\n", .{pad});
             },
             .slice => |elem| {
                 const index = try std.fmt.allocPrint(self.arena, "nscfIdx{d}", .{temp_seed});
                 try self.print("{s}parts[parts.length] = nscfU32({s}.length);\n{s}for (let {s} = 0; {s} < {s}.length; {s}++) {{\n", .{ pad, expr, pad, index, index, expr, index });
-                try self.fieldEncodeStatements(elem.*, try std.fmt.allocPrint(self.arena, "{s}[{s}]", .{ expr, index }), depth + 1, temp_seed + 1);
+                try self.fieldEncodeStatements(elem.*, try std.fmt.allocPrint(self.arena, "{s}[{s}]", .{ expr, index }), depth + 1, temp_seed + 1, null);
                 try self.print("{s}}}\n", .{pad});
             },
             .node, .value => |name| try self.print("{s}parts[parts.length] = {s}({s});\n", .{ pad, try self.encoderNameFor(name), expr }),
@@ -1465,6 +1534,49 @@ test "envelope payloads follow the sidecar's classes and flattened orders" {
     // declaration order, exactly as the arm's mirror payload decodes.
     try testing.expect(std.mem.indexOf(u8, generated, "if (value.kind === \"loaded\") {\n    const parts: Uint8Array[] = [nscfByte(1), nscfByte(1)];\n    parts[parts.length] = nscfF64(value.status);\n    parts[parts.length] = nscfByte(value.ok ? 1 : 0);\n    return nscfCat(parts);\n  }") != null);
     try testing.expect(std.mem.indexOf(u8, generated, "export function nsc_core_frame_msg(msg: Msg | null): Uint8Array {") != null);
+}
+
+test "u64-attested slots pick the unsigned encoder; the twin emits only when attested" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A u64-attested model field and message arm beside an i64-attested
+    // one, with the key channel wired so the envelope path emits too.
+    var source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        sidecar_mod.minimal_valid_json,
+        "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}}",
+        "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}},\n        {\"name\": \"id\", \"type\": {\"kind\": \"i64\"}}",
+    );
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"tick\", \"payload\": {\"kind\": \"number\", \"class\": \"i64\"}}",
+    );
+    source = try std.mem.replaceOwned(u8, arena, source, "\"key_msg\": false", "\"key_msg\": true");
+    source = try std.mem.replaceOwned(u8, arena, source, "\"helper_call\"]", "\"helper_call\", \"key_msg\"]");
+    source = try std.mem.replaceOwned(
+        u8,
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Model.id\", \"class\": \"u64\"}, {\"slot\": \"Msg.tick\", \"class\": \"u64\"}",
+    );
+    const generated = try facadeFromJson(arena, source);
+    // Slot by slot: the attestation picks the encoder.
+    try testing.expect(std.mem.indexOf(u8, generated, "function nscfU64(value: number): Uint8Array {") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "parts[parts.length] = nscfI64(value.count);") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "parts[parts.length] = nscfU64(value.id);") != null);
+    try testing.expect(std.mem.indexOf(u8, generated, "parts[parts.length] = nscfU64(value.value);") != null);
+    // The unsigned encoder refuses negatives, and its sample stays
+    // non-negative so the deterministic sample model encodes.
+    try testing.expect(std.mem.indexOf(u8, generated, "value < 0") != null);
+    // Without a u64 attestation, the twin never emits.
+    const signed_only = try facadeFromJson(arena, sidecar_mod.minimal_valid_json);
+    try testing.expect(std.mem.indexOf(u8, signed_only, "nscfU64") == null);
 }
 
 test "composite slice elements parenthesize in the projection" {

--- a/tools/corewire/extract.zig
+++ b/tools/corewire/extract.zig
@@ -409,7 +409,9 @@ fn payloadDescriptor(comptime T: type, comptime msg_zig: []const u8, comptime ar
     if (isBytes(T)) return "{\"kind\": \"bytes\"}";
     if (T == f64) return "{\"kind\": \"number\", \"class\": \"f64\"}";
     if (T == i64) {
-        appendSlot(slots, slot_count, "Msg." ++ arm_name);
+        // Message-side slot paths spell the union's AUTHORED name, never
+        // a literal `Msg` token.
+        appendSlot(slots, slot_count, msg_zig ++ "." ++ arm_name);
         return "{\"kind\": \"number\", \"class\": \"i64\"}";
     }
     if (T == bool) return "{\"kind\": \"scalar\", \"type\": {\"kind\": \"bool\"}}";
@@ -425,7 +427,7 @@ fn payloadDescriptor(comptime T: type, comptime msg_zig: []const u8, comptime ar
             if (isNumberBytesShape(T, msg_zig)) {
                 const class = if (info.fields[0].type == i64) "i64" else "f64";
                 if (info.fields[0].type == i64) {
-                    appendSlot(slots, slot_count, "Msg." ++ arm_name ++ "." ++ info.fields[0].name);
+                    appendSlot(slots, slot_count, msg_zig ++ "." ++ arm_name ++ "." ++ info.fields[0].name);
                 }
                 return "{\"kind\": \"number_bytes\", \"number_field\": " ++ js(info.fields[0].name) ++
                     ", \"number_class\": \"" ++ class ++ "\", \"bytes_field\": " ++ js(info.fields[1].name) ++ "}";
@@ -551,6 +553,37 @@ test "extraction of a small core produces a valid sidecar" {
 
     // Determinism: a second evaluation is byte-identical.
     try testing.expectEqualStrings(json, comptime sidecarJson(Core, "src/core.ts"));
+}
+
+test "message-side integer slot paths spell the union's authored name" {
+    const Core = struct {
+        pub const Model = struct { count: i64 };
+        pub const Event = union(enum) {
+            tick: i64,
+            fetched: struct { status: i64, body: []const u8 },
+        };
+        pub const Msg = Event;
+        pub fn initialModel() *const Model {
+            unreachable;
+        }
+        pub fn update(model: *const Model, msg: Msg) *const Model {
+            _ = msg;
+            return model;
+        }
+    };
+    const json = comptime sidecarJson(Core, "src/core.ts");
+    try testing.expect(std.mem.indexOf(u8, json, "{\"slot\": \"Event.tick\", \"class\": \"i64\"}") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "{\"slot\": \"Event.fetched.status\", \"class\": \"i64\"}") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"Msg.tick\"") == null);
+
+    // The reader's bijection accepts the authored spelling end to end.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const sidecar_mod = @import("sidecar.zig");
+    var diags = sidecar_mod.Diagnostics{ .arena = arena };
+    const sidecar = try sidecar_mod.read(arena, json, &diags);
+    try testing.expectEqual(@as(usize, 3), sidecar.integer_slots.len);
 }
 
 test "anonymous-name detection keys on the final compiler suffix" {

--- a/tools/corewire/shim_rt.zig
+++ b/tools/corewire/shim_rt.zig
@@ -22,6 +22,9 @@
 //!                       deterministic across producers.
 //!   i64                 8 bytes, two's complement, LE (never a bit
 //!                       reinterpretation of the f64)
+//!   u64                 8 bytes, unsigned, LE — the unsigned twin, for
+//!                       slots whose integer_slots attestation refines
+//!                       the i64 spelling to the u64 class
 //!   bool                u8, 0 or 1
 //!   bytes               u32 LE length + the bytes
 //!   enum                u32 LE declaration-order member index
@@ -116,7 +119,7 @@ fn encodeInto(comptime T: type, value: T, allocator: std.mem.Allocator, out: *st
     switch (@typeInfo(T)) {
         .bool => try out.append(allocator, @intFromBool(value)),
         .int => {
-            comptime std.debug.assert(T == i64);
+            comptime std.debug.assert(T == i64 or T == u64);
             try appendInt(u64, @bitCast(value), allocator, out);
         },
         .float => {
@@ -226,7 +229,10 @@ pub fn decode(comptime T: type, reader: *Reader, allocator: std.mem.Allocator) T
             return raw == 1;
         },
         .int => {
-            comptime std.debug.assert(T == i64);
+            comptime std.debug.assert(T == i64 or T == u64);
+            // The wire type is 8 bytes: every bit pattern decodes (the
+            // compiler-provable crossing range is narrower, but the
+            // decoder is total over the encoding).
             return @bitCast(reader.int(u64));
         },
         .float => {
@@ -344,6 +350,16 @@ pub fn panicSink(ctx: ?*anyopaque, msg: [*]const u8, msg_len: usize, address: u6
 pub fn exactF64(value: i64) f64 {
     const bound: i64 = 9007199254740992; // 2^53: the first alias point.
     if (value >= bound or value <= -bound) {
+        @panic("an integer message payload is at or past 2^53 — the f64 wire aliases such values, so dispatching one would corrupt it silently; keep integer payloads within +-(2^53 - 1)");
+    }
+    return @floatFromInt(value);
+}
+
+/// The unsigned twin, for u64-attested slots: the same 2^53 exactness
+/// line, one-sided.
+pub fn exactF64Unsigned(value: u64) f64 {
+    const bound: u64 = 9007199254740992; // 2^53: the first alias point.
+    if (value >= bound) {
         @panic("an integer message payload is at or past 2^53 — the f64 wire aliases such values, so dispatching one would corrupt it silently; keep integer payloads within +-(2^53 - 1)");
     }
     return @floatFromInt(value);
@@ -483,6 +499,63 @@ test "exactF64 carries every in-range integer and matches the wire grid" {
     try testing.expectEqual(@as(f64, 9007199254740991.0), exactF64(9007199254740991));
     try testing.expectEqual(@as(f64, -9007199254740991.0), exactF64(-9007199254740991));
     try testing.expectEqual(@as(f64, 0.0), exactF64(0));
+    try testing.expectEqual(@as(f64, 9007199254740991.0), exactF64Unsigned(9007199254740991));
+    try testing.expectEqual(@as(f64, 0.0), exactF64Unsigned(0));
+}
+
+test "integer slots encode as hand-computed 8-byte little-endian vectors" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // The compiler-provable extremes: +-(2^53 - 1) = 0x1fffffffffffff.
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00 }, encodeAlloc(i64, 9007199254740991, a));
+    try testing.expectEqualSlices(u8, &.{ 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xff }, encodeAlloc(i64, -9007199254740991, a));
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00 }, encodeAlloc(u64, 9007199254740991, a));
+
+    // Sign handling: two's complement for i64, plain magnitude for u64.
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, encodeAlloc(i64, -1, a));
+    try testing.expectEqualSlices(u8, &.{ 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, encodeAlloc(u64, 1, a));
+
+    // The wire type is 8 bytes: the full i64/u64 range encodes, past
+    // the f64-exact crossing bound.
+    try testing.expectEqualSlices(u8, &.{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }, encodeAlloc(i64, std.math.minInt(i64), a));
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f }, encodeAlloc(i64, std.math.maxInt(i64), a));
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, encodeAlloc(u64, std.math.maxInt(u64), a));
+}
+
+test "the full 8-byte wire range decodes and round-trips for both integer classes" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Every bit pattern is a value of the wire type: the same bytes
+    // read signed or unsigned per the attested class.
+    const all_ones = [_]u8{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+    try testing.expectEqual(@as(i64, -1), decodeExact(i64, &all_ones, a));
+    try testing.expectEqual(@as(u64, 18446744073709551615), decodeExact(u64, &all_ones, a));
+    const high_bit = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 };
+    try testing.expectEqual(@as(i64, std.math.minInt(i64)), decodeExact(i64, &high_bit, a));
+    try testing.expectEqual(@as(u64, 9223372036854775808), decodeExact(u64, &high_bit, a));
+
+    const i64_values = [_]i64{ 0, 1, -1, 9007199254740991, -9007199254740991, std.math.minInt(i64), std.math.maxInt(i64) };
+    for (i64_values) |value| {
+        try testing.expectEqual(value, decodeExact(i64, encodeAlloc(i64, value, a), a));
+    }
+    const u64_values = [_]u64{ 0, 1, 9007199254740991, 9007199254740992, 9223372036854775808, std.math.maxInt(u64) };
+    for (u64_values) |value| {
+        try testing.expectEqual(value, decodeExact(u64, encodeAlloc(u64, value, a), a));
+    }
+
+    // Wrapped shapes carry the class through: optionals and record
+    // fields decode per the slot's own integer class.
+    try testing.expectEqualSlices(u8, &.{ 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, encodeAlloc(?u64, std.math.maxInt(u64), a));
+    try testing.expectEqual(@as(?u64, std.math.maxInt(u64)), decodeExact(?u64, &.{ 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, a));
+    const Pair = struct { id: u64, delta: i64 };
+    const pair = Pair{ .id = 9007199254740991, .delta = -9007199254740991 };
+    const encoded = encodeAlloc(Pair, pair, a);
+    try testing.expectEqualSlices(u8, &.{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0xff }, encoded);
+    try testing.expectEqual(pair, decodeExact(Pair, encoded, a));
 }
 
 test "a decoded model root survives exactly one subsequent decode" {

--- a/tools/corewire/sidecar.zig
+++ b/tools/corewire/sidecar.zig
@@ -8,9 +8,10 @@
 //! message union with declaration-order wire tags, helper signatures,
 //! channel declarations, and build identity. Its only consumers are the
 //! shim generator (emit.zig turns it into a Zig mirror module) and the
-//! checker; both refuse a malformed or unknown-generation sidecar loudly
-//! at tool time, with a teaching that names the exact field path — never
-//! a silent skew that surfaces as wrong dispatch at runtime.
+//! checker; both refuse a malformed or unknown-generation sidecar
+//! outright at tool time, with a teaching that names the exact field
+//! path — never a silent skew that surfaces as wrong dispatch at
+//! runtime.
 //!
 //! Forward compatibility (reader side, normative):
 //! - Unknown FIELDS anywhere are ignored with a one-line warning naming
@@ -148,9 +149,16 @@ pub const Abi = struct {
     snapshot_format: i64,
 };
 
+/// The resolved integer class an `integer_slots` entry attests. The
+/// type table's one integer spelling is `i64`; the attestation refines
+/// it — `u64` marks the slot's wire bytes as the unsigned twin (8-byte
+/// unsigned LE instead of two's complement). `f64` never appears here:
+/// it is the default class and is never attested.
+pub const IntegerClass = enum { i64, u64 };
+
 pub const IntegerSlot = struct {
     slot: []const u8,
-    class: NumberClass,
+    class: IntegerClass,
 };
 
 pub const Sidecar = struct {
@@ -612,6 +620,20 @@ const Mapper = struct {
         return self.diags.fail(at, "unknown number class \"{s}\" — the v1 classes are \"f64\" and \"i64\"; this reader is too old for anything else", .{text});
     }
 
+    /// The integer_slots class vocabulary is its own closed set:
+    /// payload descriptors spell "f64"/"i64" (V7), attestations spell
+    /// "i64"/"u64" — the unsigned class exists only as a per-slot
+    /// verdict, never as a TypeRef or descriptor spelling.
+    fn mapIntegerClass(self: *Mapper, value: std.json.Value, at: []const u8) error{ Refused, OutOfMemory }!IntegerClass {
+        const text = try self.string(value, at);
+        if (std.mem.eql(u8, text, "i64")) return .i64;
+        if (std.mem.eql(u8, text, "u64")) return .u64;
+        if (std.mem.eql(u8, text, "f64")) {
+            return self.diags.fail(at, "integer_slots records the compiler's integer-class verdicts; class \"f64\" has no place here (f64 is the default class and is never attested)", .{});
+        }
+        return self.diags.fail(at, "unknown integer class \"{s}\" — the format-1 classes are \"i64\" and \"u64\"; this reader is too old for anything else", .{text});
+    }
+
     fn mapHelpers(self: *Mapper, value: std.json.Value) error{ Refused, OutOfMemory }![]const Helper {
         const items = try self.array(value, "model_helpers");
         const out = try self.arena.alloc(Helper, items.items.len);
@@ -750,13 +772,9 @@ const Mapper = struct {
             const at = self.path("integer_slots[{d}]", .{index});
             const entry = try self.members(item, at, &.{ "slot", "class" });
             entry.warnUnknown();
-            const class = try self.mapNumberClass(try entry.get("class"), self.path("{s}.class", .{at}));
-            if (class != .i64) {
-                return self.diags.fail(self.path("{s}.class", .{at}), "integer_slots records the compiler's i64 verdicts; class \"f64\" has no place here (f64 is the default class and is never attested)", .{});
-            }
             out[index] = .{
                 .slot = try self.nonEmptyString(try entry.get("slot"), self.path("{s}.slot", .{at})),
-                .class = class,
+                .class = try self.mapIntegerClass(try entry.get("class"), self.path("{s}.class", .{at})),
             };
         }
         return out;
@@ -796,7 +814,10 @@ fn jsonKindName(value: std.json.Value) []const u8 {
 //                                          scalar shape).
 //   V8  unbound lists resolve            — validateUnbound.
 //   V9  channel wiring                   — validateChannels.
-//   V10 integer-slot bijection           — validateIntegerSlots.
+//   V10 integer-slot bijection           — validateIntegerSlots: the
+//       one-to-one check both ways, plus structural resolution of every
+//       leftover entry's path (unresolvable, wrong spelling, or the
+//       grammar's slice-element gap each carry their own teaching).
 //   V11 export attestation               — validateAbi checks the list
 //       against the profile's canonical vocabulary and order; the
 //       "exactly what the object exports" half needs the object and is
@@ -1423,16 +1444,19 @@ pub fn collectIntegerSlotPaths(arena: std.mem.Allocator, sidecar: Sidecar) error
             }
         }
     }
+    // The message-side path forms spell the union's AUTHORED name —
+    // an app whose union is named Action spells its slots
+    // `Action.<arm>`, never a literal `Msg` token.
     for (sidecar.msg.arms) |arm| {
         switch (arm.payload) {
             .number => |class| if (class == .i64) {
-                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "Msg.{s}", .{arm.name}), .components_dotted = dotted(&.{arm.name}) });
+                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "{s}.{s}", .{ sidecar.msg.name, arm.name }), .components_dotted = dotted(&.{ sidecar.msg.name, arm.name }) });
             },
             .number_bytes => |desc| if (desc.number_class == .i64) {
-                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "Msg.{s}.{s}", .{ arm.name, desc.number_field }), .components_dotted = dotted(&.{ arm.name, desc.number_field }) });
+                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "{s}.{s}.{s}", .{ sidecar.msg.name, arm.name, desc.number_field }), .components_dotted = dotted(&.{ sidecar.msg.name, arm.name, desc.number_field }) });
             },
             .scalar => |ref| if (spellsInteger(ref)) {
-                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "Msg.{s}", .{arm.name}), .components_dotted = dotted(&.{arm.name}) });
+                try paths.append(arena, .{ .path = try std.fmt.allocPrint(arena, "{s}.{s}", .{ sidecar.msg.name, arm.name }), .components_dotted = dotted(&.{ sidecar.msg.name, arm.name }) });
             },
             else => {},
         }
@@ -1460,6 +1484,142 @@ fn spellsInteger(ref: TypeRef) bool {
         .optional => |inner| spellsInteger(inner.*),
         else => false,
     };
+}
+
+/// What an `integer_slots` entry's path names once resolved against the
+/// sidecar's own tables under the format-1 slot-path grammar.
+pub const SlotTarget = union(enum) {
+    /// A slot the sidecar spells i64 — an attestable target.
+    integer,
+    /// A real slot, spelled or classed as described — not attestable.
+    not_integer: []const u8,
+    /// A sequence whose elements spell an integer: the format-1 grammar
+    /// has no slice-element form, so no path can attest it.
+    slice_element,
+    /// No grammar form reaches a slot of this spelling.
+    unresolved,
+};
+
+fn refSpelling(ref: TypeRef) []const u8 {
+    return switch (ref) {
+        .bool => "bool",
+        .f64 => "f64",
+        .i64 => "i64",
+        .bytes => "bytes",
+        .void => "void",
+        .optional => |inner| refSpelling(inner.*),
+        .slice => "a slice",
+        .node, .value => "a record",
+        .enum_ref => "an enum",
+        .union_ref => "a union",
+    };
+}
+
+fn wrapsInteger(ref: TypeRef) bool {
+    return switch (ref) {
+        .i64 => true,
+        .optional => |inner| wrapsInteger(inner.*),
+        .slice => |elem| wrapsInteger(elem.*),
+        else => false,
+    };
+}
+
+/// Classify the TypeRef a resolved path lands on: i64 through optionals
+/// is the attestable shape; an integer buried under a slice is the
+/// grammar's known gap; everything else is a real slot of another
+/// spelling.
+fn classifyRef(ref: TypeRef) SlotTarget {
+    return switch (ref) {
+        .i64 => .integer,
+        .optional => |inner| classifyRef(inner.*),
+        .slice => |elem| if (wrapsInteger(elem.*)) .slice_element else .{ .not_integer = "a slice" },
+        else => .{ .not_integer = refSpelling(ref) },
+    };
+}
+
+fn classifyNumberClass(class: NumberClass) SlotTarget {
+    return switch (class) {
+        .i64 => .integer,
+        .f64 => .{ .not_integer = "f64" },
+    };
+}
+
+/// Resolve one slot path against the sidecar's tables. The grammar's
+/// forms, each segment the author's spelling: `<TypeName>.<field>` (a
+/// struct field, or a non-msg union arm's payload),
+/// `<msgName>.<arm>` (a scalar-number arm), `<msgName>.<arm>.<field>`
+/// (a number_bytes arm's number field), `helpers.<name>.return`, and
+/// `helpers.<name>.params[<index>]`.
+pub fn resolveSlotPath(sidecar: Sidecar, path: []const u8) SlotTarget {
+    var segments: [4][]const u8 = undefined;
+    var count: usize = 0;
+    var it = std.mem.splitScalar(u8, path, '.');
+    while (it.next()) |segment| {
+        if (segment.len == 0) return .unresolved;
+        if (count == segments.len) return .unresolved;
+        segments[count] = segment;
+        count += 1;
+    }
+
+    if (count == 3 and std.mem.eql(u8, segments[0], "helpers")) {
+        for (sidecar.model_helpers) |helper| {
+            if (!std.mem.eql(u8, helper.name, segments[1])) continue;
+            if (std.mem.eql(u8, segments[2], "return")) return classifyRef(helper.returns);
+            if (std.mem.startsWith(u8, segments[2], "params[") and std.mem.endsWith(u8, segments[2], "]")) {
+                const digits = segments[2]["params[".len .. segments[2].len - 1];
+                const index = std.fmt.parseInt(usize, digits, 10) catch return .unresolved;
+                if (index >= helper.params.len) return .unresolved;
+                return classifyRef(helper.params[index]);
+            }
+            return .unresolved;
+        }
+        return .unresolved;
+    }
+
+    if (std.mem.eql(u8, segments[0], sidecar.msg.name)) {
+        if (count == 2) {
+            if (findArm(sidecar.msg, segments[1])) |arm| {
+                return switch (arm.payload) {
+                    .number => |class| classifyNumberClass(class),
+                    .scalar => |ref| classifyRef(ref),
+                    .void => .{ .not_integer = "void" },
+                    .bytes => .{ .not_integer = "bytes" },
+                    .number_bytes => .{ .not_integer = "a number_bytes record (its number field is the slot)" },
+                    .record => .{ .not_integer = "a record" },
+                    .union_ref => .{ .not_integer = "a union" },
+                    .enum_ref => .{ .not_integer = "an enum" },
+                };
+            }
+        }
+        if (count == 3) {
+            if (findArm(sidecar.msg, segments[1])) |arm| {
+                switch (arm.payload) {
+                    .number_bytes => |desc| {
+                        if (std.mem.eql(u8, segments[2], desc.number_field)) return classifyNumberClass(desc.number_class);
+                        if (std.mem.eql(u8, segments[2], desc.bytes_field)) return .{ .not_integer = "bytes" };
+                    },
+                    else => {},
+                }
+            }
+            return .unresolved;
+        }
+    }
+
+    if (count == 2) {
+        if (findStruct(sidecar.types, segments[0])) |record| {
+            for (record.fields) |field| {
+                if (std.mem.eql(u8, field.name, segments[1])) return classifyRef(field.type);
+            }
+            return .unresolved;
+        }
+        if (findUnion(sidecar.types, segments[0])) |tagged| {
+            for (tagged.arms) |arm| {
+                if (std.mem.eql(u8, arm.name, segments[1])) return classifyRef(arm.payload);
+            }
+            return .unresolved;
+        }
+    }
+    return .unresolved;
 }
 
 fn validateIntegerSlots(arena: std.mem.Allocator, sidecar: Sidecar, diags: *Diagnostics) error{OutOfMemory}!void {
@@ -1495,10 +1655,19 @@ fn validateIntegerSlots(arena: std.mem.Allocator, sidecar: Sidecar, diags: *Diag
         for (sidecar.integer_slots[0..index]) |earlier| {
             if (std.mem.eql(u8, earlier.slot, slot.slot)) duplicate = true;
         }
+        const at = pathOfStatic(diags, "integer_slots[{d}].slot", .{index});
         if (duplicate) {
-            diags.flag(pathOfStatic(diags, "integer_slots[{d}].slot", .{index}), "duplicate entry for \"{s}\" — every i64 slot has exactly one entry (V10)", .{slot.slot});
-        } else {
-            diags.flag(pathOfStatic(diags, "integer_slots[{d}].slot", .{index}), "\"{s}\" resolves to no slot the sidecar spells i64 — every entry must name a real i64 slot (V10)", .{slot.slot});
+            diags.flag(at, "duplicate entry for \"{s}\" — every i64 slot has exactly one entry (V10)", .{slot.slot});
+            continue;
+        }
+        // The entry consumed nothing: resolve its path structurally so
+        // the teaching names what actually went wrong instead of one
+        // generic mismatch.
+        switch (resolveSlotPath(sidecar, slot.slot)) {
+            .integer => diags.flag(at, "\"{s}\" resolves to no slot the sidecar spells i64 — every entry must name a real i64 slot (V10)", .{slot.slot}),
+            .not_integer => |spelling| diags.flag(at, "\"{s}\" resolves to a slot the sidecar spells {s}, not i64 — an attested integer class must sit on an i64 spelling (V10)", .{ slot.slot, spelling }),
+            .slice_element => diags.flag(at, "\"{s}\" addresses a sequence — the format-1 slot-path grammar has no slice-element form, so slice elements are never integer-attested; the emitter spells them f64 and readers exempt them from the bijection (V10)", .{slot.slot}),
+            .unresolved => diags.flag(at, "\"{s}\" resolves against none of the sidecar's own tables — slot paths name a record field or union arm (<Type>.<name>), a message payload (\"{s}.<arm>\" or \"{s}.<arm>.<numberField>\"), or a helper signature slot (helpers.<name>.return, helpers.<name>.params[<index>]) (V10)", .{ slot.slot, sidecar.msg.name, sidecar.msg.name }),
         }
     }
 }
@@ -1868,7 +2037,7 @@ test "V10: an i64 spelling without an integer_slots entry refuses" {
     try expectRefusal(source, "integer_slots", "spells \"Model.count\" i64 but attests no integer_slots entry");
 }
 
-test "V10: an integer_slots entry naming no i64 slot refuses" {
+test "V10: an entry on a slot of another spelling refuses with that spelling named" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const source = try replaced(
@@ -1877,7 +2046,139 @@ test "V10: an integer_slots entry naming no i64 slot refuses" {
         "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
         "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Model.label\", \"class\": \"i64\"}",
     );
-    try expectRefusal(source, "integer_slots[1].slot", "resolves to no slot the sidecar spells i64");
+    try expectRefusal(source, "integer_slots[1].slot", "resolves to a slot the sidecar spells bytes, not i64");
+}
+
+test "V10: an unresolvable slot path refuses with the grammar's forms" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const ghost = try replaced(
+        arena,
+        minimal_valid_json,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Ghost.count\", \"class\": \"i64\"}",
+    );
+    try expectRefusal(ghost, "integer_slots[1].slot", "resolves against none of the sidecar's own tables");
+    // An element-indexing spelling has no grammar form either — the
+    // format-1 grammar cannot address inside a sequence.
+    const indexed = try replaced(
+        arena,
+        minimal_valid_json,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Model.ids[0]\", \"class\": \"i64\"}",
+    );
+    try expectRefusal(indexed, "integer_slots[1].slot", "resolves against none of the sidecar's own tables");
+    // A missing helper signature slot is the same refusal.
+    const helper = try replaced(
+        arena,
+        minimal_valid_json,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"helpers.rowCount.return\", \"class\": \"i64\"}",
+    );
+    try expectRefusal(helper, "integer_slots[1].slot", "resolves against none of the sidecar's own tables");
+}
+
+test "V10: a slot path landing on a slice refuses as the grammar's element gap" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A slice of i64 is a legal spelling (its elements are exempt from
+    // the bijection), but no entry may claim it: the grammar has no
+    // slice-element form, so the checker refuses rather than
+    // half-supporting element attestation.
+    var source = try replaced(
+        arena,
+        minimal_valid_json,
+        "{\"name\": \"label\", \"type\": {\"kind\": \"bytes\"}}",
+        "{\"name\": \"label\", \"type\": {\"kind\": \"bytes\"}}, {\"name\": \"ids\", \"type\": {\"kind\": \"slice\", \"elem\": {\"kind\": \"i64\"}}}",
+    );
+    source = try replaced(
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Model.ids\", \"class\": \"i64\"}",
+    );
+    try expectRefusal(source, "integer_slots[1].slot", "no slice-element form");
+}
+
+test "V10: a duplicate entry refuses with the exact index" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const source = try replaced(
+        arena_state.allocator(),
+        minimal_valid_json,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Model.count\", \"class\": \"u64\"}",
+    );
+    try expectRefusal(source, "integer_slots[1].slot", "duplicate entry for \"Model.count\"");
+}
+
+test "V10: the u64 class is accepted and carried" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const source = try replaced(arena, minimal_valid_json, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "{\"slot\": \"Model.count\", \"class\": \"u64\"}");
+    const sidecar = try readValid(arena, source);
+    try testing.expectEqual(@as(usize, 1), sidecar.integer_slots.len);
+    try testing.expectEqual(IntegerClass.u64, sidecar.integer_slots[0].class);
+}
+
+test "V10: class f64 in integer_slots refuses (the default class is never attested)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const source = try replaced(arena_state.allocator(), minimal_valid_json, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "{\"slot\": \"Model.count\", \"class\": \"f64\"}");
+    try expectRefusal(source, "integer_slots[0].class", "never attested");
+}
+
+test "V10: an unknown integer class refuses as reader-too-old" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const source = try replaced(arena_state.allocator(), minimal_valid_json, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "{\"slot\": \"Model.count\", \"class\": \"i128\"}");
+    try expectRefusal(source, "integer_slots[0].class", "unknown integer class \"i128\"");
+}
+
+test "V10: message-side slot paths spell the union's authored name" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var source = try replaced(arena, minimal_valid_json, "\"name\": \"Msg\"", "\"name\": \"Event\"");
+    source = try replaced(
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"tick\", \"payload\": {\"kind\": \"number\", \"class\": \"i64\"}}",
+    );
+    // The authored spelling resolves.
+    const authored = try replaced(
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Event.tick\", \"class\": \"i64\"}",
+    );
+    const sidecar = try readValid(arena, authored);
+    try testing.expectEqual(@as(usize, 2), sidecar.integer_slots.len);
+    // A literal `Msg` token does not: the grammar's message forms use
+    // the designated union's own name.
+    const literal = try replaced(
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Msg.tick\", \"class\": \"i64\"}",
+    );
+    try expectRefusal(literal, "integer_slots", "spells \"Event.tick\" i64 but attests no integer_slots entry");
+}
+
+test "V10: an empty integer_slots list is valid when nothing spells i64" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The f64-only sequencing: an emitter predating integer inference
+    // spells every numeric slot f64 and attests the empty list.
+    var source = try replaced(arena, minimal_valid_json, "{\"name\": \"count\", \"type\": {\"kind\": \"i64\"}}", "{\"name\": \"count\", \"type\": {\"kind\": \"f64\"}}");
+    source = try replaced(arena, source, "{\"slot\": \"Model.count\", \"class\": \"i64\"}", "");
+    const sidecar = try readValid(arena, source);
+    try testing.expectEqual(@as(usize, 0), sidecar.integer_slots.len);
 }
 
 test "V11: an unknown export suffix refuses" {

--- a/tools/corewire/sidecar.zig
+++ b/tools/corewire/sidecar.zig
@@ -1634,6 +1634,19 @@ fn validateIntegerSlots(arena: std.mem.Allocator, sidecar: Sidecar, diags: *Diag
             diags.flag("integer_slots", "the i64 slot at \"{s}\" involves a name containing '.', which the slot path grammar cannot address unambiguously — rename it in the core source (V10)", .{path.path});
         }
     }
+    // Two DISTINCT slots spelling one path is the same ambiguity from
+    // another direction (a message union named `helpers` whose
+    // number_bytes field spells a helper's return slot, a table type
+    // sharing the message union's name): the bijection would consume
+    // entries interchangeably and one attestation would silently govern
+    // both slots.
+    for (expected, 0..) |path, index| {
+        for (expected[0..index]) |earlier| {
+            if (std.mem.eql(u8, earlier.path, path.path)) {
+                diags.flag("integer_slots", "two distinct i64 slots spell the one path \"{s}\" — the slot-path grammar cannot address them separately, so their attestations cannot be told apart; rename one of the colliding surfaces in the core source (V10)", .{path.path});
+            }
+        }
+    }
     if (diags.hasErrors()) return;
 
     // One-to-one both ways: every expected slot consumes exactly one
@@ -2167,6 +2180,36 @@ test "V10: message-side slot paths spell the union's authored name" {
         "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"Msg.tick\", \"class\": \"i64\"}",
     );
     try expectRefusal(literal, "integer_slots", "spells \"Event.tick\" i64 but attests no integer_slots entry");
+}
+
+test "V10: two distinct slots spelling one path refuse as unaddressable" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // A message union named "helpers" whose number_bytes arm "peak"
+    // declares its number field "return", beside an exported helper
+    // "peak" returning i64: both slots spell "helpers.peak.return", so
+    // no attestation can be told apart from the other's.
+    var source = try replaced(arena, minimal_valid_json, "\"name\": \"Msg\"", "\"name\": \"helpers\"");
+    source = try replaced(
+        arena,
+        source,
+        "{\"name\": \"bump\", \"payload\": {\"kind\": \"void\"}}",
+        "{\"name\": \"peak\", \"payload\": {\"kind\": \"number_bytes\", \"number_field\": \"return\", \"number_class\": \"i64\", \"bytes_field\": \"body\"}}",
+    );
+    source = try replaced(
+        arena,
+        source,
+        "\"model_helpers\": []",
+        "\"model_helpers\": [{\"name\": \"peak\", \"params\": [], \"returns\": {\"kind\": \"i64\"}, \"arena\": false}]",
+    );
+    source = try replaced(
+        arena,
+        source,
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}",
+        "{\"slot\": \"Model.count\", \"class\": \"i64\"}, {\"slot\": \"helpers.peak.return\", \"class\": \"i64\"}, {\"slot\": \"helpers.peak.return\", \"class\": \"u64\"}",
+    );
+    try expectRefusal(source, "integer_slots", "two distinct i64 slots spell the one path \"helpers.peak.return\"");
 }
 
 test "V10: an empty integer_slots list is valid when nothing spells i64" {


### PR DESCRIPTION
## What

The contract sidecar's `integer_slots` attestation — the compiler's resolved integer class per boundary slot — is now validated and consumed end to end in corewire:

- **Structural validation**: every entry's slot path must resolve against the sidecar's own tables (struct fields, non-msg union arms, msg-arm payload forms, number_bytes fields, helper returns and params) under the format-1 grammar; the class set is closed ({i64, u64}); duplicates, colliding paths, unresolvable paths, and slice-element paths (inexpressible in format 1) refuse with exact-path teachings.
- **Class-faithful decoding**: generated mirrors decode an i64-attested slot as 8-byte two's-complement little-endian and a u64-attested slot as its unsigned twin; every non-attested slot stays f64 byte-identically. Dispatch narrows through matching 2^53 guards; the TypeScript facade routes u64-attested slots through a refusing unsigned encoder; host adapters accept u64 exactly where host value domains permit, with teachings where they do not.
- **Round-trip proof**: hand-computed little-endian goldens, ±(2^53 − 1) extremes, the full 8-byte wire range, and sign handling — through the codec and through a generated mirror (envelope, dispatch, snapshot).
- **External-artifact validation**: the conformance suite consumes a compiler-emitted sidecar via the existing external-artifact path (skipping cleanly when unset); a real emitted attestation validates end to end.
- **Exact-integer delivery window for audio**: audio scalars now clamp below 2^53 at every delivery boundary, mirroring the video doctrine, and replay refuses out-of-window audio records as journal damage.

## Compatibility

The session journal's semantic epoch bumps to 5: recordings made before the audio scalar window refuse to replay as a different generation rather than replaying with changed semantics. Stated in the changelog fragment.

## Proof

`zig build test`, `sidecar-conformance`, `test-ts-core-e2e`, and the Windows cross-compile all pass; corewire unit suites green across sidecar/emit/facade/extract/shim_rt.