### PR TITLE
fix(runtime/ts_ui_app): raise validateEnvMsgs eval branch quota

### DIFF
--- a/src/runtime/ts_ui_app.zig
+++ b/src/runtime/ts_ui_app.zig
@@ -286,6 +286,7 @@ pub fn TsUiApp(comptime core: type) type {
         /// hand-assembled cores: every `envMsgs` entry must name a Msg
         /// arm carrying exactly one bytes payload.
         fn validateEnvMsgs() void {
+            @setEvalBranchQuota(10_000);
             for (core.envMsgs) |entry| {
                 var found = false;
                 for (@typeInfo(Msg).@"union".fields) |arm| {


### PR DESCRIPTION
## Summary

`TsUiApp.validateEnvMsgs` is a comptime teaching re-derivation of the transpiler's NS1033 check. It walks `core.envMsgs` and, for each entry, iterates every `Msg` union arm with `std.mem.eql(u8, ...)` to confirm the arm exists and carries a single bytes payload.

The comptime branch count scales with `envMsgs.length * Msg.arm_count`. Generated cores with a large `Msg` union exceed the default `@setEvalBranchQuota` ceiling and fail to compile, forcing apps to carry a local overlay that raises the quota.

## Change

Raise the quota to `10_000` inside `validateEnvMsgs` only. The function is already invoked at comptime (`comptime validateEnvMsgs();`) and performs no runtime work, so behavior, journal, and protocols are unchanged.

## Why upstream

The quota ceiling is hit by any app whose generated `Msg`/`envMsgs` matrix is large enough; it is not app-specific behavior. Keeping it local means every SDK upgrade re-baselines the overlay for no semantic benefit.

## Verification

- The change is a single `@setEvalBranchQuota(10_000);` line at the top of an existing comptime function.
- This exact patch has been exercised through a full SDK overlay build (Debug + ReleaseFast) and the `native test` suite in a downstream app that triggered the original quota failure; those gates pass with the raised quota and fail without it.
- I did not run `zig build test` from the SDK repo root in this PR environment because a Zig 0.16 toolchain is not available here; reviewers with the toolchain can run the standard suite.