### PR TITLE
fix: keep terminal Tab input in the PTY

### DIFF
--- a/changelog.d/terminal-tab-input.md
+++ b/changelog.d/terminal-tab-input.md
@@ -1,0 +1,1 @@
+fix: **Terminal Tab input**: focused `<terminal>` components now send Tab and Shift+Tab to the PTY for completion, indentation, and TUI navigation instead of moving focus to a neighboring control.

--- a/changelog.d/terminal-tab-input.md
+++ b/changelog.d/terminal-tab-input.md
@@ -1,1 +1,1 @@
-fix: **Terminal Tab input**: focused `<terminal>` components now send Tab and Shift+Tab to the PTY for completion, indentation, and TUI navigation instead of moving focus to a neighboring control.
+fix: **Terminal Tab input**: focused live `<terminal>` components now send Tab and Shift+Tab to the PTY for completion, indentation, and TUI navigation, while focus-entry gestures and ended or unbound terminals retain ordinary traversal.

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -416,10 +416,63 @@ test "a live pty session flows through the <terminal> element: output, typing, r
     } });
     try testing.expectEqualStrings("ls\t", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
 
+    // Entering the live terminal is still traversal for the WHOLE
+    // physical Shift+Tab: neither an auto-repeat nor the matching
+    // release may leak into the pty (kitty reports releases, so this
+    // covers the otherwise-invisible orphan-release case too).
+    try h.app_state.effects.feedPtyOutput(app.shell_effect_key, "\x1b[>11u");
+    try h.frame();
+    const layout = try h.harness.runtime.canvasWidgetLayout(1, app.canvas_label);
+    var terminal_id: canvas.ObjectId = 0;
+    var divider_id: canvas.ObjectId = 0;
+    for (layout.nodes) |node| {
+        if (node.widget.kind == .terminal) terminal_id = node.widget.id;
+        if (node.widget.kind == .split_divider) divider_id = node.widget.id;
+    }
+    try testing.expect(terminal_id != 0);
+    try testing.expect(divider_id != 0);
+    const view_index = h.harness.runtime.findViewIndex(1, app.canvas_label) orelse return error.TestUnexpectedResult;
+    h.harness.runtime.views[view_index].canvas_widget_focused_id = divider_id;
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_up,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try testing.expectEqualStrings("ls\t", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
+
     // The session ends exactly once and the app notes it.
     try h.app_state.effects.feedPtyExit(app.shell_effect_key, 0, 0, .exited, 0);
     try h.frame();
     try testing.expect(h.app_state.model.shell_exited);
     try testing.expect(!h.app_state.model.shell_live);
     try testing.expect(!(try h.grid()).running);
+
+    // The binding remains the nonzero model-owned effect key after
+    // exit, but the grid is no longer running. Tab therefore leaves
+    // the terminal instead of becoming a dead-session focus trap.
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "tab",
+    } });
+    try testing.expectEqual(divider_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try testing.expectEqualStrings("", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
 }

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -403,10 +403,18 @@ test "a live pty session flows through the <terminal> element: output, typing, r
 
     // Focus the terminal (a click in the left pane) and type: the
     // keystrokes reach the pty through the journaled write path, with
-    // no app-side keyboard handling at all.
+    // no app-side keyboard handling at all. Tab belongs to the shell
+    // too (completion/indentation), rather than moving focus into the
+    // browser toolbar beside it.
     try h.click(200, 400);
     try h.typeText("ls");
-    try testing.expectEqualStrings("ls", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "tab",
+    } });
+    try testing.expectEqualStrings("ls\t", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
 
     // The session ends exactly once and the app notes it.
     try h.app_state.effects.feedPtyExit(app.shell_effect_key, 0, 0, .exited, 0);

--- a/src/runtime/canvas_widget_event_tests.zig
+++ b/src/runtime/canvas_widget_event_tests.zig
@@ -496,6 +496,99 @@ test "runtime dispatches routed canvas widget pointer events" {
     try std.testing.expect(app_state.last_keyboard_shift);
 }
 
+test "a focused terminal owns Tab instead of moving focus" {
+    const TestApp = struct {
+        keyboard_count: u32 = 0,
+        target_id: canvas.ObjectId = 0,
+        target_kind: canvas.WidgetKind = .stack,
+        focus_moved: bool = true,
+
+        fn app(self: *@This()) App {
+            return .{
+                .context = self,
+                .name = "gpu-terminal-tab",
+                .source = platform.WebViewSource.html("<h1>GPU</h1>"),
+                .event_fn = event,
+            };
+        }
+
+        fn event(context: *anyopaque, runtime: *Runtime, event_value: Event) anyerror!void {
+            _ = runtime;
+            const self: *@This() = @ptrCast(@alignCast(context));
+            switch (event_value) {
+                .canvas_widget_keyboard => |keyboard_event| {
+                    self.keyboard_count += 1;
+                    self.focus_moved = keyboard_event.keyboard.focus_moved;
+                    if (keyboard_event.target) |target| {
+                        self.target_id = target.id;
+                        self.target_kind = target.kind;
+                    }
+                },
+                else => {},
+            }
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    const app = app_state.app();
+    try harness.start(app);
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 320, 180),
+    });
+    const children = [_]canvas.Widget{
+        .{
+            .id = 2,
+            .kind = .terminal,
+            .frame = geometry.RectF.init(10, 10, 200, 100),
+            .terminal = .{ .pty = 7 },
+        },
+        .{
+            .id = 3,
+            .kind = .button,
+            .frame = geometry.RectF.init(220, 10, 80, 32),
+            .text = "Run",
+        },
+    };
+    var nodes: [3]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .panel, .children = &children },
+        geometry.RectF.init(0, 0, 320, 180),
+        &nodes,
+    );
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+
+    // Pointer focus starts in the terminal. Tab must route to that same
+    // widget with no focus move; the UiApp layer then hands it to the
+    // bound terminal session instead of the neighboring button.
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .pointer_down,
+        .x = 40,
+        .y = 40,
+    } });
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "tab",
+    } });
+    try std.testing.expectEqual(@as(u32, 1), app_state.keyboard_count);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), app_state.target_id);
+    try std.testing.expectEqual(canvas.WidgetKind.terminal, app_state.target_kind);
+    try std.testing.expect(!app_state.focus_moved);
+}
+
 test "runtime routes captured canvas pointer drags without outside release activation" {
     const TestApp = struct {
         command_count: u32 = 0,

--- a/src/runtime/canvas_widget_event_tests.zig
+++ b/src/runtime/canvas_widget_event_tests.zig
@@ -496,7 +496,7 @@ test "runtime dispatches routed canvas widget pointer events" {
     try std.testing.expect(app_state.last_keyboard_shift);
 }
 
-test "a focused terminal owns Tab instead of moving focus" {
+test "only a focused live terminal owns Tab and focus entry suppresses the whole gesture" {
     const TestApp = struct {
         keyboard_count: u32 = 0,
         target_id: canvas.ObjectId = 0,
@@ -542,12 +542,18 @@ test "a focused terminal owns Tab instead of moving focus" {
         .kind = .gpu_surface,
         .frame = geometry.RectF.init(0, 0, 320, 180),
     });
-    const children = [_]canvas.Widget{
+    var terminal_grid = canvas.TerminalGrid{
+        .background = canvas.Color.rgba(0, 0, 0, 1),
+        .foreground = canvas.Color.rgba(1, 1, 1, 1),
+        .cursor_color = canvas.Color.rgba(1, 1, 1, 1),
+        .selection_color = canvas.Color.rgba(0, 0.5, 1, 1),
+    };
+    var children = [_]canvas.Widget{
         .{
             .id = 2,
             .kind = .terminal,
             .frame = geometry.RectF.init(10, 10, 200, 100),
-            .terminal = .{ .pty = 7 },
+            .terminal = .{ .pty = 7, .grid = &terminal_grid },
         },
         .{
             .id = 3,
@@ -587,6 +593,104 @@ test "a focused terminal owns Tab instead of moving focus" {
     try std.testing.expectEqual(@as(canvas.ObjectId, 2), app_state.target_id);
     try std.testing.expectEqual(canvas.WidgetKind.terminal, app_state.target_kind);
     try std.testing.expect(!app_state.focus_moved);
+
+    // A Tab pressed while the terminal already owns focus is terminal
+    // input for its whole lifetime, including the release protocols
+    // such as kitty keyboard reporting can encode.
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_up,
+        .key = "tab",
+    } });
+    try std.testing.expectEqual(@as(u32, 2), app_state.keyboard_count);
+
+    // The inverse gesture is focus traversal: Shift+Tab from the button
+    // enters the live terminal, but its repeat and release must not be
+    // reinterpreted against the newly focused pty.
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .pointer_down,
+        .x = 240,
+        .y = 24,
+    } });
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), harness.runtime.views[0].canvas_widget_focused_id);
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try std.testing.expectEqual(@as(u32, 3), app_state.keyboard_count);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), app_state.target_id);
+    try std.testing.expect(app_state.focus_moved);
+    try std.testing.expect(harness.runtime.views[0].canvas_widget_terminal_focus_entry_tab_held);
+
+    // Auto-repeat while Tab is held, then its key-up: neither produces
+    // another widget event at the terminal.
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_up,
+        .key = "tab",
+        .modifiers = .{ .shift = true },
+    } });
+    try std.testing.expectEqual(@as(u32, 3), app_state.keyboard_count);
+    try std.testing.expect(!harness.runtime.views[0].canvas_widget_terminal_focus_entry_tab_held);
+
+    // The same nonzero binding after session exit is no longer an input
+    // owner: its published grid says the session cannot accept input,
+    // so Tab resumes ordinary traversal to the button.
+    terminal_grid.running = false;
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "tab",
+    } });
+    try std.testing.expectEqual(@as(u32, 4), app_state.keyboard_count);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), app_state.target_id);
+    try std.testing.expect(app_state.focus_moved);
+
+    // The explicit unbound sentinel behaves the same even if a caller
+    // supplied a running-looking grid by mistake: no pty means no Tab
+    // input owner.
+    terminal_grid.running = true;
+    children[0].terminal.pty = 0;
+    const unbound_layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .panel, .children = &children },
+        geometry.RectF.init(0, 0, 320, 180),
+        &nodes,
+    );
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", unbound_layout);
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .pointer_down,
+        .x = 40,
+        .y = 40,
+    } });
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "tab",
+    } });
+    try std.testing.expectEqual(@as(u32, 5), app_state.keyboard_count);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), app_state.target_id);
+    try std.testing.expect(app_state.focus_moved);
 }
 
 test "runtime routes captured canvas pointer drags without outside release activation" {

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2298,17 +2298,31 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             if (self.views[index].kind != .gpu_surface) return false;
 
             const current_id: ?canvas.ObjectId = if (self.views[index].canvas_widget_focused_id == 0) null else self.views[index].canvas_widget_focused_id;
+            const layout = self.views[index].widgetLayoutTree();
             if (std.ascii.eqlIgnoreCase(input_event.key, "tab")) {
+                // A terminal owns Tab as INPUT (completion, indentation,
+                // and TUI navigation), not as focus traversal. Decide
+                // against the pre-key focus before choosing the next
+                // target: the routed keyboard pass below will therefore
+                // address this same terminal and its emulator can encode
+                // Tab/Shift+Tab for the pty. Disabled/hidden terminals
+                // cannot occupy the focus register because
+                // focusTargetById rejects them, so stale focus still
+                // falls through to the ordinary traversal repair.
+                if (current_id) |id| {
+                    if (layout.focusTargetById(id)) |current| {
+                        if (current.kind == .terminal) return false;
+                    }
+                }
                 const direction: canvas.WidgetFocusDirection = if (input_event.modifiers.shift) .backward else .forward;
                 const target = if (current_id) |id|
-                    self.views[index].canvasWidgetScopedFocusTarget(id, direction) orelse self.views[index].widgetLayoutTree().focusTarget(current_id, direction) orelse return false
+                    self.views[index].canvasWidgetScopedFocusTarget(id, direction) orelse layout.focusTarget(current_id, direction) orelse return false
                 else
-                    self.views[index].widgetLayoutTree().focusTarget(current_id, direction) orelse return false;
+                    layout.focusTarget(current_id, direction) orelse return false;
                 return try setCanvasWidgetFocusFromKeyboardMoved(self, index, current_id, target.id);
             }
 
             const focused_id = current_id orelse return false;
-            const layout = self.views[index].widgetLayoutTree();
             const focused = layout.focusTargetById(focused_id) orelse return false;
             // FRAMEWORK BEHAVIOR CHANGE (deliberate, scoped — the same
             // seam as the keyboard-routing gate below): arrows and

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2292,6 +2292,18 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
         /// widget — the caller stamps it onto the routed keyboard event
         /// (`focus_moved`) so tree rows can tell selection-follows-focus
         /// arrivals from in-place collapse/expand intents.
+        pub fn consumeCanvasWidgetTerminalFocusEntryTab(self: *Runtime, input_event: GpuSurfaceInputEvent) bool {
+            if (input_event.kind != .key_down and input_event.kind != .key_up) return false;
+            if (!std.ascii.eqlIgnoreCase(input_event.key, "tab")) return false;
+            const index = runtimeFindViewIndex(self, input_event.window_id, input_event.label) orelse return false;
+            if (self.views[index].kind != .gpu_surface) return false;
+            if (!self.views[index].canvas_widget_terminal_focus_entry_tab_held) return false;
+            if (input_event.kind == .key_up) {
+                self.views[index].canvas_widget_terminal_focus_entry_tab_held = false;
+            }
+            return true;
+        }
+
         pub fn updateCanvasWidgetFocusFromKeyboardInput(self: *Runtime, input_event: GpuSurfaceInputEvent) anyerror!bool {
             if (input_event.kind != .key_down) return false;
             const index = runtimeFindViewIndex(self, input_event.window_id, input_event.label) orelse return false;
@@ -2311,7 +2323,7 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                 // falls through to the ordinary traversal repair.
                 if (current_id) |id| {
                     if (layout.focusTargetById(id)) |current| {
-                        if (current.kind == .terminal) return false;
+                        if (canvasWidgetTerminalOwnsTabInput(layout, current)) return false;
                     }
                 }
                 const direction: canvas.WidgetFocusDirection = if (input_event.modifiers.shift) .backward else .forward;
@@ -2319,7 +2331,16 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                     self.views[index].canvasWidgetScopedFocusTarget(id, direction) orelse layout.focusTarget(current_id, direction) orelse return false
                 else
                     layout.focusTarget(current_id, direction) orelse return false;
-                return try setCanvasWidgetFocusFromKeyboardMoved(self, index, current_id, target.id);
+                const moved = try setCanvasWidgetFocusFromKeyboardMoved(self, index, current_id, target.id);
+                if (moved and canvasWidgetTerminalOwnsTabInput(layout, target)) {
+                    // The key-down moved focus INTO this live terminal;
+                    // it is traversal, not terminal input. Hold that
+                    // classification through auto-repeat and key-up so
+                    // the same physical gesture cannot leak a Tab press
+                    // (legacy) or orphan release (kitty) into the pty.
+                    self.views[index].canvas_widget_terminal_focus_entry_tab_held = true;
+                }
+                return moved;
             }
 
             const focused_id = current_id orelse return false;
@@ -2453,6 +2474,14 @@ fn runtimeFindViewIndex(self: anytype, window_id: platform.WindowId, label: []co
         if (view.open and view.window_id == window_id and std.mem.eql(u8, view.label, label)) return index;
     }
     return null;
+}
+
+fn canvasWidgetTerminalOwnsTabInput(layout: canvas.WidgetLayoutTree, target: canvas.WidgetFocusTarget) bool {
+    if (target.kind != .terminal or target.index >= layout.nodes.len) return false;
+    const terminal = layout.nodes[target.index].widget.terminal;
+    if (terminal.pty == 0) return false;
+    const grid = terminal.grid orelse return false;
+    return grid.running;
 }
 
 fn canvasDirtyRegionForView(view_frame: geometry.RectF, local_dirty: geometry.RectF) ?geometry.RectF {

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2288,10 +2288,10 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             try dispatchCanvasWidgetCommandForId(self, app, index, target.id);
         }
 
-        /// Returns true when the key moved keyboard focus to a DIFFERENT
-        /// widget — the caller stamps it onto the routed keyboard event
-        /// (`focus_moved`) so tree rows can tell selection-follows-focus
-        /// arrivals from in-place collapse/expand intents.
+        /// Returns true for an auto-repeat or release belonging to the
+        /// physical Tab gesture that moved focus into a live terminal.
+        /// The caller suppresses that transition; the release also
+        /// retires the gesture latch.
         pub fn consumeCanvasWidgetTerminalFocusEntryTab(self: *Runtime, input_event: GpuSurfaceInputEvent) bool {
             if (input_event.kind != .key_down and input_event.kind != .key_up) return false;
             if (!std.ascii.eqlIgnoreCase(input_event.key, "tab")) return false;
@@ -2304,6 +2304,10 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             return true;
         }
 
+        /// Returns true when the key moved keyboard focus to a DIFFERENT
+        /// widget — the caller stamps it onto the routed keyboard event
+        /// (`focus_moved`) so tree rows can tell selection-follows-focus
+        /// arrivals from in-place collapse/expand intents.
         pub fn updateCanvasWidgetFocusFromKeyboardInput(self: *Runtime, input_event: GpuSurfaceInputEvent) anyerror!bool {
             if (input_event.kind != .key_down) return false;
             const index = runtimeFindViewIndex(self, input_event.window_id, input_event.label) orelse return false;

--- a/src/runtime/gpu_surface_events.zig
+++ b/src/runtime/gpu_surface_events.zig
@@ -346,17 +346,23 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
                     self.targetless_ime_preedit_label[0..self.targetless_ime_preedit_label_len],
                     input_event.label,
                 );
-            const keyboard_dismissed_id = if (targetless_composition_owns_keys)
+            // A Tab key-down that moved focus INTO a live terminal is a
+            // focus gesture for its whole physical lifetime. Suppress
+            // its auto-repeats and release before any widget pass can
+            // reinterpret them against the newly focused terminal.
+            const terminal_focus_entry_tab_suppressed =
+                CanvasWidgetEventMethods().consumeCanvasWidgetTerminalFocusEntryTab(self, input_event);
+            const keyboard_dismissed_id = if (targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
                 0
             else
                 try CanvasWidgetEventMethods().dismissCanvasWidgetSurfaceFromKeyboardInput(self, input_event);
             if (keyboard_dismissed_id != 0) dismissed_surface_id = keyboard_dismissed_id;
             const widget_surface_dismissed = keyboard_dismissed_id != 0;
-            const widget_focus_moved = if (widget_surface_dismissed or targetless_composition_owns_keys)
+            const widget_focus_moved = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
                 false
             else
                 try CanvasWidgetEventMethods().updateCanvasWidgetFocusFromKeyboardInput(self, input_event);
-            var widget_keyboard_event = if (widget_surface_dismissed or targetless_composition_owns_keys)
+            var widget_keyboard_event = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
                 null
             else
                 CanvasWidgetEventMethods().routeCanvasWidgetKeyboardInput(self, input_event, &self.widget_event_route_entries) catch |err| switch (err) {
@@ -617,7 +623,9 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
             if (widget_keyboard_event) |keyboard_event| {
                 try CanvasWidgetEventMethods().dispatchCanvasWidgetCommandFromKeyboard(self, app, keyboard_event);
                 try self.dispatchEvent(app, .{ .canvas_widget_keyboard = keyboard_event });
-            } else if ((input_event.kind == .key_down or input_event.kind == .key_up) and !widget_surface_dismissed) {
+            } else if ((input_event.kind == .key_down or input_event.kind == .key_up) and
+                !widget_surface_dismissed and !terminal_focus_entry_tab_suppressed)
+            {
                 // No focused widget routed this key (nothing is
                 // focused, or the focused id is gone from the tree): the
                 // key still reaches the app, as a TARGET-LESS keyboard

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -5359,6 +5359,15 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                         // session declines, and the key falls through
                         // (an app may bind a restart chord).
                         if (widget.kind == .terminal and widget.terminal.pty != 0) {
+                            // Focus traversal/spatial navigation routes
+                            // the arriving key to the NEW target. That
+                            // key moved focus; it is not terminal input
+                            // (Tabbing into a terminal must not also
+                            // complete at the shell prompt). Once the
+                            // terminal already owns focus, the focus pass
+                            // leaves Tab in place and this flag is false,
+                            // so Tab/Shift+Tab encode normally below.
+                            if (keyboard_event.keyboard.focus_moved) return;
                             // The runtime clipboard pass already copied
                             // this emulator selection. Do not forward the
                             // same Cmd/Ctrl+C chord to the child (where

--- a/src/runtime/view.zig
+++ b/src/runtime/view.zig
@@ -159,6 +159,12 @@ pub fn clearImeGraceOnViewBlur(runtime: anytype, view: *RuntimeView) void {
     // otherwise leave the carry armed to swallow the refocused view's
     // first unrelated commit.
     view.canvas_widget_claimed_key_grace = .none;
+    // A Tab that entered a live terminal suppresses its repeats and
+    // release until the physical key comes up. If the view blurs first,
+    // that release may never arrive here; retire the latch with the
+    // other view-local input graces so a later Tab is never mistaken
+    // for the tail of the old gesture.
+    view.canvas_widget_terminal_focus_entry_tab_held = false;
     if ((runtime.targetless_ime_preedit_len > 0 or
         runtime.targetless_ime_commit_grace) and
         runtime.targetless_ime_preedit_window == view.window_id and
@@ -525,6 +531,12 @@ pub const RuntimeView = struct {
     /// one is still held, on hosts that emit input-method text before
     /// its key_down) flows instead of being eaten by a stale latch.
     canvas_widget_claimed_key_grace: CanvasWidgetClaimedKeyGrace = .none,
+    /// A physical Tab whose first key-down moved focus INTO a live
+    /// terminal. Its auto-repeats and eventual release still belong to
+    /// focus traversal, not the newly focused pty; the gpu-input pass
+    /// suppresses those transitions and clears this on key-up (or view
+    /// blur through `clearImeGraceOnViewBlur`).
+    canvas_widget_terminal_focus_entry_tab_held: bool = false,
     canvas_widget_focus_visible_id: canvas.ObjectId = 0,
     /// True when `canvas_widget_focus_visible_id` was written by the
     /// KEYBOARD focus contract (`setCanvasWidgetFocusFromKeyboard`) —


### PR DESCRIPTION
- Keep focus on active terminal components while routing Tab and Shift+Tab to the PTY.
- Prevent focus-entry keys from reaching the shell and add router plus live-session regressions.