### PR TITLE
fix: hide workbench terminal focus rule

### DIFF
--- a/changelog.d/workbench-terminal-focus-ring.md
+++ b/changelog.d/workbench-terminal-focus-ring.md
@@ -1,1 +1,2 @@
-fix: **Clean workbench terminal focus**: the full-bleed terminal pane now keeps keyboard focus without showing its clipped focus ring as a stray horizontal rule beneath the titlebar.
+fix: **Clear terminal focus**: terminal cursors now fill while their live session owns keyboard focus and switch to a hollow outline when focus leaves or the session ends.
+- **Clean workbench terminal chrome**: the full-bleed terminal pane keeps keyboard focus without showing its clipped outer focus ring as a stray horizontal rule beneath the titlebar.

--- a/changelog.d/workbench-terminal-focus-ring.md
+++ b/changelog.d/workbench-terminal-focus-ring.md
@@ -1,0 +1,1 @@
+fix: **Clean workbench terminal focus**: the full-bleed terminal pane now keeps keyboard focus without showing its clipped focus ring as a stray horizontal rule beneath the titlebar.

--- a/examples/terminal/src/grid.zig
+++ b/examples/terminal/src/grid.zig
@@ -26,6 +26,7 @@ pub const max_cells: usize = 7168;
 /// Stable command-id namespace for grid commands so the retained
 /// renderer matches rows across rebuilds and damage stays row-shaped.
 const grid_id_base: u64 = 0x7e21_0000_0000_0000;
+pub const cursor_command_id: u64 = grid_id_base + 0x1_0000_0000;
 
 /// One text run's staging capacity — shared by the paint loop's scratch
 /// and the preflight's per-cell cap so measure and emission agree.
@@ -465,6 +466,10 @@ pub const PaintOptions = struct {
     /// The pty is live (cursor paints filled; an ended session paints
     /// the cursor hollow).
     running: bool,
+    /// Whether this terminal window currently owns keyboard focus.
+    /// A live cursor fills only while focused; blur leaves its outline
+    /// in place as the conventional inactive-terminal cue.
+    focused: bool = true,
     /// Selection mode is armed (the head cell paints a focus outline).
     selecting: bool,
     /// Hard ceiling on display-list commands this paint may emit — the
@@ -868,7 +873,8 @@ pub fn paint(session: *Session, builder: *canvas.Builder, options: PaintOptions)
         }
     }
 
-    // The cursor, over the ink: filled while live, hollow after exit.
+    // The cursor, over the ink: filled only while focused and live;
+    // blur or session exit leaves the conventional hollow outline.
     if (rs.cursor.visible) {
         if (rs.cursor.viewport) |cursor| {
             const cursor_x = origin_x + @as(f32, @floatFromInt(cursor.x)) * cell_w;
@@ -884,11 +890,19 @@ pub fn paint(session: *Session, builder: *canvas.Builder, options: PaintOptions)
                 .underline => geometry.RectF.init(cursor_x, cursor_y + cell_h - 2, cell_w, 2),
                 else => geometry.RectF.init(cursor_x, cursor_y, cell_w, cell_h),
             };
-            try builder.fillRect(.{
-                .id = grid_id_base + 0x1_0000_0000,
-                .rect = rect,
-                .fill = .{ .color = cursor_color },
-            });
+            if (options.focused and options.running) {
+                try builder.fillRect(.{
+                    .id = cursor_command_id,
+                    .rect = rect,
+                    .fill = .{ .color = cursor_color },
+                });
+            } else {
+                try builder.strokeRect(.{
+                    .id = cursor_command_id,
+                    .rect = rect,
+                    .stroke = .{ .fill = .{ .color = cursor_color }, .width = 1 },
+                });
+            }
         }
     }
 

--- a/examples/terminal/src/main.zig
+++ b/examples/terminal/src/main.zig
@@ -115,6 +115,10 @@ pub const Model = struct {
     /// the app starts); everything inside derives from journaled inputs.
     session: *grid.Session,
     phase: Phase = .starting,
+    /// This single-window app owns terminal keyboard input exactly while
+    /// the application is active. Lifecycle messages rebuild the custom
+    /// chrome so the cursor fills on focus and hollows on blur.
+    focused: bool = true,
     exit_code: i32 = 0,
     exit_signal: i32 = 0,
     exit_reason: native_sdk.EffectExitReason = .exited,
@@ -194,6 +198,7 @@ pub const Msg = union(enum) {
     /// points, accumulated into whole rows of scrollback.
     wheel: f32,
     chrome_changed: native_sdk.platform.WindowChrome,
+    focus_changed: bool,
 };
 
 const TerminalApp = native_sdk.UiApp(Model, Msg);
@@ -317,6 +322,9 @@ pub fn update(model: *Model, msg: Msg, fx: *Fx) void {
         },
         .chrome_changed => |chrome| {
             model.chrome_top = chrome.insets.top;
+        },
+        .focus_changed => |focused| {
+            model.focused = focused;
         },
         .wheel => |delta| {
             // Natural direction, like every terminal: swiping the
@@ -538,6 +546,14 @@ fn onWheel(wheel: native_sdk.platform.WheelEvent) ?Msg {
 
 fn onChrome(chrome: native_sdk.platform.WindowChrome) ?Msg {
     return .{ .chrome_changed = chrome };
+}
+
+fn onLifecycle(event: native_sdk.LifecycleEvent) ?Msg {
+    return switch (event) {
+        .activate => .{ .focus_changed = true },
+        .deactivate => .{ .focus_changed = false },
+        else => null,
+    };
 }
 
 fn handleKey(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent) void {
@@ -860,6 +876,7 @@ fn buildChrome(model: *const Model, builder: *canvas.Builder, size: geometry.Siz
         .background_frame = geometry.RectF.init(0, 0, size.width, size.height),
         .tokens = tokens,
         .running = model.phase == .live or model.phase == .starting,
+        .focused = model.focused,
         .selecting = model.selecting,
         .command_budget = grid_command_budget,
         .text_reserve = grid_text_reserve,
@@ -921,6 +938,7 @@ pub fn appOptions() TerminalApp.Options {
         .on_text = onText,
         .on_wheel = onWheel,
         .on_chrome = onChrome,
+        .on_lifecycle = onLifecycle,
         .on_frame = onFrame,
         .chrome = .{
             .prefix_commands = grid_command_budget,

--- a/examples/terminal/src/tests.zig
+++ b/examples/terminal/src/tests.zig
@@ -131,6 +131,44 @@ test "the grid paints real text runs with theme-derived ANSI and exact truecolor
     try testing.expect(saw_exact);
 }
 
+test "the custom cursor fills only while focused and live" {
+    const session = try createSession(20, 4);
+    defer session.destroy();
+
+    var focused_commands: [64]canvas.CanvasCommand = undefined;
+    var focused_builder = canvas.Builder.init(&focused_commands);
+    try grid.paint(session, &focused_builder, .{
+        .frame = geometry.RectF.init(0, 0, 200, 100),
+        .tokens = .{},
+        .running = true,
+        .focused = true,
+        .selecting = false,
+    });
+    try expectCursorPaintKind(focused_builder.displayList(), .filled);
+
+    var blurred_commands: [64]canvas.CanvasCommand = undefined;
+    var blurred_builder = canvas.Builder.init(&blurred_commands);
+    try grid.paint(session, &blurred_builder, .{
+        .frame = geometry.RectF.init(0, 0, 200, 100),
+        .tokens = .{},
+        .running = true,
+        .focused = false,
+        .selecting = false,
+    });
+    try expectCursorPaintKind(blurred_builder.displayList(), .hollow);
+
+    var ended_commands: [64]canvas.CanvasCommand = undefined;
+    var ended_builder = canvas.Builder.init(&ended_commands);
+    try grid.paint(session, &ended_builder, .{
+        .frame = geometry.RectF.init(0, 0, 200, 100),
+        .tokens = .{},
+        .running = false,
+        .focused = true,
+        .selecting = false,
+    });
+    try expectCursorPaintKind(ended_builder.displayList(), .hollow);
+}
+
 test "a styled wide character's background covers both of its cells" {
     const session = try createSession(30, 4);
     defer session.destroy();
@@ -383,6 +421,17 @@ test "grid clamping trades rows for columns inside the cell budget" {
 
 const TerminalApp = native_sdk.UiApp(app.Model, app.Msg);
 
+const CursorPaintKind = enum { filled, hollow };
+
+fn expectCursorPaintKind(display_list: anytype, expected: CursorPaintKind) !void {
+    const command = display_list.findCommandById(grid.cursor_command_id) orelse return error.TestExpectedCursor;
+    switch (command.command) {
+        .fill_rect => try testing.expectEqual(CursorPaintKind.filled, expected),
+        .stroke_rect => try testing.expectEqual(CursorPaintKind.hollow, expected),
+        else => return error.TestUnexpectedCursorCommand,
+    }
+}
+
 const JournalBuffer = struct {
     bytes: [512 * 1024]u8 = undefined,
     len: usize = 0,
@@ -565,6 +614,28 @@ fn startFocusedTerminal(gpa: std.mem.Allocator, harness: anytype) !*TerminalApp 
         .y = 200,
     } });
     return app_state;
+}
+
+test "terminal lifecycle focus rebuilds the custom cursor fill" {
+    const gpa = testing.allocator;
+    const harness = try native_sdk.TestHarness().create(gpa, .{ .size = geometry.SizeF.init(980, 640) });
+    defer harness.destroy(gpa);
+    const app_state = try startFocusedTerminal(gpa, harness);
+    defer gpa.destroy(app_state);
+    defer app_state.model.session.destroy();
+    defer app_state.deinit();
+    const app_iface = app_state.app();
+
+    try testing.expect(app_state.model.focused);
+    try expectCursorPaintKind(harness.runtime.views[0].canvasDisplayList(), .filled);
+
+    try harness.runtime.dispatchPlatformEvent(app_iface, .app_deactivated);
+    try testing.expect(!app_state.model.focused);
+    try expectCursorPaintKind(harness.runtime.views[0].canvasDisplayList(), .hollow);
+
+    try harness.runtime.dispatchPlatformEvent(app_iface, .app_activated);
+    try testing.expect(app_state.model.focused);
+    try expectCursorPaintKind(harness.runtime.views[0].canvasDisplayList(), .filled);
 }
 
 test "IME: a preedit is provisional; only the commit reaches the pty" {

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -87,6 +87,10 @@ test "the markup lays a terminal-left split with a browser toolbar and no tabs" 
     try testing.expectEqual(canvas.WidgetKind.terminal, terminal.kind);
     try testing.expectEqual(app.shell_effect_key, terminal.terminal.pty);
     try testing.expectEqual(@as(u32, 0), terminal.terminal.scrollback);
+    // Full-bleed terminal chrome: keyboard focus stays functional, but
+    // its ring dissolves into the pane instead of leaving only the
+    // exposed top edge visible as a stray horizontal rule.
+    try testing.expectEqualDeep((canvas.DesignTokens{}).colors.background, terminal.style.focus_ring.?);
 
     // The browser chrome is the whole toolbar: back, forward, reload,
     // address bar — and nothing else. No tabs anywhere in the tree.

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -15,6 +15,7 @@ const Model = app.Model;
 const Msg = app.Msg;
 const WorkbenchUi = canvas.Ui(Msg);
 const WorkbenchApp = native_sdk.UiApp(Model, Msg);
+const CursorPaintKind = enum { filled, hollow };
 
 fn buildTree(arena: std.mem.Allocator, model: *const Model) !WorkbenchUi.Tree {
     var ui = WorkbenchUi.init(arena);
@@ -55,6 +56,16 @@ fn fakeEffects() app.Effects {
     var fx = app.Effects.init(testing.allocator);
     fx.executor = .fake;
     return fx;
+}
+
+fn expectTerminalCursorPaint(harness: *native_sdk.TestHarness(), terminal_id: canvas.ObjectId, expected: CursorPaintKind) !void {
+    const cursor_id = canvas.terminal_grid.paintIdBase(terminal_id) + 0x61_0002;
+    const command = (try harness.runtime.canvasDisplayList(1, app.canvas_label)).findCommandById(cursor_id) orelse return error.TestExpectedCursor;
+    switch (command.command) {
+        .fill_rect => try testing.expectEqual(CursorPaintKind.filled, expected),
+        .stroke_rect => try testing.expectEqual(CursorPaintKind.hollow, expected),
+        else => return error.TestUnexpectedCursorCommand,
+    }
 }
 
 // ------------------------------------------------------------------ layout
@@ -479,4 +490,46 @@ test "a live pty session flows through the <terminal> element: output, typing, r
     } });
     try testing.expectEqual(divider_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
     try testing.expectEqualStrings("", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
+}
+
+test "the terminal cursor follows app and key-window keyboard ownership" {
+    if (comptime !native_sdk.runtime.terminal_sessions_enabled) return error.SkipZigTest;
+    var h = try Harness.create();
+    defer h.destroy();
+
+    try h.app_state.effects.feedPtyOutput(app.shell_effect_key, "demo$ ");
+    try h.frame();
+    try h.click(200, 400);
+
+    const layout = try h.harness.runtime.canvasWidgetLayout(1, app.canvas_label);
+    var terminal_id: canvas.ObjectId = 0;
+    for (layout.nodes) |node| {
+        if (node.widget.kind == .terminal) terminal_id = node.widget.id;
+    }
+    try testing.expect(terminal_id != 0);
+    const view_index = h.harness.runtime.findViewIndex(1, app.canvas_label) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .filled);
+
+    // App blur hollows the cursor but preserves the per-window focus
+    // memory that activation restores.
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .app_deactivated);
+    try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .hollow);
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .app_activated);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .filled);
+
+    // Moving key status to another app window has the same pixel
+    // consequence without discarding the first window's remembered
+    // widget focus.
+    const second = try h.harness.runtime.createWindow(.{
+        .label = "tools",
+        .title = "Tools",
+        .source = native_sdk.platform.WebViewSource.html("<p>Tools</p>"),
+    });
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .window_focused = second.id });
+    try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .hollow);
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .window_focused = 1 });
+    try expectTerminalCursorPaint(h.harness, terminal_id, .filled);
 }

--- a/examples/workbench/src/workbench.native
+++ b/examples/workbench/src/workbench.native
@@ -17,8 +17,11 @@
            with only the lights floating over it. -->
       <row height="{titlebar_band}" window-drag="true"></row>
       <!-- Autofocused: a terminal window's keyboard belongs to the shell
-           the moment it opens, no click first. -->
-      <terminal pty="{shell_key}" scrollback="{term_scrollback}" on-terminal="term_state" autofocus="true" grow="1" label="Shell" />
+           the moment it opens, no click first. This is a full-bleed pane,
+           so dissolve its focus ring into the background; otherwise the
+           exposed top edge reads as a stray rule while the other three
+           edges disappear into the window and split boundaries. -->
+      <terminal pty="{shell_key}" scrollback="{term_scrollback}" on-terminal="term_state" autofocus="true" grow="1" focus-ring="background" label="Shell" />
     </column>
     <column min-width="420">
       <!-- The browser toolbar: navigation cluster, then the address bar

--- a/src/platform/windows/root.zig
+++ b/src/platform/windows/root.zig
@@ -1839,6 +1839,25 @@ test "windows WM_CLOSE hide consults the live tray state and downgrades to a rea
     try std.testing.expect(std.mem.indexOf(u8, close_hook, "downgraded to a real close") != null);
 }
 
+test "windows window focus includes focused native child views" {
+    // This predicate lives in the C++ host, where the real HWND tree is
+    // available. Pin the two parts of its contract textually: focus is
+    // resolved through GA_ROOT, and every emitted window frame uses
+    // that shared answer. Cross-target host builds compile the code;
+    // the Windows canvas smoke supplies the live child-focus exercise.
+    const host_source = @embedFile("webview2_host.cpp");
+    const predicate_at = std.mem.indexOf(u8, host_source, "static bool windowOwnsKeyboardFocus(const Window &window)");
+    try std.testing.expect(predicate_at != null);
+    const predicate = host_source[predicate_at.?..];
+    try std.testing.expect(std.mem.indexOf(u8, predicate, "GetAncestor(focused, GA_ROOT) == window.hwnd") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "event.focused = windowOwnsKeyboardFocus(window);") != null);
+    const focus_edge_at = std.mem.indexOf(u8, host_source, "case WM_SETFOCUS:");
+    try std.testing.expect(focus_edge_at != null);
+    const focus_edge = host_source[focus_edge_at.?..];
+    try std.testing.expect(std.mem.indexOf(u8, focus_edge, "HWND root = GetAncestor(hwnd, GA_ROOT);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, focus_edge, "entry.second.hwnd == root") != null);
+}
+
 test "windows audio event maps kinds and payload" {
     var event = std.mem.zeroes(WindowsEvent);
     event.audio_kind = 1;

--- a/src/platform/windows/webview2_host.cpp
+++ b/src/platform/windows/webview2_host.cpp
@@ -1214,6 +1214,18 @@ static std::string extractHtmlClipboardFragment(const std::string &payload) {
 
 static UINT dpiForWindow(HWND hwnd);
 
+/* A Win32 top-level window keeps keyboard ownership while focus lives
+ * in any of its native child views. GetFocus() returns the CHILD HWND in
+ * that case (GPU surfaces and hosted controls alike), so direct equality
+ * with window.hwnd falsely reports the owning window blurred exactly
+ * while its child is receiving keyboard input. Walking to GA_ROOT makes
+ * the window-level flag match Win32's active focus tree. */
+static bool windowOwnsKeyboardFocus(const Window &window) {
+    if (!window.hwnd) return false;
+    HWND focused = GetFocus();
+    return focused && GetAncestor(focused, GA_ROOT) == window.hwnd;
+}
+
 static void emit(Host *host, const Window &window, EventKind kind) {
     if (!host || !host->callback) return;
     RECT rect = {};
@@ -1232,7 +1244,7 @@ static void emit(Host *host, const Window &window, EventKind kind) {
     event.x = window.x;
     event.y = window.y;
     event.open = window.hwnd != nullptr;
-    event.focused = window.hwnd && GetFocus() == window.hwnd;
+    event.focused = windowOwnsKeyboardFocus(window);
     event.hidden = window.policy_hidden ? 1 : 0;
     event.label = window.label.c_str();
     event.label_len = window.label.size();
@@ -5072,6 +5084,18 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
             return 0;
         case WM_SETFOCUS:
         case WM_KILLFOCUS:
+            if (host) {
+                /* Native child views own Win32 focus directly. Project
+                 * their focus edges onto the owning top-level window so
+                 * runtime key-window state follows child-to-child and
+                 * cross-window focus moves, not only the rare edges
+                 * delivered to the top-level HWND itself. */
+                HWND root = GetAncestor(hwnd, GA_ROOT);
+                for (auto &entry : host->windows) {
+                    if (entry.second.hwnd == root) emit(host, entry.second, kWindowFrame);
+                }
+            }
+            return 0;
         case WM_MOVE:
             if (host) {
                 for (auto &entry : host->windows) {

--- a/src/primitives/canvas/terminal_grid.zig
+++ b/src/primitives/canvas/terminal_grid.zig
@@ -243,6 +243,12 @@ pub const TerminalPaintOptions = struct {
     /// Grid origin and extent in canvas points (the text region).
     frame: geometry.RectF,
     tokens: canvas.DesignTokens,
+    /// Whether this terminal owns keyboard focus. A live focused cursor
+    /// paints solid; an unfocused cursor paints as a hollow outline, the
+    /// conventional terminal-window focus cue. Defaults on for direct
+    /// painter callers; the `.terminal` widget always supplies its live
+    /// logical focus state.
+    focused: bool = true,
     /// The rect the grid background fills — the widget's whole frame,
     /// so the inset text region sits on a full-bleed surface. Null
     /// fills `frame` (tests that paint the grid alone).
@@ -894,8 +900,10 @@ pub fn paint(grid: TerminalGrid, builder: *canvas.Builder, options: TerminalPain
         painted_rows = row_index + 1;
     }
 
-    // The cursor, over the ink: filled while live, hollow-dim after exit.
-    // Suppressed if its row was never painted (dropped for budget).
+    // The cursor, over the ink: solid only while this live terminal owns
+    // keyboard focus. Blur leaves the conventional hollow terminal
+    // cursor; an ended session keeps that outline at the dimmer stopped
+    // alpha. Suppressed if its row was never painted (dropped for budget).
     if (grid.cursor) |cursor| if (cursor.y < painted_rows) {
         const cursor_x = origin_x + @as(f32, @floatFromInt(cursor.x)) * cell_w;
         const cursor_y = origin_y + @as(f32, @floatFromInt(cursor.y)) * cell_h;
@@ -910,11 +918,19 @@ pub fn paint(grid: TerminalGrid, builder: *canvas.Builder, options: TerminalPain
             .underline => geometry.RectF.init(cursor_x, cursor_y + cell_h - 2, cell_w, 2),
             .block => geometry.RectF.init(cursor_x, cursor_y, cell_w, cell_h),
         };
-        try builder.fillRect(.{
-            .id = ids.at(0x61_0002),
-            .rect = rect,
-            .fill = .{ .color = cursor_color },
-        });
+        if (options.focused and grid.running) {
+            try builder.fillRect(.{
+                .id = ids.at(0x61_0002),
+                .rect = rect,
+                .fill = .{ .color = cursor_color },
+            });
+        } else {
+            try builder.strokeRect(.{
+                .id = ids.at(0x61_0002),
+                .rect = rect,
+                .stroke = .{ .fill = .{ .color = cursor_color }, .width = 1 },
+            });
+        }
     };
 
     // Selection head outline while selecting (the keyboard caret).

--- a/src/primitives/canvas/terminal_grid_tests.zig
+++ b/src/primitives/canvas/terminal_grid_tests.zig
@@ -177,7 +177,7 @@ test "the selection wash and keyboard caret paint from snapshot state" {
     try testing.expect(saw_caret);
 }
 
-test "the cursor register: filled while running, dim after exit" {
+test "the cursor register: filled only while focused and live, hollow otherwise" {
     const rows = [_]grid_model.TerminalRow{.{ .cells = &.{} }};
     var grid = baseGrid(&rows);
     grid.cursor = .{ .x = 0, .y = 0 };
@@ -186,6 +186,7 @@ test "the cursor register: filled while running, dim after exit" {
     var builder = try paintInto(grid, &commands, .{
         .frame = geometry.RectF.init(0, 0, 100, 40),
         .tokens = .{},
+        .focused = true,
     });
     var running_alpha: f32 = 0;
     for (builder.displayList().commands) |command| {
@@ -198,22 +199,96 @@ test "the cursor register: filled while running, dim after exit" {
     }
     try testing.expectApproxEqAbs(@as(f32, 0.45), running_alpha, 0.001);
 
+    var blurred_commands: [16]canvas.CanvasCommand = undefined;
+    var blurred_builder = try paintInto(grid, &blurred_commands, .{
+        .frame = geometry.RectF.init(0, 0, 100, 40),
+        .tokens = .{},
+        .focused = false,
+    });
+    var blurred_alpha: f32 = 0;
+    for (blurred_builder.displayList().commands) |command| {
+        switch (command) {
+            .stroke_rect => |stroke| {
+                if (stroke.stroke.fill == .color and stroke.stroke.fill.color.b == blue.b) {
+                    blurred_alpha = stroke.stroke.fill.color.a;
+                    try testing.expectEqual(@as(f32, 1), stroke.stroke.width);
+                }
+            },
+            else => {},
+        }
+    }
+    try testing.expectApproxEqAbs(@as(f32, 0.45), blurred_alpha, 0.001);
+
     grid.running = false;
     var ended_commands: [16]canvas.CanvasCommand = undefined;
     var ended_builder = try paintInto(grid, &ended_commands, .{
         .frame = geometry.RectF.init(0, 0, 100, 40),
         .tokens = .{},
+        .focused = true,
     });
     var ended_alpha: f32 = 0;
     for (ended_builder.displayList().commands) |command| {
         switch (command) {
-            .fill_rect => |fill| {
-                if (fill.fill == .color and fill.fill.color.b == blue.b and fill.fill.color.a < 1) ended_alpha = fill.fill.color.a;
+            .stroke_rect => |stroke| {
+                if (stroke.stroke.fill == .color and stroke.stroke.fill.color.b == blue.b) {
+                    ended_alpha = stroke.stroke.fill.color.a;
+                    try testing.expectEqual(@as(f32, 1), stroke.stroke.width);
+                }
             },
             else => {},
         }
     }
     try testing.expectApproxEqAbs(@as(f32, 0.22), ended_alpha, 0.001);
+}
+
+test "the terminal widget cursor follows logical focus independently of the outer ring" {
+    const rows = [_]grid_model.TerminalRow{.{ .cells = &.{} }};
+    var grid = baseGrid(&rows);
+    grid.cursor = .{ .x = 0, .y = 0 };
+    const terminal = canvas.Widget{
+        .id = 9,
+        .kind = .terminal,
+        .frame = geometry.RectF.init(0, 0, 200, 100),
+        .terminal = .{ .pty = 1, .grid = &grid },
+    };
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(terminal, terminal.frame, &nodes);
+    const cursor_id = grid_model.paintIdBase(terminal.id) + 0x61_0002;
+
+    // Logical focus fills the cursor even when the modality-specific
+    // outer ring is quiet.
+    var focused_commands: [32]canvas.CanvasCommand = undefined;
+    var focused_builder = canvas.Builder.init(&focused_commands);
+    try layout.emitDisplayListWithState(&focused_builder, .{}, .{ .focused_id = terminal.id });
+    var saw_filled_cursor = false;
+    var saw_outer_ring = false;
+    for (focused_builder.displayList().commands) |command| {
+        switch (command) {
+            .fill_rect => |fill| if (fill.id == cursor_id) {
+                saw_filled_cursor = true;
+            },
+            .stroke_rect => |stroke| if (stroke.id != cursor_id) {
+                saw_outer_ring = true;
+            },
+            else => {},
+        }
+    }
+    try testing.expect(saw_filled_cursor);
+    try testing.expect(!saw_outer_ring);
+
+    var blurred_commands: [32]canvas.CanvasCommand = undefined;
+    var blurred_builder = canvas.Builder.init(&blurred_commands);
+    try layout.emitDisplayListWithState(&blurred_builder, .{}, .{});
+    var saw_hollow_cursor = false;
+    for (blurred_builder.displayList().commands) |command| {
+        switch (command) {
+            .stroke_rect => |stroke| if (stroke.id == cursor_id) {
+                saw_hollow_cursor = true;
+            },
+            else => {},
+        }
+    }
+    try testing.expect(saw_hollow_cursor);
 }
 
 test "the scrollback thumb paints only while the viewport is in history" {

--- a/src/primitives/canvas/terminal_grid_tests.zig
+++ b/src/primitives/canvas/terminal_grid_tests.zig
@@ -278,17 +278,27 @@ test "the terminal widget cursor follows logical focus independently of the oute
 
     var blurred_commands: [32]canvas.CanvasCommand = undefined;
     var blurred_builder = canvas.Builder.init(&blurred_commands);
-    try layout.emitDisplayListWithState(&blurred_builder, .{}, .{});
+    try layout.emitDisplayListWithState(&blurred_builder, .{}, .{
+        .keyboard_active = false,
+        .focused_id = terminal.id,
+        .focus_visible_id = terminal.id,
+    });
     var saw_hollow_cursor = false;
+    var kept_outer_ring = false;
     for (blurred_builder.displayList().commands) |command| {
         switch (command) {
             .stroke_rect => |stroke| if (stroke.id == cursor_id) {
                 saw_hollow_cursor = true;
+            } else {
+                kept_outer_ring = true;
             },
             else => {},
         }
     }
     try testing.expect(saw_hollow_cursor);
+    // Key-window/app activity gates the terminal's ownership cue only;
+    // retained focus-visible chrome keeps its normal restoration state.
+    try testing.expect(kept_outer_ring);
 }
 
 test "the scrollback thumb paints only while the viewport is in history" {

--- a/src/primitives/canvas/widget_invalidation.zig
+++ b/src/primitives/canvas/widget_invalidation.zig
@@ -353,6 +353,18 @@ pub fn widgetRenderStateDirtyBounds(layout: anytype, previous: WidgetRenderState
         const base = widgetWithFrame(node.widget, node.frame);
         const previous_widget = widgetWithRenderState(base, previous);
         const next_widget = widgetWithRenderState(base, next);
+        // A terminal's cursor follows LOGICAL focus (`focused_id`), not
+        // the focus-visible state projected into `WidgetState.focused`.
+        // Dirtiness has to mirror that extra render dependency or a
+        // quiet pointer-focus/window-focus transition can change the
+        // cursor from hollow to filled while this API reports no pixels.
+        if (terminalLogicalFocusPaintChanged(base, previous, next)) {
+            bounds = unionOptionalBounds(bounds, widgetClippedDirtyBounds(
+                layout,
+                index,
+                widgetFullPaintBoundsWithTransform(node, widgetAccumulatedTransform(layout, index), tokens),
+            ));
+        }
         if (widgetStatesEqual(previous_widget.state, next_widget.state)) continue;
         bounds = unionOptionalBounds(bounds, widgetClippedDirtyBounds(layout, index, widgetRenderStatePaintChangeBounds(previous_widget, next_widget, tokens)));
     }
@@ -373,6 +385,24 @@ pub fn widgetRenderStateDirtyBounds(layout: anytype, previous: WidgetRenderState
         bounds = unionOptionalBounds(bounds, widget_render.chartHoverDetailDirtyBounds(layout, next, tokens));
     }
     return bounds;
+}
+
+/// Whether a live, visible terminal cursor changes fill-vs-outline
+/// because logical keyboard focus moved. Ended sessions are always
+/// hollow and a grid without a cursor paints no focus-dependent pixels.
+fn terminalLogicalFocusPaintChanged(widget: Widget, previous: WidgetRenderState, next: WidgetRenderState) bool {
+    if (widget.kind != .terminal) return false;
+    const grid = widget.terminal.grid orelse return false;
+    if (!grid.running or grid.cursor == null) return false;
+    return widgetHasLogicalFocus(widget, previous) != widgetHasLogicalFocus(widget, next);
+}
+
+fn widgetHasLogicalFocus(widget: Widget, state: WidgetRenderState) bool {
+    if (state.focused_id != null or state.focus_visible_id != null) {
+        const focused_id = state.focused_id orelse return false;
+        return widget.id != 0 and widget.id == focused_id;
+    }
+    return widget.state.focused;
 }
 
 fn optionalPointsEqual(a: ?geometry.PointF, b: ?geometry.PointF) bool {

--- a/src/primitives/canvas/widget_invalidation.zig
+++ b/src/primitives/canvas/widget_invalidation.zig
@@ -372,6 +372,26 @@ pub fn widgetRenderStateDirtyBounds(layout: anytype, previous: WidgetRenderState
         if (widgetStatesEqual(previous_widget.state, next_widget.state)) continue;
         bounds = unionOptionalBounds(bounds, widgetClippedDirtyBounds(layout, index, widgetRenderStatePaintChangeBounds(previous_widget, next_widget, tokens)));
     }
+    // With no runtime focus ids, baked `WidgetState.focused` is the
+    // renderer's source of truth. A keyboard-active transition still
+    // changes a baked-focused terminal cursor, but the targeted id list
+    // above is empty in exactly that state. Walk the layout only for
+    // this rare window/app activity edge so the dirty-bounds API mirrors
+    // the pixels without taxing ordinary hover/press/focus changes.
+    if (previous.keyboard_active != next.keyboard_active and
+        renderStateUsesBakedFocus(previous) and
+        renderStateUsesBakedFocus(next))
+    {
+        for (layout.nodes, 0..) |node, index| {
+            const base = widgetWithFrame(node.widget, node.frame);
+            if (!terminalLogicalFocusPaintChanged(base, previous, next)) continue;
+            bounds = unionOptionalBounds(bounds, widgetClippedDirtyBounds(
+                layout,
+                index,
+                widgetFullPaintBoundsWithTransform(node, widgetAccumulatedTransform(layout, index), tokens),
+            ));
+        }
+    }
     // Focus-within chrome: an `.input_group` ancestor wears the focus
     // ring FOR its focused descendant, so a focus-visible change dirties
     // the group's ring region too — the group's own id never appears in
@@ -408,6 +428,10 @@ fn widgetHasLogicalFocus(widget: Widget, state: WidgetRenderState) bool {
         return widget.id != 0 and widget.id == focused_id;
     }
     return widget.state.focused;
+}
+
+fn renderStateUsesBakedFocus(state: WidgetRenderState) bool {
+    return state.focused_id == null and state.focus_visible_id == null;
 }
 
 fn optionalPointsEqual(a: ?geometry.PointF, b: ?geometry.PointF) bool {

--- a/src/primitives/canvas/widget_invalidation.zig
+++ b/src/primitives/canvas/widget_invalidation.zig
@@ -332,6 +332,10 @@ pub fn widgetRenderStateDirtyBounds(layout: anytype, previous: WidgetRenderState
         appendOptionalObjectId(&ids, &id_len, previous.focused_id);
         appendOptionalObjectId(&ids, &id_len, next.focused_id);
     }
+    if (previous.keyboard_active != next.keyboard_active) {
+        appendOptionalObjectId(&ids, &id_len, previous.focused_id);
+        appendOptionalObjectId(&ids, &id_len, next.focused_id);
+    }
     if (previous.focus_visible_id != next.focus_visible_id) {
         appendOptionalObjectId(&ids, &id_len, previous.focus_visible_id);
         appendOptionalObjectId(&ids, &id_len, next.focus_visible_id);
@@ -398,6 +402,7 @@ fn terminalLogicalFocusPaintChanged(widget: Widget, previous: WidgetRenderState,
 }
 
 fn widgetHasLogicalFocus(widget: Widget, state: WidgetRenderState) bool {
+    if (!state.keyboard_active) return false;
     if (state.focused_id != null or state.focus_visible_id != null) {
         const focused_id = state.focused_id orelse return false;
         return widget.id != 0 and widget.id == focused_id;

--- a/src/primitives/canvas/widget_render.zig
+++ b/src/primitives/canvas/widget_render.zig
@@ -2801,6 +2801,7 @@ fn widgetWithRenderState(widget: Widget, state: WidgetRenderState) Widget {
 /// With no runtime state, a baked focused widget remains the static
 /// scene/test source of truth.
 fn widgetHasLogicalFocus(widget: Widget, state: WidgetRenderState) bool {
+    if (!state.keyboard_active) return false;
     if (state.focused_id != null or state.focus_visible_id != null) {
         const focused_id = state.focused_id orelse return false;
         return widget.id != 0 and widget.id == focused_id;

--- a/src/primitives/canvas/widget_render.zig
+++ b/src/primitives/canvas/widget_render.zig
@@ -235,7 +235,7 @@ fn emitWidgetDepthContent(builder: *Builder, widget: Widget, tokens: DesignToken
         .icon => try emitIconWidget(builder, paint_widget, tokens),
         .image => try emitImageWidget(builder, paint_widget),
         .media_surface => try emitMediaSurfaceWidget(builder, paint_widget),
-        .terminal => try emitTerminalWidget(builder, paint_widget, tokens),
+        .terminal => try emitTerminalWidget(builder, paint_widget, tokens, paint_widget.state.focused),
         .avatar => try emitAvatarWidget(builder, paint_widget, tokens),
         .badge => try emitBadgeWidget(builder, paint_widget, tokens),
         .button, .toggle_button, .toggle => try widget_render_controls.emitButtonWidget(builder, paint_widget, tokens),
@@ -578,7 +578,7 @@ fn emitWidgetLayoutNodeContent(
         .icon => try emitIconWidget(builder, paint_widget, tokens),
         .image => try emitImageWidget(builder, paint_widget),
         .media_surface => try emitMediaSurfaceWidget(builder, paint_widget),
-        .terminal => try emitTerminalWidget(builder, paint_widget, tokens),
+        .terminal => try emitTerminalWidget(builder, paint_widget, tokens, widgetHasLogicalFocus(paint_widget, state)),
         .avatar => try emitAvatarWidget(builder, paint_widget, tokens),
         .badge => try emitBadgeWidget(builder, paint_widget, tokens),
         .button, .toggle_button, .toggle => try widget_render_controls.emitButtonWidget(builder, paint_widget, tokens),
@@ -1249,7 +1249,7 @@ fn mediaSurfaceQuadRadius(radius: Radius, bar: f32) Radius {
 /// the widget's frame, so a terminal awaiting its pty reads as an empty
 /// terminal, never a hole. Focus wears the house ring like every other
 /// focusable control.
-fn emitTerminalWidget(builder: *Builder, widget: Widget, tokens: DesignTokens) Error!void {
+fn emitTerminalWidget(builder: *Builder, widget: Widget, tokens: DesignTokens, focused: bool) Error!void {
     const frame = widget.frame.normalized();
     if (frame.isEmpty()) return;
     if (widget.terminal.grid) |grid| {
@@ -1283,6 +1283,7 @@ fn emitTerminalWidget(builder: *Builder, widget: Widget, tokens: DesignTokens) E
             .frame = content,
             .background_frame = frame,
             .tokens = tokens,
+            .focused = focused,
             .id_base = widget.id,
             .command_budget = command_budget,
             .text_reserve = canvas.terminal_grid.widget_text_reserve,
@@ -2792,6 +2793,19 @@ fn widgetWithRenderState(widget: Widget, state: WidgetRenderState) Widget {
         copy.state.pressed = copy.id != 0 and copy.id == pressed_id;
     }
     return copy;
+}
+
+/// The terminal cursor follows logical keyboard focus, not merely
+/// focus-visible: the outer ring is a modality affordance, while the
+/// filled-vs-hollow cursor answers whether typed bytes go to this pty.
+/// With no runtime state, a baked focused widget remains the static
+/// scene/test source of truth.
+fn widgetHasLogicalFocus(widget: Widget, state: WidgetRenderState) bool {
+    if (state.focused_id != null or state.focus_visible_id != null) {
+        const focused_id = state.focused_id orelse return false;
+        return widget.id != 0 and widget.id == focused_id;
+    }
+    return widget.state.focused;
 }
 
 fn accordionChildrenVisible(widget: Widget) bool {

--- a/src/primitives/canvas/widget_runtime_tests.zig
+++ b/src/primitives/canvas/widget_runtime_tests.zig
@@ -639,6 +639,18 @@ test "widget render state dirty bounds tracks terminal logical focus" {
         ),
     );
 
+    // A static/baked focused state is the source of truth when neither
+    // render state carries a focus id. The keyboard gate still hollows
+    // that cursor, so the no-id path must report its frame dirty too.
+    var baked_terminal = terminal;
+    baked_terminal.state.focused = true;
+    var baked_nodes: [1]WidgetLayoutNode = undefined;
+    const baked_layout = try layoutWidgetTree(baked_terminal, baked_terminal.frame, &baked_nodes);
+    try expectRect(
+        baked_terminal.frame,
+        baked_layout.renderStateDirtyBounds(.{}, .{ .keyboard_active = false }),
+    );
+
     // An ended cursor is hollow in both states: logical focus no longer
     // changes pixels, so no damage is reported.
     grid.running = false;

--- a/src/primitives/canvas/widget_runtime_tests.zig
+++ b/src/primitives/canvas/widget_runtime_tests.zig
@@ -606,6 +606,38 @@ test "widget render state dirty bounds tracks changed runtime states" {
     try std.testing.expect(layout.renderStateDirtyBounds(.{ .focused_id = 99 }, .{ .focused_id = 100 }) == null);
 }
 
+test "widget render state dirty bounds tracks terminal logical focus" {
+    const rows = [_]canvas.TerminalRow{.{ .cells = &.{} }};
+    var grid = canvas.TerminalGrid{
+        .rows = &rows,
+        .background = Color.rgb8(0, 0, 0),
+        .foreground = Color.rgb8(255, 255, 255),
+        .cursor_color = Color.rgb8(255, 255, 255),
+        .selection_color = Color.rgb8(0, 128, 255),
+        .cursor = .{ .x = 0, .y = 0 },
+    };
+    const terminal = Widget{
+        .id = 9,
+        .kind = .terminal,
+        .frame = geometry.RectF.init(10, 12, 200, 100),
+        .terminal = .{ .pty = 1, .grid = &grid },
+    };
+    var nodes: [1]WidgetLayoutNode = undefined;
+    const layout = try layoutWidgetTree(terminal, terminal.frame, &nodes);
+
+    // Logical focus changes the live cursor from outline to fill even
+    // when focus-visible stays quiet, so the terminal frame is dirty.
+    try expectRect(
+        terminal.frame,
+        layout.renderStateDirtyBounds(.{}, .{ .focused_id = terminal.id }),
+    );
+
+    // An ended cursor is hollow in both states: logical focus no longer
+    // changes pixels, so no damage is reported.
+    grid.running = false;
+    try std.testing.expect(layout.renderStateDirtyBounds(.{}, .{ .focused_id = terminal.id }) == null);
+}
+
 test "widget render state dirty bounds uses custom focus stroke tokens" {
     const children = [_]Widget{.{
         .id = 2,

--- a/src/primitives/canvas/widget_runtime_tests.zig
+++ b/src/primitives/canvas/widget_runtime_tests.zig
@@ -631,11 +631,22 @@ test "widget render state dirty bounds tracks terminal logical focus" {
         terminal.frame,
         layout.renderStateDirtyBounds(.{}, .{ .focused_id = terminal.id }),
     );
+    try expectRect(
+        terminal.frame,
+        layout.renderStateDirtyBounds(
+            .{ .focused_id = terminal.id },
+            .{ .keyboard_active = false, .focused_id = terminal.id },
+        ),
+    );
 
     // An ended cursor is hollow in both states: logical focus no longer
     // changes pixels, so no damage is reported.
     grid.running = false;
     try std.testing.expect(layout.renderStateDirtyBounds(.{}, .{ .focused_id = terminal.id }) == null);
+    try std.testing.expect(layout.renderStateDirtyBounds(
+        .{ .focused_id = terminal.id },
+        .{ .keyboard_active = false, .focused_id = terminal.id },
+    ) == null);
 }
 
 test "widget render state dirty bounds uses custom focus stroke tokens" {

--- a/src/primitives/canvas/widgets.zig
+++ b/src/primitives/canvas/widgets.zig
@@ -264,6 +264,12 @@ pub const WidgetState = struct {
 };
 
 pub const WidgetRenderState = struct {
+    /// Whether the app is active and this widget tree's window is key.
+    /// Runtime focus ids stay retained while false so focus-visible
+    /// chrome and per-window restoration keep their existing semantics;
+    /// controls whose pixels represent CURRENT keyboard ownership (the
+    /// terminal cursor) consult this gate too.
+    keyboard_active: bool = true,
     focused_id: ?ObjectId = null,
     focus_visible_id: ?ObjectId = null,
     hovered_id: ?ObjectId = null,

--- a/src/runtime/automation_snapshot.zig
+++ b/src/runtime/automation_snapshot.zig
@@ -221,7 +221,7 @@ pub fn RuntimeAutomationSnapshot(comptime Runtime: type) type {
                         },
                         .virtual_range = canvasVirtualRange(layout.virtualRangeById(node.id)),
                         .bounds = node.bounds.translate(geometry.OffsetF.init(view.frame.x, view.frame.y)),
-                        .focused = node.state.focused or (view.focused and node.id == view.canvas_widget_focused_id),
+                        .focused = node.state.focused or (view.keyboard_active and view.focused and node.id == view.canvas_widget_focused_id),
                         .enabled = !node.state.disabled,
                         .hovered = node.state.hovered or (node.id != 0 and node.id == view.canvas_widget_hovered_id),
                         .pressed = node.state.pressed or (node.id != 0 and node.id == view.canvas_widget_pressed_id),

--- a/src/runtime/canvas_widget_display.zig
+++ b/src/runtime/canvas_widget_display.zig
@@ -234,7 +234,7 @@ pub fn RuntimeCanvasWidgetDisplay(comptime Runtime: type) type {
                     .scroll_viewport_extent = if (node.scroll.present) node.scroll.viewport_extent else null,
                     .scroll_content_extent = if (node.scroll.present) node.scroll.content_extent else null,
                     .enabled = !node.state.disabled,
-                    .focused = node.state.focused or (view.focused and node.id == view.canvas_widget_focused_id),
+                    .focused = node.state.focused or (view.keyboard_active and view.focused and node.id == view.canvas_widget_focused_id),
                     .hovered = node.state.hovered or (node.id != 0 and node.id == view.canvas_widget_hovered_id),
                     .pressed = node.state.pressed or (node.id != 0 and node.id == view.canvas_widget_pressed_id),
                     .selected = canvasWidgetSelectedState(node),

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -1773,7 +1773,7 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             // live tokens, so the dirty region must measure the same way.
             const local_dirty = self.views[view_index].widgetLayoutTree().renderStateDirtyBoundsWithTokens(previous, next, self.views[view_index].widget_tokens);
             invalidateForCanvasWidgetRenderStateDirty(self, view_index, local_dirty);
-            const publish_accessibility = previous.focused_id != next.focused_id;
+            const publish_accessibility = previous.focused_id != next.focused_id or previous.keyboard_active != next.keyboard_active;
             _ = try runtime_canvas_widget_display.RuntimeCanvasWidgetDisplay(Runtime).refreshCanvasWidgetDisplayListIfOwnedWithAccessibility(self, view_index, publish_accessibility);
         }
 
@@ -1791,6 +1791,7 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
         pub fn canvasWidgetRenderStateAfterLayout(previous: canvas.WidgetRenderState, layout: canvas.WidgetLayoutTree) canvas.WidgetRenderState {
             const next_focused_id = if (previous.focused_id) |id| if (layout.focusTargetById(id) != null) id else null else null;
             return .{
+                .keyboard_active = previous.keyboard_active,
                 .focused_id = next_focused_id,
                 .focus_visible_id = if (previous.focus_visible_id) |id| if (next_focused_id != null and next_focused_id.? == id and layout.focusTargetById(id) != null) id else null else null,
                 .hovered_id = if (previous.hovered_id) |id| if (canvasWidgetInteractionTargetExists(layout, id)) id else null else null,
@@ -1802,7 +1803,8 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
         }
 
         pub fn canvasWidgetRenderStatesEqual(a: canvas.WidgetRenderState, b: canvas.WidgetRenderState) bool {
-            return a.focused_id == b.focused_id and
+            return a.keyboard_active == b.keyboard_active and
+                a.focused_id == b.focused_id and
                 a.focus_visible_id == b.focus_visible_id and
                 a.hovered_id == b.hovered_id and
                 a.pressed_id == b.pressed_id and

--- a/src/runtime/flow.zig
+++ b/src/runtime/flow.zig
@@ -242,7 +242,7 @@ pub fn RuntimeFlow(comptime Runtime: type) type {
                     log(self, "app.start", "app started", &.{trace.string("app", app.name)});
                 },
                 .app_activated => {
-                    self.app_active = true;
+                    try WindowViewMethods().setAppActive(self, true);
                     try dispatchEvent(self, app, .{ .lifecycle = .activate });
                     emitAppLifecycleEvent(self, "app:activate") catch |err| log(self, "app.activate.emit_failed", @errorName(err), &.{});
                 },
@@ -254,7 +254,7 @@ pub fn RuntimeFlow(comptime Runtime: type) type {
                     // that already knows the app is inactive: the
                     // adoption arm's reveal/arm paths are gated on this
                     // register and stay silent.
-                    self.app_active = false;
+                    try WindowViewMethods().setAppActive(self, false);
                     // Deactivation drops every tooltip conversation in
                     // every window (see the seam's own rationale) BEFORE
                     // the app hears the lifecycle event, so a model that

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -498,6 +498,11 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
             /// Optional mapping from shell command events (menus, shortcuts,
             /// native controls) into messages.
             on_command: ?*const fn (name: []const u8) ?MsgT = null,
+            /// Optional mapping from app lifecycle events into messages.
+            /// A single-window app can use activate/deactivate as its
+            /// keyboard-focus signal for custom canvas chrome whose
+            /// pixels live outside the widget focus register.
+            on_lifecycle: ?*const fn (event: core.LifecycleEvent) ?MsgT = null,
             /// Model-driven selection for declared platform chrome
             /// (`scene.chrome.tabs`): returns the id of the tab the
             /// model currently selects (one of the declared tab ids, or
@@ -3892,6 +3897,10 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
 
         fn handleRuntimeEvent(self: *Self, runtime: *Runtime, event_value: Event) anyerror!void {
             switch (event_value) {
+                .lifecycle => |lifecycle| {
+                    const map = self.options.on_lifecycle orelse return;
+                    if (map(lifecycle)) |msg| try self.dispatch(runtime, self.canvas_window_id, msg);
+                },
                 .command => |command| {
                     const map = self.options.on_command orelse return;
                     if (map(command.name)) |msg| {

--- a/src/runtime/view.zig
+++ b/src/runtime/view.zig
@@ -722,7 +722,16 @@ pub const RuntimeView = struct {
     widget_chart_points_len: usize = 0,
     widget_chart_x_labels: [canvas_limits.max_canvas_widget_chart_x_labels_per_view][]const u8 = undefined,
     widget_chart_x_labels_len: usize = 0,
+    /// Whether this view is the focused child INSIDE its window. This
+    /// memory deliberately survives app deactivation and window key
+    /// loss so focus returns to the same child when keyboard ownership
+    /// comes back.
     focused: bool = false,
+    /// Whether the app is active AND this view's owning window is key.
+    /// Kept separate from `focused`: retained widget focus remains
+    /// remembered while inactive, but it must not paint or report as
+    /// keyboard focus until this gate reopens.
+    keyboard_active: bool = false,
     open: bool = false,
     label_storage: [platform.max_view_label_bytes]u8 = undefined,
     parent_storage: [platform.max_view_label_bytes]u8 = undefined,

--- a/src/runtime/view_widget_tree.zig
+++ b/src/runtime/view_widget_tree.zig
@@ -369,6 +369,7 @@ pub fn RuntimeViewCanvasWidgetTree(comptime RuntimeView: type) type {
         pub fn canvasWidgetRenderState(self: *const RuntimeView) canvas.WidgetRenderState {
             const focused_id: ?canvas.ObjectId = if (!self.focused or self.canvas_widget_focused_id == 0) null else self.canvas_widget_focused_id;
             return .{
+                .keyboard_active = self.keyboard_active,
                 .focused_id = focused_id,
                 .focus_visible_id = if (focused_id) |id| if (self.canvas_widget_focus_visible_id == id) id else null else null,
                 .hovered_id = if (self.canvas_widget_hovered_id == 0) null else self.canvas_widget_hovered_id,

--- a/src/runtime/window_storage.zig
+++ b/src/runtime/window_storage.zig
@@ -272,9 +272,13 @@ pub fn RuntimeWindowStorage(comptime Runtime: type) type {
         /// and the re-key restores focus where it was without revealing
         /// anything.
         pub fn setFocusedIndex(self: *Runtime, focused_index: usize) anyerror!void {
+            var first_error: ?anyerror = null;
             for (0..self.window_count) |index| {
-                try Self.setWindowFocused(self, index, index == focused_index);
+                Self.setWindowFocused(self, index, index == focused_index) catch |err| {
+                    if (first_error == null) first_error = err;
+                };
             }
+            if (first_error) |err| return err;
         }
 
         /// The ONE writer of a tracked window's `focused` flag: the
@@ -303,8 +307,47 @@ pub fn RuntimeWindowStorage(comptime Runtime: type) type {
             const window = &self.windows[index];
             const was_focused = window.info.focused;
             window.info.focused = focused;
+            var first_error: ?anyerror = null;
+            for (self.views[0..self.view_count], 0..) |*view, view_index| {
+                if (view.window_id != window.info.id) continue;
+                Self.setViewKeyboardActive(self, view_index, self.app_active and focused) catch |err| {
+                    if (first_error == null) first_error = err;
+                };
+            }
             if (was_focused and !focused) {
-                try CanvasWidgetEventMethods.resetCanvasTooltipIntentForWindowKeyLoss(self, window.info.id);
+                CanvasWidgetEventMethods.resetCanvasTooltipIntentForWindowKeyLoss(self, window.info.id) catch |err| {
+                    if (first_error == null) first_error = err;
+                };
+            }
+            if (first_error) |err| return err;
+        }
+
+        /// Move the application-active register and project it into every
+        /// view's keyboard gate without disturbing per-window focus
+        /// memory. A deactivated app owns no keyboard focus; activation
+        /// reopens the gate only in the key window.
+        pub fn setAppActive(self: *Runtime, active: bool) anyerror!void {
+            self.app_active = active;
+            var first_error: ?anyerror = null;
+            for (self.views[0..self.view_count], 0..) |*view, view_index| {
+                const window_index = Self.findWindowIndexById(self, view.window_id);
+                const window_focused = if (window_index) |index| self.windows[index].info.focused else false;
+                Self.setViewKeyboardActive(self, view_index, active and window_focused) catch |err| {
+                    if (first_error == null) first_error = err;
+                };
+            }
+            if (first_error) |err| return err;
+        }
+
+        fn setViewKeyboardActive(self: *Runtime, view_index: usize, active: bool) anyerror!void {
+            const CanvasWidgetEventMethods = runtime_canvas_widget_events.RuntimeCanvasWidgetEvents(Runtime);
+            const view = &self.views[view_index];
+            if (view.keyboard_active == active) return;
+            const previous_state = view.canvasWidgetRenderState();
+            view.keyboard_active = active;
+            const next_state = view.canvasWidgetRenderState();
+            if (!CanvasWidgetEventMethods.canvasWidgetRenderStatesEqual(previous_state, next_state)) {
+                try CanvasWidgetEventMethods.invalidateForCanvasWidgetRenderStateChange(self, view_index, previous_state, next_state);
             }
         }
 

--- a/src/runtime/window_view_runtime.zig
+++ b/src/runtime/window_view_runtime.zig
@@ -493,6 +493,7 @@ pub fn RuntimeWindowViewRuntime(comptime Runtime: type) type {
                 .gpu_status = if (options.kind == .gpu_surface) .ready else .unavailable,
                 .gpu_surface_created_timestamp_ns = if (options.kind == .gpu_surface) timestampToU64(nowNanoseconds()) else 0,
                 .focused = false,
+                .keyboard_active = windowKeyboardActive(self, options.window_id),
                 .open = true,
             };
             self.views[index].label = try copyInto(&self.views[index].label_storage, options.label);
@@ -502,6 +503,12 @@ pub fn RuntimeWindowViewRuntime(comptime Runtime: type) type {
             self.views[index].text = try copyInto(&self.views[index].text_storage, options.text);
             self.views[index].command = try copyInto(&self.views[index].command_storage, options.command);
             self.view_count += 1;
+        }
+
+        fn windowKeyboardActive(self: *const Runtime, window_id: platform.WindowId) bool {
+            if (!self.app_active) return false;
+            const window_index = WindowStorageMethods.findWindowIndexById(self, window_id) orelse return false;
+            return self.windows[window_index].info.focused;
         }
 
         pub fn findViewIndex(self: *const Runtime, window_id: platform.WindowId, label: []const u8) ?usize {

--- a/src/runtime/window_views.zig
+++ b/src/runtime/window_views.zig
@@ -47,6 +47,7 @@ pub fn RuntimeWindowViews(comptime Runtime: type) type {
         pub const findShellLayoutIndex = WindowStorageMethods.findShellLayoutIndex;
         pub const removeShellLayoutForWindow = WindowStorageMethods.removeShellLayoutForWindow;
         pub const setFocusedIndex = WindowStorageMethods.setFocusedIndex;
+        pub const setAppActive = WindowStorageMethods.setAppActive;
         pub const findWindowIndexById = WindowStorageMethods.findWindowIndexById;
         pub const findWindowIndexByLabel = WindowStorageMethods.findWindowIndexByLabel;
         pub const allocateWindowId = WindowStorageMethods.allocateWindowId;


### PR DESCRIPTION
- Blend the full-bleed terminal focus ring into the pane while preserving autofocus.
- Pin the styling with a workbench regression and document the user-visible fix.