### PR TITLE
fix: add terminal copy/paste context menu

### DIFF
--- a/changelog.d/terminal-context-menu.md
+++ b/changelog.d/terminal-context-menu.md
@@ -1,0 +1,1 @@
+fix: **Terminal context menu**: right-clicking a `<terminal>` now presents the standard Copy and Paste actions, copying the emulator selection and sending pasted clipboard text to the bound PTY.

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -374,6 +374,26 @@ const Harness = struct {
         } });
     }
 
+    fn rightClick(self: *Harness, x: f32, y: f32) !void {
+        try self.harness.runtime.dispatchPlatformEvent(self.app_iface, .{ .gpu_surface_input = .{
+            .window_id = 1,
+            .label = app.canvas_label,
+            .kind = .pointer_down,
+            .button = 1,
+            .x = x,
+            .y = y,
+        } });
+    }
+
+    fn contextMenuAction(self: *Harness, token: u64, item_id: u32) !void {
+        try self.harness.runtime.dispatchPlatformEvent(self.app_iface, .{ .context_menu_action = .{
+            .window_id = 1,
+            .view_label = app.canvas_label,
+            .token = token,
+            .item_id = item_id,
+        } });
+    }
+
     fn typeText(self: *Harness, text: []const u8) !void {
         try self.harness.runtime.dispatchPlatformEvent(self.app_iface, .{ .gpu_surface_input = .{
             .window_id = 1,
@@ -490,6 +510,53 @@ test "a live pty session flows through the <terminal> element: output, typing, r
     } });
     try testing.expectEqual(divider_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
     try testing.expectEqualStrings("", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
+}
+
+test "terminal context-menu Paste uses VT paste encoding and revalidates a pending session" {
+    if (comptime !native_sdk.runtime.terminal_sessions_enabled) return error.SkipZigTest;
+    var h = try Harness.create();
+    defer h.destroy();
+
+    // Mode 2004 is emulator state derived from child output. Context
+    // Paste must observe it rather than treating clipboard bytes as an
+    // ordinary multi-character typing commit.
+    try h.app_state.effects.feedPtyOutput(app.shell_effect_key, "demo$ \x1b[?2004h");
+    try h.frame();
+    const pasted = "echo one\n\x1b[201~echo two\x03";
+    try h.harness.runtime.writeClipboard(pasted);
+    const before = h.app_state.effects.ptyWrittenBytes(app.shell_effect_key).len;
+
+    try h.rightClick(200, 400);
+    const items = h.harness.null_platform.contextMenuItems();
+    try testing.expectEqual(@as(usize, 2), items.len);
+    try testing.expect(items[1].enabled);
+    try h.contextMenuAction(h.harness.null_platform.context_menu_token, 3);
+
+    // The encoder supplies bracketed-paste fenceposts and strips ESC /
+    // VINTR from the clipboard payload. The embedded LF stays inside
+    // the bracket instead of becoming an immediately executed command.
+    const written = h.app_state.effects.ptyWrittenBytes(app.shell_effect_key);
+    try testing.expectEqualStrings(
+        "\x1b[200~echo one\n [201~echo two \x1b[201~",
+        written[before..],
+    );
+
+    // Open another live menu, then let the child exit before the native
+    // action resolves (GTK's asynchronous shape). The stale Paste is a
+    // no-op, and a fresh ended-session menu disables it up front.
+    try h.rightClick(200, 400);
+    const pending_token = h.harness.null_platform.context_menu_token;
+    try h.app_state.effects.feedPtyExit(app.shell_effect_key, 0, 0, .exited, 0);
+    try h.frame();
+    const before_stale_action = h.app_state.effects.ptyWrittenBytes(app.shell_effect_key).len;
+    try h.contextMenuAction(pending_token, 3);
+    try testing.expectEqual(
+        before_stale_action,
+        h.app_state.effects.ptyWrittenBytes(app.shell_effect_key).len,
+    );
+
+    try h.rightClick(200, 400);
+    try testing.expect(!h.harness.null_platform.contextMenuItems()[1].enabled);
 }
 
 test "the terminal cursor follows app and key-window keyboard ownership" {

--- a/src/runtime/api.zig
+++ b/src/runtime/api.zig
@@ -79,6 +79,12 @@ pub const CanvasWidgetKeyboardEvent = struct {
     keyboard: canvas.WidgetKeyboardEvent,
     target: ?canvas.WidgetFocusTarget = null,
     route: []const canvas.WidgetEventRouteEntry = &.{},
+    /// This committed-text payload came from the terminal context
+    /// menu's Paste action, not ordinary typing or IME input. UiApp
+    /// routes it through the emulator's paste encoder (bracketed-paste
+    /// framing, newline normalization, and unsafe-control stripping)
+    /// before writing it to the pty.
+    terminal_paste: bool = false,
     /// True when this event is dispatched OUTSIDE a gpu-surface input
     /// cycle — the accessibility selection edits and the default
     /// context-menu cut/paste/select-all, which have no terminal

--- a/src/runtime/canvas_widget_context_menu.zig
+++ b/src/runtime/canvas_widget_context_menu.zig
@@ -212,8 +212,9 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                     if (!has_presenter) return;
                     try CanvasWidgetEventMethods().updateCanvasWidgetFocusFromPointer(self, pointer_event);
                     const has_selection = if (widget.terminal.grid) |grid| grid.selection_active else false;
+                    const can_paste = if (widget.terminal.grid) |grid| widget.terminal.pty != 0 and grid.running else false;
                     items[0] = .{ .id = default_item_copy, .label = "Copy", .enabled = has_selection };
-                    items[1] = .{ .id = default_item_paste, .label = "Paste", .enabled = widget.terminal.pty != 0 };
+                    items[1] = .{ .id = default_item_paste, .label = "Paste", .enabled = can_paste };
                     _ = try showMenu(self, app, index, .{
                         .window_id = input_event.window_id,
                         .target_id = target.id,
@@ -456,14 +457,23 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                 },
                 default_item_paste => {
                     if (widget.terminal.pty == 0) return;
+                    const grid = widget.terminal.grid orelse return;
+                    // The native menu resolves asynchronously on GTK:
+                    // a session that was live when the menu opened may
+                    // have exited before Paste is chosen. Revalidate at
+                    // action time so dead-session input cannot fall
+                    // through to UiApp's app-level `on_text` seam.
+                    if (!grid.running) return;
                     var paste_buffer: [platform.max_clipboard_data_bytes]u8 = undefined;
                     const text = self.readClipboard(&paste_buffer) catch return;
                     if (text.len == 0) return;
                     // Terminals deliberately stay outside the TextBuffer
-                    // editor pipeline. Send clipboard bytes through the
-                    // same committed-text event UiApp routes to the
-                    // focused emulator session, preserving multiline
-                    // input and avoiding text-field sanitization.
+                    // editor pipeline. Mark this committed payload as a
+                    // PASTE so UiApp routes it through the emulator's
+                    // dedicated paste encoder, not the ordinary typing
+                    // path: bracketed-paste framing, newline conversion,
+                    // and unsafe-control stripping are all provenance-
+                    // sensitive terminal behavior.
                     try self.dispatchEvent(app, .{ .canvas_widget_keyboard = .{
                         .window_id = self.views[view_index].window_id,
                         .view_label = self.views[view_index].label,
@@ -473,6 +483,7 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                             .text = text,
                             .edit = .{ .insert_text = text },
                         },
+                        .terminal_paste = true,
                         .standalone = true,
                     } });
                 },

--- a/src/runtime/canvas_widget_context_menu.zig
+++ b/src/runtime/canvas_widget_context_menu.zig
@@ -13,10 +13,13 @@
 //!    `ElementOptions.context_menu` (app-declared, Msg-mapped items),
 //! 2. an editable text target: the standard Cut / Copy / Paste /
 //!    Select All menu wired to the existing clipboard actions,
-//! 3. the view's live static-text selection: a Copy-only menu.
-//! The zero-code defaults (2 and 3) are presenter-only: without a native
-//! menu they degrade to the keyboard clipboard paths, never a synthesized
-//! surface (there are no app-declared items to mount).
+//! 3. a terminal target: the standard Copy / Paste menu wired to its
+//!    emulator selection and committed-input channel,
+//! 4. the view's live static-text selection: a Copy-only menu.
+//! The zero-code defaults (2 through 4) are presenter-only: without a
+//! native menu they present no synthesized surface (there are no
+//! app-declared items to mount), while their available keyboard paths
+//! remain unchanged.
 //!
 //! Presentation is asynchronous (macOS `popUpMenuPositioningItem` runs a
 //! nested tracking loop): the platform emits a `context_menu_action`
@@ -73,6 +76,7 @@ pub const PendingCanvasWidgetContextMenu = struct {
     pub const Kind = enum {
         app,
         edit_text,
+        terminal,
         static_copy,
     };
 };
@@ -180,9 +184,10 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                 return;
             }
 
-            // 2. Editable text target: the standard edit menu, wired to
-            // the existing clipboard actions. Focus the field first so
-            // paste lands where the user clicked (macOS behavior).
+            // 2/3. Editable text and terminal targets: standard menus
+            // wired to the existing clipboard and committed-input
+            // paths. Focus the target first so paste lands where the
+            // user clicked (macOS behavior).
             if (pointer_event.target) |target| {
                 const node_index = self.views[index].canvasWidgetNodeIndexById(target.id) orelse return;
                 const widget = self.views[index].widget_layout_nodes[node_index].widget;
@@ -203,7 +208,21 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                     return;
                 }
 
-                // 3. Static text with a live selection: Copy only.
+                if (widget.kind == .terminal and !widget.state.disabled) {
+                    if (!has_presenter) return;
+                    try CanvasWidgetEventMethods().updateCanvasWidgetFocusFromPointer(self, pointer_event);
+                    const has_selection = if (widget.terminal.grid) |grid| grid.selection_active else false;
+                    items[0] = .{ .id = default_item_copy, .label = "Copy", .enabled = has_selection };
+                    items[1] = .{ .id = default_item_paste, .label = "Paste", .enabled = widget.terminal.pty != 0 };
+                    _ = try showMenu(self, app, index, .{
+                        .window_id = input_event.window_id,
+                        .target_id = target.id,
+                        .kind = .terminal,
+                    }, point, items[0..2]);
+                    return;
+                }
+
+                // 4. Static text with a live selection: Copy only.
                 const selected_id = self.views[index].canvas_widget_selected_text_id;
                 if (selected_id != 0 and selected_id == target.id) {
                     if (!has_presenter) return;
@@ -217,7 +236,7 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                 }
             }
 
-            // 4. No menu anywhere on the route: the press-and-hold
+            // 5. No menu anywhere on the route: the press-and-hold
             // alternative. Deliver the context press so `UiApp` can
             // dispatch the press target's `on_hold` Msg.
             try self.dispatchEvent(app, .{ .canvas_widget_context_press = .{
@@ -354,16 +373,19 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
             const index = runtimeFindViewIndex(self, event.window_id, event.view_label) orelse return;
 
             switch (pending.kind) {
-                .app => try self.dispatchEvent(app, .{ .canvas_widget_context_menu = .{
-                    .window_id = event.window_id,
-                    .view_label = self.views[index].label,
-                    .target_id = pending.target_id,
-                    .item_index = event.item_id - 1,
-                    // The shown snapshot's key: UiApp resolves the
-                    // selection from what was presented under this token.
-                    .token = pending.token,
-                } }),
+                .app => try self.dispatchEvent(app, .{
+                    .canvas_widget_context_menu = .{
+                        .window_id = event.window_id,
+                        .view_label = self.views[index].label,
+                        .target_id = pending.target_id,
+                        .item_index = event.item_id - 1,
+                        // The shown snapshot's key: UiApp resolves the
+                        // selection from what was presented under this token.
+                        .token = pending.token,
+                    },
+                }),
                 .edit_text => try applyDefaultEditAction(self, app, index, pending.target_id, event.item_id),
+                .terminal => try applyDefaultTerminalAction(self, app, index, pending.target_id, event.item_id),
                 .static_copy => {
                     if (event.item_id != default_item_copy) return;
                     const text = self.views[index].canvasWidgetCopyText() orelse return;
@@ -416,6 +438,43 @@ pub fn RuntimeCanvasWidgetContextMenu(comptime Runtime: type) type {
                     keyboard_event.keyboard.key = "a";
                     keyboard_event.keyboard.modifiers = .{ .super = true };
                     try applyEditKeyboardEvent(self, app, keyboard_event);
+                },
+                else => {},
+            }
+        }
+
+        fn applyDefaultTerminalAction(self: *Runtime, app: runtime_api.App(Runtime), view_index: usize, target_id: canvas.ObjectId, item_id: u32) anyerror!void {
+            const node_index = self.views[view_index].canvasWidgetNodeIndexById(target_id) orelse return;
+            const widget = self.views[view_index].widget_layout_nodes[node_index].widget;
+            if (widget.kind != .terminal or widget.state.disabled) return;
+
+            switch (item_id) {
+                default_item_copy => {
+                    const grid = widget.terminal.grid orelse return;
+                    if (!grid.selection_active) return;
+                    self.writeClipboard(grid.selection_text) catch return;
+                },
+                default_item_paste => {
+                    if (widget.terminal.pty == 0) return;
+                    var paste_buffer: [platform.max_clipboard_data_bytes]u8 = undefined;
+                    const text = self.readClipboard(&paste_buffer) catch return;
+                    if (text.len == 0) return;
+                    // Terminals deliberately stay outside the TextBuffer
+                    // editor pipeline. Send clipboard bytes through the
+                    // same committed-text event UiApp routes to the
+                    // focused emulator session, preserving multiline
+                    // input and avoiding text-field sanitization.
+                    try self.dispatchEvent(app, .{ .canvas_widget_keyboard = .{
+                        .window_id = self.views[view_index].window_id,
+                        .view_label = self.views[view_index].label,
+                        .keyboard = .{
+                            .phase = .text_input,
+                            .focused_id = target_id,
+                            .text = text,
+                            .edit = .{ .insert_text = text },
+                        },
+                        .standalone = true,
+                    } });
                 },
                 else => {},
             }

--- a/src/runtime/canvas_widget_context_menu_tests.zig
+++ b/src/runtime/canvas_widget_context_menu_tests.zig
@@ -3,7 +3,8 @@
 //! platform's `context_menu_action` event resolves to a
 //! `.canvas_widget_context_menu` runtime event for app-declared menus,
 //! and the zero-code defaults (editable-text Cut/Copy/Paste/Select All,
-//! static-selection Copy) drive the existing clipboard actions.
+//! terminal Copy/Paste, static-selection Copy) drive the existing
+//! clipboard and committed-input actions.
 
 const support = @import("test_support.zig");
 const std = support.std;
@@ -34,6 +35,9 @@ const MenuTestApp = struct {
     last_request_point: geometry.PointF = .{},
     last_edit_insert: [64]u8 = undefined,
     last_edit_insert_len: usize = 0,
+    last_keyboard_phase: canvas.WidgetKeyboardPhase = .key_down,
+    last_keyboard_focused_id: ?canvas.ObjectId = null,
+    last_keyboard_standalone: bool = false,
     saw_truncated: bool = false,
     dismissed_count: u32 = 0,
     last_dismissed_token: u64 = 0,
@@ -97,6 +101,9 @@ const MenuTestApp = struct {
                 if (self.dismissal_error) |err| return err;
             },
             .canvas_widget_keyboard => |keyboard_event| {
+                self.last_keyboard_phase = keyboard_event.keyboard.phase;
+                self.last_keyboard_focused_id = keyboard_event.keyboard.focused_id;
+                self.last_keyboard_standalone = keyboard_event.standalone;
                 if (keyboard_event.keyboard.edit_truncated) self.saw_truncated = true;
                 if (keyboard_event.keyboard.edit) |edit| switch (edit) {
                     .insert_text => |text| {
@@ -459,6 +466,60 @@ test "a near-capacity multi-line context-menu paste sanitizes before it clamps" 
     try std.testing.expectEqualStrings("abc", text[text.len - 3 ..]);
     try std.testing.expectEqualStrings("abc", app_state.last_edit_insert[0..app_state.last_edit_insert_len]);
     try std.testing.expect(!app_state.saw_truncated);
+}
+
+test "right click on a terminal presents Copy and Paste wired to selection and committed input" {
+    var app_state: MenuTestApp = .{};
+    const app = app_state.app();
+    const harness = try createMenuHarness(app);
+    defer harness.destroy(std.testing.allocator);
+
+    var grid = canvas.TerminalGrid{
+        .background = canvas.Color.rgba(0, 0, 0, 1),
+        .foreground = canvas.Color.rgba(1, 1, 1, 1),
+        .cursor_color = canvas.Color.rgba(1, 1, 1, 1),
+        .selection_color = canvas.Color.rgba(0, 0.5, 1, 1),
+        .screen_text = "alpha beta",
+        .selection_text = "beta",
+        .selection_active = true,
+    };
+    const terminal = canvas.Widget{
+        .id = 2,
+        .kind = .terminal,
+        .frame = geometry.RectF.init(12, 16, 280, 120),
+        .terminal = .{ .pty = 7, .grid = &grid },
+    };
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(.{ .kind = .stack, .children = &.{terminal} }, geometry.RectF.init(0, 0, 320, 200), &nodes);
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+
+    try harness.runtime.dispatchPlatformEvent(app, rightClick(100, 40));
+
+    try std.testing.expectEqual(@as(usize, 1), harness.null_platform.context_menu_request_count);
+    const recorded = harness.null_platform.contextMenuItems();
+    try std.testing.expectEqual(@as(usize, 2), recorded.len);
+    try std.testing.expectEqual(@as(u32, 2), recorded[0].id);
+    try std.testing.expectEqualStrings("Copy", recorded[0].label);
+    try std.testing.expect(recorded[0].enabled);
+    try std.testing.expectEqual(@as(u32, 3), recorded[1].id);
+    try std.testing.expectEqualStrings("Paste", recorded[1].label);
+    try std.testing.expect(recorded[1].enabled);
+    // Secondary-click focus ensures the eventual paste addresses this
+    // terminal even when another editor previously owned focus.
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+
+    try harness.runtime.dispatchPlatformEvent(app, menuAction(harness.null_platform.context_menu_token, 2));
+    var clipboard_buffer: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("beta", try harness.runtime.readClipboard(&clipboard_buffer));
+
+    const paste = "printf 'ready'\n";
+    try harness.runtime.writeClipboard(paste);
+    try harness.runtime.dispatchPlatformEvent(app, rightClick(100, 40));
+    try harness.runtime.dispatchPlatformEvent(app, menuAction(harness.null_platform.context_menu_token, 3));
+    try std.testing.expectEqual(canvas.WidgetKeyboardPhase.text_input, app_state.last_keyboard_phase);
+    try std.testing.expectEqual(@as(?canvas.ObjectId, 2), app_state.last_keyboard_focused_id);
+    try std.testing.expect(app_state.last_keyboard_standalone);
+    try std.testing.expectEqualStrings(paste, app_state.last_edit_insert[0..app_state.last_edit_insert_len]);
 }
 
 test "right click on selected static text presents a copy-only menu" {

--- a/src/runtime/canvas_widget_context_menu_tests.zig
+++ b/src/runtime/canvas_widget_context_menu_tests.zig
@@ -35,8 +35,10 @@ const MenuTestApp = struct {
     last_request_point: geometry.PointF = .{},
     last_edit_insert: [64]u8 = undefined,
     last_edit_insert_len: usize = 0,
+    keyboard_count: u32 = 0,
     last_keyboard_phase: canvas.WidgetKeyboardPhase = .key_down,
     last_keyboard_focused_id: ?canvas.ObjectId = null,
+    last_keyboard_terminal_paste: bool = false,
     last_keyboard_standalone: bool = false,
     saw_truncated: bool = false,
     dismissed_count: u32 = 0,
@@ -101,8 +103,10 @@ const MenuTestApp = struct {
                 if (self.dismissal_error) |err| return err;
             },
             .canvas_widget_keyboard => |keyboard_event| {
+                self.keyboard_count += 1;
                 self.last_keyboard_phase = keyboard_event.keyboard.phase;
                 self.last_keyboard_focused_id = keyboard_event.keyboard.focused_id;
+                self.last_keyboard_terminal_paste = keyboard_event.terminal_paste;
                 self.last_keyboard_standalone = keyboard_event.standalone;
                 if (keyboard_event.keyboard.edit_truncated) self.saw_truncated = true;
                 if (keyboard_event.keyboard.edit) |edit| switch (edit) {
@@ -518,8 +522,52 @@ test "right click on a terminal presents Copy and Paste wired to selection and c
     try harness.runtime.dispatchPlatformEvent(app, menuAction(harness.null_platform.context_menu_token, 3));
     try std.testing.expectEqual(canvas.WidgetKeyboardPhase.text_input, app_state.last_keyboard_phase);
     try std.testing.expectEqual(@as(?canvas.ObjectId, 2), app_state.last_keyboard_focused_id);
+    try std.testing.expect(app_state.last_keyboard_terminal_paste);
     try std.testing.expect(app_state.last_keyboard_standalone);
     try std.testing.expectEqualStrings(paste, app_state.last_edit_insert[0..app_state.last_edit_insert_len]);
+}
+
+test "terminal Paste disables after exit and a pending live menu revalidates before dispatch" {
+    var app_state: MenuTestApp = .{};
+    const app = app_state.app();
+    const harness = try createMenuHarness(app);
+    defer harness.destroy(std.testing.allocator);
+
+    var grid = canvas.TerminalGrid{
+        .background = canvas.Color.rgba(0, 0, 0, 1),
+        .foreground = canvas.Color.rgba(1, 1, 1, 1),
+        .cursor_color = canvas.Color.rgba(1, 1, 1, 1),
+        .selection_color = canvas.Color.rgba(0, 0.5, 1, 1),
+    };
+    const terminal = canvas.Widget{
+        .id = 2,
+        .kind = .terminal,
+        .frame = geometry.RectF.init(12, 16, 280, 120),
+        .terminal = .{ .pty = 7, .grid = &grid },
+    };
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(.{ .kind = .stack, .children = &.{terminal} }, geometry.RectF.init(0, 0, 320, 200), &nodes);
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+
+    try harness.runtime.writeClipboard("must-not-escape");
+    try harness.runtime.dispatchPlatformEvent(app, rightClick(100, 40));
+    const live_token = harness.null_platform.context_menu_token;
+    try std.testing.expect(harness.null_platform.contextMenuItems()[1].enabled);
+
+    // GTK resolves menus asynchronously: the pty can exit while its
+    // live menu remains open. The action-time guard must swallow that
+    // stale Paste instead of emitting terminal input that could fall
+    // through to an app-level text handler.
+    grid.running = false;
+    try harness.runtime.dispatchPlatformEvent(app, menuAction(live_token, 3));
+    try std.testing.expectEqual(@as(u32, 0), app_state.keyboard_count);
+
+    // A new menu on the ended terminal describes the same truth up
+    // front: Copy remains selection-dependent, Paste is disabled.
+    try harness.runtime.dispatchPlatformEvent(app, rightClick(100, 40));
+    const ended_items = harness.null_platform.contextMenuItems();
+    try std.testing.expectEqual(@as(usize, 2), ended_items.len);
+    try std.testing.expect(!ended_items[1].enabled);
 }
 
 test "right click on selected static text presents a copy-only menu" {

--- a/src/runtime/terminal_session.zig
+++ b/src/runtime/terminal_session.zig
@@ -118,6 +118,12 @@ const DisabledStore = struct {
         _ = text;
         return false;
     }
+    pub fn pasteInput(self: *DisabledStore, pty: u64, text: []const u8) bool {
+        _ = self;
+        _ = pty;
+        _ = text;
+        return false;
+    }
     pub fn wheel(self: *DisabledStore, pty: u64, delta_y: f32) bool {
         _ = self;
         _ = pty;
@@ -322,6 +328,38 @@ const EnabledStore = struct {
         session.scrollToBottom();
         if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
         session.sendCommittedText(self.gateway, pty, text);
+        return true;
+    }
+
+    /// Clipboard paste is terminal input with distinct protocol
+    /// semantics, never just a multi-byte typing commit. Encode against
+    /// the emulator's live bracketed-paste mode, normalize unbracketed
+    /// newlines like xterm, and strip control bytes that could inject
+    /// terminal commands. Returns whether a live session consumed the
+    /// paste; an ended or unknown session declines without writing.
+    pub fn pasteInput(self: *EnabledStore, pty: u64, text: []const u8) bool {
+        const session = self.find(pty) orelse return false;
+        if (!session.acceptsInput()) return false;
+        if (text.len == 0) return true;
+        session.clearSelectionForInput();
+        const before = session.scrollbarState().offset;
+        session.scrollToBottom();
+        if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
+
+        const options: vt.input.PasteOptions = .fromTerminal(&session.term);
+        var mutable: ?[]u8 = null;
+        const encoded = vt.input.encodePaste(text, options) catch |err| switch (err) {
+            error.MutableRequired => encoded: {
+                const copy = session.gpa.dupe(u8, text) catch {
+                    session.outbound_dropped += text.len;
+                    return true;
+                };
+                mutable = copy;
+                break :encoded vt.input.encodePaste(copy, options);
+            },
+        };
+        defer if (mutable) |copy| session.gpa.free(copy);
+        session.enqueueTransientSlices(self.gateway, pty, &encoded);
         return true;
     }
 
@@ -714,6 +752,41 @@ const Session = if (enabled) struct {
         if (!session.enqueueOutbound(gateway, key, bytes)) {
             session.outbound_dropped += bytes.len;
         }
+    }
+
+    /// Paste encoding is a vector (optional bracket, payload, optional
+    /// bracket) but admission is atomic: never enqueue an opening
+    /// bracket without its payload and closing bracket when a
+    /// back-pressured child has nearly filled the ring.
+    fn enqueueTransientSlices(session: *Session, gateway: ?PtyGateway, key: u64, slices: []const []const u8) void {
+        session.moveResponsesToOutbound(gateway, key);
+        var total: usize = 0;
+        for (slices) |bytes| total += bytes.len;
+        if (session.response_len > 0) {
+            session.outbound_dropped += total;
+            return;
+        }
+
+        const cap = session.outbound_buffer.len;
+        if (total > cap) {
+            session.outbound_dropped += total;
+            return;
+        }
+        if (total > cap - session.outbound_len) session.flushOutbound(gateway, key);
+        if (total > cap - session.outbound_len) {
+            session.outbound_dropped += total;
+            return;
+        }
+
+        var offset = session.outbound_len;
+        for (slices) |bytes| {
+            for (bytes) |byte| {
+                session.outbound_buffer[(session.outbound_head + offset) % cap] = byte;
+                offset += 1;
+            }
+        }
+        session.outbound_len += total;
+        session.flushOutbound(gateway, key);
     }
 
     /// Push as much pending outbound as the pty's stdin FIFO will

--- a/src/runtime/terminal_session_tests.zig
+++ b/src/runtime/terminal_session_tests.zig
@@ -198,6 +198,36 @@ test "committed text and encoded keys reach the pty through the gateway in stdin
     try testing.expectEqualStrings("", gw.written.items);
 }
 
+test "clipboard paste uses terminal paste encoding and ended sessions refuse it" {
+    if (comptime !terminal_session.enabled) return error.SkipZigTest;
+    var store = TerminalSessions.init(testing.allocator);
+    defer store.deinit();
+    var gw = TestGateway{ .gpa = testing.allocator };
+    defer gw.deinit();
+    store.setGateway(gw.gateway());
+    store.beginBuild(.{});
+    _ = resolveGrid(&store, 3) orelse return error.TestExpectedGrid;
+
+    // Unbracketed paste follows xterm: LF becomes CR and dangerous
+    // control bytes are spaces, never injected verbatim.
+    try testing.expect(store.pasteInput(3, "echo one\necho two\x03\x1b"));
+    try testing.expectEqualStrings("echo one\recho two  ", gw.written.items);
+
+    // The child enables mode 2004. The next paste is framed against
+    // that live emulator mode, with its multiline payload preserved.
+    gw.written.clearRetainingCapacity();
+    feedOutput(&store, 3, "\x1b[?2004h");
+    try testing.expect(store.pasteInput(3, "alpha\nbeta"));
+    try testing.expectEqualStrings("\x1b[200~alpha\nbeta\x1b[201~", gw.written.items);
+
+    // A parked session is no longer an input target. In particular,
+    // the clipboard payload does not escape through any fallback.
+    gw.written.clearRetainingCapacity();
+    feedExit(&store, 3);
+    try testing.expect(!store.pasteInput(3, "late"));
+    try testing.expectEqualStrings("", gw.written.items);
+}
+
 test "a refused write is retained in the ring and drains on the frame flush" {
     if (comptime !terminal_session.enabled) return error.SkipZigTest;
     var store = TerminalSessions.init(testing.allocator);

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -5444,6 +5444,21 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                             if (widget.kind == .terminal and widget.terminal.pty != 0) {
                                 const edit = keyboard_event.keyboard.textEditEvent() orelse return;
                                 if (edit != .insert_text) return;
+                                if (keyboard_event.terminal_paste) {
+                                    // Context-menu paste is provenance-
+                                    // sensitive terminal input: the
+                                    // session must apply bracketed-paste
+                                    // framing and paste sanitization.
+                                    // Consume it even when the session
+                                    // ended between presentation and
+                                    // dispatch; clipboard bytes addressed
+                                    // to a terminal must never leak to the
+                                    // app-level `on_text` fallback.
+                                    if (self.terminal_sessions.pasteInput(widget.terminal.pty, edit.insert_text)) {
+                                        try self.repaintTerminals(runtime, keyboard_event.window_id);
+                                    }
+                                    return;
+                                }
                                 if (self.terminal_sessions.textInput(widget.terminal.pty, edit.insert_text)) {
                                     try self.repaintTerminals(runtime, keyboard_event.window_id);
                                     return;


### PR DESCRIPTION
- Present standard Copy and Paste actions for terminal widgets.
- Route emulator selections to the clipboard and pasted text to PTY input.
- Add regression coverage and a changelog fragment.