### PR TITLE
fix terminal macOS shortcuts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1191,6 +1191,11 @@ pub fn build(b: *std.Build) void {
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "- (void)selectAll:(id)sender" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "@selector(selectAll:)" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "emitSyntheticKeyDownWithKey:@\"a\" modifiers:(NativeSdkShortcutModifierPrimary | NativeSdkShortcutModifierCommand)" },
+        // Modified horizontal navigation must bypass AppKit's selector
+        // rewrite: the shared editor consumes the raw modifiers, and a
+        // terminal translates them to its shell/protocol bindings.
+        .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NativeSdkTextNavigationNeedsRawKeyEvent(event)" },
+        .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NSEventModifierFlagCommand | NSEventModifierFlagOption" },
     });
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-appkit-appearance-bridge", "Verify AppKit reports system light and dark appearance changes", &.{
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "effectiveAppearance" },

--- a/changelog.d/terminal-macos-natural-navigation.md
+++ b/changelog.d/terminal-macos-natural-navigation.md
@@ -1,0 +1,1 @@
+fix: **Natural terminal editing on macOS**: focused terminals now translate Option+Left/Right to word movement, Command+Left/Right to line boundaries, and Command+Delete to clearing back to the line start, instead of leaking unsupported modifier sequences into the shell prompt; Command+V now sends clipboard text through the terminal's bracketed-paste-aware input path.

--- a/examples/terminal/src/main.zig
+++ b/examples/terminal/src/main.zig
@@ -645,15 +645,26 @@ fn handleKey(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent) void {
     encodeKeyEvent(model, fx, event, .press);
 }
 
-/// Encode one key transition through the emulator's encoder and push
-/// the bytes toward the child. Releases ride the same path with
-/// `.release`: the encoder emits them only under the kitty protocol's
-/// negotiated event reporting and stays silent in legacy modes, so
-/// feeding every release is always correct. (Key REPEAT is the one
-/// event type the hosts do not distinguish from a fresh press, so a
-/// TUI that enabled event reporting sees repeats as presses.)
+/// Encode one key transition and push the bytes toward the child. macOS
+/// natural-text arrow gestures use conventional shell bindings;
+/// everything else goes through the emulator's encoder. Releases ride
+/// the same path with `.release`: the encoder emits them only under the
+/// kitty protocol's negotiated event reporting and stays silent in
+/// legacy modes. (Key REPEAT is the one event type the hosts do not
+/// distinguish from a fresh press, so a TUI that enabled event reporting
+/// sees repeats as presses.)
 fn encodeKeyEvent(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent, action: vt.input.KeyAction) void {
     const session = model.session;
+    if (macosNaturalTextSequence(event)) |sequence| {
+        // Natural-text bindings consume the whole gesture. In
+        // particular, a child using kitty event reporting must not
+        // receive a release for a modified arrow whose press arrived as
+        // legacy editing bytes.
+        if (action == .release) return;
+        session.scrollToBottom();
+        enqueueTransient(model, fx, sequence);
+        return;
+    }
     const mods = event.modifiers;
     const key = mapKey(event) orelse blk: {
         // A release of a plain printable never maps (its PRESS came
@@ -691,6 +702,28 @@ fn encodeKeyEvent(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent, act
     // Through the pending ring like committed text, so an encoded key
     // typed while a paste is still draining lands after it in the stream.
     enqueueTransient(model, fx, buffer[0..writer.end]);
+}
+
+/// Match macOS terminals' "natural text editing" bindings. These are
+/// exact bare-modifier gestures: shifted or combined chords continue
+/// through the key encoder so terminal applications can distinguish
+/// them. The raw bindings intentionally bypass negotiated kitty
+/// reporting, just as Ghostty's own default keybinds do.
+fn macosNaturalTextSequence(event: canvas.WidgetKeyboardEvent) ?[]const u8 {
+    if (comptime builtin.os.tag != .macos) return null;
+    const mods = event.modifiers;
+    if (mods.shift or mods.control) return null;
+    if (mods.alt and !mods.super) {
+        if (keyIs(event.key, "arrowleft")) return "\x1bb";
+        if (keyIs(event.key, "arrowright")) return "\x1bf";
+    }
+    if (mods.super and !mods.alt) {
+        if (keyIs(event.key, "arrowleft")) return "\x01";
+        if (keyIs(event.key, "arrowright")) return "\x05";
+        // The physical macOS Delete key is normalized as Backspace.
+        if (keyIs(event.key, "backspace")) return "\x15";
+    }
+    return null;
 }
 
 /// Committed text reaches the child through the emulator's key encoder

--- a/examples/terminal/src/main.zig
+++ b/examples/terminal/src/main.zig
@@ -128,6 +128,10 @@ pub const Model = struct {
     selecting: bool = false,
     /// Copy feedback for the status line, cleared by the next copy.
     copied_bytes: u64 = 0,
+    /// Physical macOS natural-editing keys whose press was sent as a
+    /// legacy shell binding. Matching releases are swallowed by key
+    /// identity even if Command/Option came up first.
+    macos_natural_keys_held: u8 = 0,
     /// The last copy FAILED (selection serialization or the clipboard
     /// write) with a selection active: the status line says so and the
     /// selection stays live for a retry. Cleared by the next copy
@@ -152,7 +156,6 @@ pub const Model = struct {
     /// Writes the pty refused over the session (reported on exit).
     dropped_writes: u32 = 0,
     /// The window's traffic-light inset so the header clears it.
-
     /// Pending outbound bytes toward the child's stdin — typed keys,
     /// pastes, AND emulator query replies, in one stream-ordered ring
     /// drained as the pty's 64 KiB stdin FIFO accepts them. A single
@@ -219,6 +222,7 @@ fn spawnShell(model: *Model, fx: *Fx) void {
     model.copied_bytes = 0;
     model.copy_failed = false;
     model.copy_inflight = false;
+    model.macos_natural_keys_held = 0;
     // Drop any bytes still queued for the session that just ended — a
     // restarted shell must not receive the dead one's unsent keystrokes.
     model.outbound_head = 0;
@@ -325,6 +329,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Fx) void {
         },
         .focus_changed => |focused| {
             model.focused = focused;
+            if (!focused) model.macos_natural_keys_held = 0;
         },
         .wheel => |delta| {
             // Natural direction, like every terminal: swiping the
@@ -655,12 +660,25 @@ fn handleKey(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent) void {
 /// sees repeats as presses.)
 fn encodeKeyEvent(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent, action: vt.input.KeyAction) void {
     const session = model.session;
+    const natural_key_mask = macosNaturalTextKeyMask(event.key);
+    if (action == .release and natural_key_mask != 0 and
+        (model.macos_natural_keys_held & natural_key_mask) != 0)
+    {
+        model.macos_natural_keys_held &= ~natural_key_mask;
+        return;
+    }
+    // A fresh press supersedes a stale latch, then re-arms it below when
+    // this is another natural-editing gesture (auto-repeat included).
+    if (action == .press and natural_key_mask != 0) {
+        model.macos_natural_keys_held &= ~natural_key_mask;
+    }
     if (macosNaturalTextSequence(event)) |sequence| {
         // Natural-text bindings consume the whole gesture. In
         // particular, a child using kitty event reporting must not
         // receive a release for a modified arrow whose press arrived as
         // legacy editing bytes.
         if (action == .release) return;
+        model.macos_natural_keys_held |= natural_key_mask;
         session.scrollToBottom();
         enqueueTransient(model, fx, sequence);
         return;
@@ -702,6 +720,14 @@ fn encodeKeyEvent(model: *Model, fx: *Fx, event: canvas.WidgetKeyboardEvent, act
     // Through the pending ring like committed text, so an encoded key
     // typed while a paste is still draining lands after it in the stream.
     enqueueTransient(model, fx, buffer[0..writer.end]);
+}
+
+fn macosNaturalTextKeyMask(key: []const u8) u8 {
+    if (comptime builtin.os.tag != .macos) return 0;
+    if (keyIs(key, "arrowleft")) return 1 << 0;
+    if (keyIs(key, "arrowright")) return 1 << 1;
+    if (keyIs(key, "backspace")) return 1 << 2;
+    return 0;
 }
 
 /// Match macOS terminals' "natural text editing" bindings. These are

--- a/examples/terminal/src/tests.zig
+++ b/examples/terminal/src/tests.zig
@@ -14,7 +14,6 @@ const canvas = native_sdk.canvas;
 const geometry = native_sdk.geometry;
 const testing = std.testing;
 
-
 fn createSession(cols: u16, rows: u16) !*grid.Session {
     return grid.Session.create(std.heap.page_allocator, testing.io, cols, rows);
 }
@@ -650,12 +649,14 @@ test "IME: a preedit is provisional; only the commit reaches the pty" {
     const app_iface = app_state.app();
 
     // Compose Japanese: the preedit must NOT reach the pty (provisional).
-    try harness.runtime.dispatchPlatformEvent(app_iface, .{ .gpu_surface_input = .{
-        .window_id = 1,
-        .label = "terminal-canvas",
-        .kind = .ime_set_composition,
-        .text = "\xe3\x81\x8b", // か
-    } });
+    try harness.runtime.dispatchPlatformEvent(app_iface, .{
+        .gpu_surface_input = .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .ime_set_composition,
+            .text = "\xe3\x81\x8b", // か
+        },
+    });
     try testing.expectEqualStrings("", app_state.effects.ptyWrittenBytes(1));
 
     // The host commits the marked text UNCHANGED — an empty commit; the
@@ -1001,9 +1002,21 @@ test "macOS natural text arrow gestures use shell editing bindings" {
         .{
             .window_id = 1,
             .label = "terminal-canvas",
+            .kind = .key_up,
+            .key = "arrowleft",
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
             .kind = .key_down,
             .key = "arrowright",
             .modifiers = .{ .option = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_up,
+            .key = "arrowright",
         },
         .{
             .window_id = 1,
@@ -1015,9 +1028,21 @@ test "macOS natural text arrow gestures use shell editing bindings" {
         .{
             .window_id = 1,
             .label = "terminal-canvas",
+            .kind = .key_up,
+            .key = "arrowleft",
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
             .kind = .key_down,
             .key = "arrowright",
             .modifiers = .{ .primary = true, .command = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_up,
+            .key = "arrowright",
         },
         .{
             .window_id = 1,
@@ -1031,7 +1056,6 @@ test "macOS natural text arrow gestures use shell editing bindings" {
             .label = "terminal-canvas",
             .kind = .key_up,
             .key = "backspace",
-            .modifiers = .{ .primary = true, .command = true },
         },
     };
     for (events) |event| {

--- a/examples/terminal/src/tests.zig
+++ b/examples/terminal/src/tests.zig
@@ -4,6 +4,7 @@
 //! pty replays fingerprint-identical offline, no shell present.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const native_sdk = @import("native_sdk");
 const vt = @import("ghostty-vt");
 const app = @import("main.zig");
@@ -971,6 +972,72 @@ test "a primary-aliased Ctrl chord still encodes its C0 byte" {
         .modifiers = .{ .control = true, .primary = true },
     } });
     try testing.expectEqualStrings("\x03", app_state.effects.ptyWrittenBytes(1));
+}
+
+test "macOS natural text arrow gestures use shell editing bindings" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    const gpa = testing.allocator;
+    const harness = try native_sdk.TestHarness().create(gpa, .{ .size = geometry.SizeF.init(980, 640) });
+    defer harness.destroy(gpa);
+    const app_state = try startFocusedTerminal(gpa, harness);
+    defer gpa.destroy(app_state);
+    defer app_state.model.session.destroy();
+    defer app_state.deinit();
+    const app_iface = app_state.app();
+
+    // Keep the platform-native bindings even after a TUI enables kitty
+    // event reporting: Option moves by words (Esc-b/f), Command moves to
+    // line boundaries (Ctrl-A/E), Command+Delete clears to the start
+    // (Ctrl-U), and a bound release emits nothing.
+    app_state.model.session.feed("\x1b[>11u");
+    const events = [_]native_sdk.platform.GpuSurfaceInputEvent{
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_down,
+            .key = "arrowleft",
+            .modifiers = .{ .option = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_down,
+            .key = "arrowright",
+            .modifiers = .{ .option = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_down,
+            .key = "arrowleft",
+            .modifiers = .{ .primary = true, .command = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_down,
+            .key = "arrowright",
+            .modifiers = .{ .primary = true, .command = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_down,
+            .key = "backspace",
+            .modifiers = .{ .primary = true, .command = true },
+        },
+        .{
+            .window_id = 1,
+            .label = "terminal-canvas",
+            .kind = .key_up,
+            .key = "backspace",
+            .modifiers = .{ .primary = true, .command = true },
+        },
+    };
+    for (events) |event| {
+        try harness.runtime.dispatchPlatformEvent(app_iface, .{ .gpu_surface_input = event });
+    }
+    try testing.expectEqualStrings("\x1bb\x1bf\x01\x05\x15", app_state.effects.ptyWrittenBytes(1));
 }
 
 test "stdin order holds: a retained reply reaches the child before newer typing" {

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -557,7 +557,6 @@ test "terminal Paste shortcuts and context menus use VT encoding and revalidate 
         .label = app.canvas_label,
         .kind = .key_up,
         .key = "v",
-        .modifiers = .{ .primary = true, .command = true },
     } });
     try testing.expectEqualStrings(
         "\x1b[200~echo one\n [201~echo two \x1b[201~",

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -512,7 +512,7 @@ test "a live pty session flows through the <terminal> element: output, typing, r
     try testing.expectEqualStrings("", h.app_state.effects.ptyWrittenBytes(app.shell_effect_key));
 }
 
-test "terminal context-menu Paste uses VT paste encoding and revalidates a pending session" {
+test "terminal Paste shortcuts and context menus use VT encoding and revalidate the session" {
     if (comptime !native_sdk.runtime.terminal_sessions_enabled) return error.SkipZigTest;
     var h = try Harness.create();
     defer h.destroy();
@@ -520,7 +520,7 @@ test "terminal context-menu Paste uses VT paste encoding and revalidates a pendi
     // Mode 2004 is emulator state derived from child output. Context
     // Paste must observe it rather than treating clipboard bytes as an
     // ordinary multi-character typing commit.
-    try h.app_state.effects.feedPtyOutput(app.shell_effect_key, "demo$ \x1b[?2004h");
+    try h.app_state.effects.feedPtyOutput(app.shell_effect_key, "demo$ \x1b[?2004h\x1b[>11u");
     try h.frame();
     const pasted = "echo one\n\x1b[201~echo two\x03";
     try h.harness.runtime.writeClipboard(pasted);
@@ -539,6 +539,29 @@ test "terminal context-menu Paste uses VT paste encoding and revalidates a pendi
     try testing.expectEqualStrings(
         "\x1b[200~echo one\n [201~echo two \x1b[201~",
         written[before..],
+    );
+
+    // Cmd+V follows the same paste encoder. Its physical key-up is
+    // consumed too: kitty event reporting must not receive an orphan
+    // modified-V release after the key-down became clipboard input.
+    const before_shortcut = written.len;
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "v",
+        .modifiers = .{ .primary = true, .command = true },
+    } });
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_up,
+        .key = "v",
+        .modifiers = .{ .primary = true, .command = true },
+    } });
+    try testing.expectEqualStrings(
+        "\x1b[200~echo one\n [201~echo two \x1b[201~",
+        h.app_state.effects.ptyWrittenBytes(app.shell_effect_key)[before_shortcut..],
     );
 
     // Open another live menu, then let the child exit before the native

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -60,6 +60,7 @@ static NSArray<NSString *> *NativeSdkPolicyListFromBytes(const char *bytes, size
 static NSString *NativeSdkOriginForURL(NSURL *url);
 static BOOL NativeSdkPolicyListMatches(NSArray<NSString *> *values, NSURL *url);
 static NSString *NativeSdkShortcutKeyForEvent(NSEvent *event);
+static BOOL NativeSdkTextNavigationNeedsRawKeyEvent(NSEvent *event);
 static BOOL NativeSdkShortcutUsesImplicitShift(NSString *key, NSEvent *event);
 static BOOL NativeSdkShortcutModifiersMatch(uint32_t shortcutModifiers, NSEventModifierFlags eventModifiers, BOOL allowImplicitShift);
 static NSEventModifierFlags NativeSdkMenuModifierFlags(uint32_t modifiers);
@@ -6149,6 +6150,17 @@ static BOOL NativeSdkCompositeBlurWriteRegion(NSDictionary *command, CGFloat sca
 
 - (void)keyDown:(NSEvent *)event {
     if ([self focusedTextAccessibilityElement]) {
+        // The shared canvas editor already maps Command/Option+Left/Right
+        // (including Shift variants) onto line/word navigation. Preserve
+        // those physical keys instead of letting interpretKeyEvents turn
+        // Command+Left/Right into modifier-less Home/End selectors. A
+        // focused terminal needs the modifiers even more: its emulator
+        // translates the natural macOS gestures to shell bindings, and
+        // negotiated key protocols must see every other combined chord.
+        if (NativeSdkTextNavigationNeedsRawKeyEvent(event)) {
+            [self emitInputEventWithKind:NATIVE_SDK_APPKIT_GPU_INPUT_KEY_DOWN event:event button:0 deltaX:0 deltaY:0];
+            return;
+        }
         self.interpretedKeyEventEmittedInput = NO;
         [self interpretKeyEvents:@[event]];
         if (!self.interpretedKeyEventEmittedInput) {
@@ -11246,6 +11258,14 @@ static NSString *NativeSdkShortcutKeyForEvent(NSEvent *event) {
         case '~': return @"`";
         default: return characters.lowercaseString;
     }
+}
+
+static BOOL NativeSdkTextNavigationNeedsRawKeyEvent(NSEvent *event) {
+    if (!event) return NO;
+    NSEventModifierFlags flags = event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
+    if ((flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) == 0) return NO;
+    NSString *key = NativeSdkShortcutKeyForEvent(event);
+    return [key isEqualToString:@"arrowleft"] || [key isEqualToString:@"arrowright"];
 }
 
 static BOOL NativeSdkShortcutUsesImplicitShift(NSString *key, NSEvent *event) {

--- a/src/runtime/api.zig
+++ b/src/runtime/api.zig
@@ -79,11 +79,11 @@ pub const CanvasWidgetKeyboardEvent = struct {
     keyboard: canvas.WidgetKeyboardEvent,
     target: ?canvas.WidgetFocusTarget = null,
     route: []const canvas.WidgetEventRouteEntry = &.{},
-    /// This committed-text payload came from the terminal context
-    /// menu's Paste action, not ordinary typing or IME input. UiApp
-    /// routes it through the emulator's paste encoder (bracketed-paste
-    /// framing, newline normalization, and unsafe-control stripping)
-    /// before writing it to the pty.
+    /// This committed-text payload came from terminal Paste (the
+    /// clipboard shortcut or context menu), not ordinary typing or IME
+    /// input. UiApp routes it through the emulator's paste encoder
+    /// (bracketed-paste framing, newline normalization, and unsafe-
+    /// control stripping) before writing it to the pty.
     terminal_paste: bool = false,
     /// True when this event is dispatched OUTSIDE a gpu-surface input
     /// cycle — the accessibility selection edits and the default

--- a/src/runtime/canvas_widget_context_menu_tests.zig
+++ b/src/runtime/canvas_widget_context_menu_tests.zig
@@ -525,6 +525,24 @@ test "right click on a terminal presents Copy and Paste wired to selection and c
     try std.testing.expect(app_state.last_keyboard_terminal_paste);
     try std.testing.expect(app_state.last_keyboard_standalone);
     try std.testing.expectEqualStrings(paste, app_state.last_edit_insert[0..app_state.last_edit_insert_len]);
+
+    // The keyboard shortcut takes the same provenance-sensitive path,
+    // but remains part of the gpu-input cycle rather than a standalone
+    // native-menu dispatch.
+    const shortcut_paste = "echo shortcut\n";
+    try harness.runtime.writeClipboard(shortcut_paste);
+    try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .key_down,
+        .key = "v",
+        .modifiers = .{ .primary = true, .command = true },
+    } });
+    try std.testing.expectEqual(canvas.WidgetKeyboardPhase.text_input, app_state.last_keyboard_phase);
+    try std.testing.expectEqual(@as(?canvas.ObjectId, 2), app_state.last_keyboard_focused_id);
+    try std.testing.expect(app_state.last_keyboard_terminal_paste);
+    try std.testing.expect(!app_state.last_keyboard_standalone);
+    try std.testing.expectEqualStrings(shortcut_paste, app_state.last_edit_insert[0..app_state.last_edit_insert_len]);
 }
 
 test "terminal Paste disables after exit and a pending live menu revalidates before dispatch" {

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -1978,6 +1978,7 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                         const focused_id = event.keyboard.focused_id;
                         event.keyboard = .{ .phase = .text_input, .focused_id = focused_id };
                         event.terminal_paste = true;
+                        self.views[index].canvas_widget_terminal_paste_v_held = true;
 
                         // Mark the shortcut as consumed before touching
                         // the clipboard. An unavailable/empty clipboard
@@ -2326,6 +2327,24 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                 self.views[index].canvas_widget_terminal_focus_entry_tab_held = false;
             }
             return true;
+        }
+
+        /// Consume the physical V release paired with a terminal Paste
+        /// shortcut. Modifier flags describe the release instant, not
+        /// the original key-down: Command/Ctrl may already be up, so the
+        /// key-down classification is latched on the view instead of
+        /// reconstructed here. A fresh V down retires a stale latch
+        /// first (native menu Paste synthesizes a down with no release);
+        /// the clipboard pass later in this input cycle re-arms it when
+        /// that fresh down is another terminal Paste.
+        pub fn consumeCanvasWidgetTerminalPasteKeyLifetime(self: *Runtime, input_event: GpuSurfaceInputEvent) bool {
+            if (input_event.kind != .key_down and input_event.kind != .key_up) return false;
+            if (!std.ascii.eqlIgnoreCase(input_event.key, "v")) return false;
+            const index = runtimeFindViewIndex(self, input_event.window_id, input_event.label) orelse return false;
+            if (self.views[index].kind != .gpu_surface) return false;
+            if (!self.views[index].canvas_widget_terminal_paste_v_held) return false;
+            self.views[index].canvas_widget_terminal_paste_v_held = false;
+            return input_event.kind == .key_up;
         }
 
         /// Returns true when the key moved keyboard focus to a DIFFERENT

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -1924,12 +1924,13 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
         /// - cut: copy, then stamp a delete-selection edit onto the routed
         ///   keyboard event so runtime widget and app model apply the same
         ///   removal.
-        /// - paste: reads the clipboard into `paste_buffer`, sanitizes it
-        ///   for the target kind and THEN clamps to the view's text
-        ///   capacity (setting `edit_truncated` loudly) — order matters:
-        ///   clamping first would spend capacity on line-break bytes the
-        ///   seam strips anyway — and stamps the insertion onto the
-        ///   routed keyboard event.
+        /// - paste: a terminal target becomes provenance-tagged committed
+        ///   input for its dedicated VT paste encoder; editable text reads
+        ///   the clipboard into `paste_buffer`, sanitizes it for the target
+        ///   kind and THEN clamps to the view's text capacity (setting
+        ///   `edit_truncated` loudly) — order matters: clamping first would
+        ///   spend capacity on line-break bytes the seam strips anyway —
+        ///   and stamps the insertion onto the routed keyboard event.
         ///
         /// Platforms without a clipboard capability report
         /// `UnsupportedService`; the shortcut degrades to a no-op instead
@@ -1968,6 +1969,27 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                     const target = event.target orelse return;
                     const node_index = self.views[index].canvasWidgetNodeIndexById(target.id) orelse return;
                     const widget = self.views[index].widget_layout_nodes[node_index].widget;
+                    if (widget.kind == .terminal and !widget.state.disabled and widget.terminal.pty != 0) {
+                        // A terminal paste is committed input, but it must
+                        // stay distinct from typing: the session's paste
+                        // encoder owns bracketed-paste framing, newline
+                        // conversion, and unsafe-control stripping. Shape
+                        // the shortcut exactly like context-menu Paste.
+                        const focused_id = event.keyboard.focused_id;
+                        event.keyboard = .{ .phase = .text_input, .focused_id = focused_id };
+                        event.terminal_paste = true;
+
+                        // Mark the shortcut as consumed before touching
+                        // the clipboard. An unavailable/empty clipboard
+                        // must not turn Cmd+V into a key sent to the child.
+                        const grid = widget.terminal.grid orelse return;
+                        if (!grid.running) return;
+                        const text = self.readClipboard(paste_buffer) catch return;
+                        if (text.len == 0) return;
+                        event.keyboard.text = text;
+                        event.keyboard.edit = .{ .insert_text = text };
+                        return;
+                    }
                     if (!canvas_widget_runtime.canvasWidgetEditableTextKind(widget.kind) or widget.state.disabled) return;
                     // An empty or unavailable clipboard pastes nothing.
                     const text = self.readClipboard(paste_buffer) catch return;

--- a/src/runtime/gpu_surface_events.zig
+++ b/src/runtime/gpu_surface_events.zig
@@ -352,17 +352,24 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
             // reinterpret them against the newly focused terminal.
             const terminal_focus_entry_tab_suppressed =
                 CanvasWidgetEventMethods().consumeCanvasWidgetTerminalFocusEntryTab(self, input_event);
-            const keyboard_dismissed_id = if (targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
+            // Terminal Paste owns its matching physical V release even
+            // when Command/Ctrl came up first. Classify it before focus,
+            // routing, or app fallbacks can reinterpret the orphan.
+            const terminal_paste_release_suppressed =
+                CanvasWidgetEventMethods().consumeCanvasWidgetTerminalPasteKeyLifetime(self, input_event);
+            const terminal_key_lifetime_suppressed =
+                terminal_focus_entry_tab_suppressed or terminal_paste_release_suppressed;
+            const keyboard_dismissed_id = if (targetless_composition_owns_keys or terminal_key_lifetime_suppressed)
                 0
             else
                 try CanvasWidgetEventMethods().dismissCanvasWidgetSurfaceFromKeyboardInput(self, input_event);
             if (keyboard_dismissed_id != 0) dismissed_surface_id = keyboard_dismissed_id;
             const widget_surface_dismissed = keyboard_dismissed_id != 0;
-            const widget_focus_moved = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
+            const widget_focus_moved = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_key_lifetime_suppressed)
                 false
             else
                 try CanvasWidgetEventMethods().updateCanvasWidgetFocusFromKeyboardInput(self, input_event);
-            var widget_keyboard_event = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_focus_entry_tab_suppressed)
+            var widget_keyboard_event = if (widget_surface_dismissed or targetless_composition_owns_keys or terminal_key_lifetime_suppressed)
                 null
             else
                 CanvasWidgetEventMethods().routeCanvasWidgetKeyboardInput(self, input_event, &self.widget_event_route_entries) catch |err| switch (err) {
@@ -624,7 +631,7 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
                 try CanvasWidgetEventMethods().dispatchCanvasWidgetCommandFromKeyboard(self, app, keyboard_event);
                 try self.dispatchEvent(app, .{ .canvas_widget_keyboard = keyboard_event });
             } else if ((input_event.kind == .key_down or input_event.kind == .key_up) and
-                !widget_surface_dismissed and !terminal_focus_entry_tab_suppressed)
+                !widget_surface_dismissed and !terminal_key_lifetime_suppressed)
             {
                 // No focused widget routed this key (nothing is
                 // focused, or the focused id is gone from the tree): the
@@ -806,21 +813,23 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
                             // above): a focused terminal resolves its
                             // typing channel from it.
                             const focused_id = self.views[index].canvas_widget_focused_id;
-                            try self.dispatchEvent(app, .{ .canvas_widget_keyboard = .{
-                                .window_id = input_event.window_id,
-                                .view_label = self.views[index].label,
-                                .keyboard = .{
-                                    .phase = .text_input,
-                                    .focused_id = if (focused_id != 0) focused_id else null,
-                                    .key = input_event.key,
-                                    .text = text,
-                                    // Mark it committed so the ui-app
-                                    // `on_text` gate (insert_text only)
-                                    // delivers it.
-                                    .edit = .{ .insert_text = text },
-                                    .modifiers = canvas_frame_helpers.canvasWidgetKeyboardModifiers(input_event.modifiers),
+                            try self.dispatchEvent(app, .{
+                                .canvas_widget_keyboard = .{
+                                    .window_id = input_event.window_id,
+                                    .view_label = self.views[index].label,
+                                    .keyboard = .{
+                                        .phase = .text_input,
+                                        .focused_id = if (focused_id != 0) focused_id else null,
+                                        .key = input_event.key,
+                                        .text = text,
+                                        // Mark it committed so the ui-app
+                                        // `on_text` gate (insert_text only)
+                                        // delivers it.
+                                        .edit = .{ .insert_text = text },
+                                        .modifiers = canvas_frame_helpers.canvasWidgetKeyboardModifiers(input_event.modifiers),
+                                    },
                                 },
-                            } });
+                            });
                         }
                     }
                 }

--- a/src/runtime/terminal_session.zig
+++ b/src/runtime/terminal_session.zig
@@ -547,6 +547,10 @@ const Session = if (enabled) struct {
     /// delta-to-rows and pointer-to-cell selection.
     cell_width: f32 = 8,
     cell_height: f32 = 18,
+    /// Physical macOS natural-editing keys whose press bypassed kitty
+    /// reporting as legacy shell bytes. Their matching release must be
+    /// swallowed by key identity even if Command/Option came up first.
+    macos_natural_keys_held: u8 = 0,
 
     /// Query-answer buffer's initial size and growth ceiling — the
     /// example tier's bounds verbatim (the ceiling matches the ring:
@@ -650,6 +654,7 @@ const Session = if (enabled) struct {
         session.outbound_len = 0;
         session.outbound_dropped = 0;
         session.wheel_accum = 0;
+        session.macos_natural_keys_held = 0;
         session.ended = false;
         session.grid.running = true;
         session.snapshot_dirty = true;
@@ -1008,12 +1013,26 @@ const Session = if (enabled) struct {
     /// (C0 chords, CSI-u exceptions, application cursor-key modes, kitty
     /// event reporting for releases).
     fn encodeKeyEvent(session: *Session, gateway: ?PtyGateway, pty_key: u64, event: canvas.WidgetKeyboardEvent, action: vt.input.KeyAction) void {
+        const natural_key_mask = macosNaturalTextKeyMask(event.key);
+        if (action == .release and natural_key_mask != 0 and
+            (session.macos_natural_keys_held & natural_key_mask) != 0)
+        {
+            session.macos_natural_keys_held &= ~natural_key_mask;
+            return;
+        }
+        // A fresh press supersedes any stale held bit (focus loss or a
+        // host-generated press with no matching release). A natural
+        // press below immediately re-arms it, including auto-repeat.
+        if (action == .press and natural_key_mask != 0) {
+            session.macos_natural_keys_held &= ~natural_key_mask;
+        }
         if (macosNaturalTextSequence(event)) |sequence| {
             // Natural-text bindings consume the whole gesture. In
             // particular, a child using kitty event reporting must not
             // receive a release for a modified arrow whose press arrived
             // as legacy editing bytes.
             if (action == .release) return;
+            session.macos_natural_keys_held |= natural_key_mask;
             const before = session.scrollbarState().offset;
             session.scrollToBottom();
             if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
@@ -1055,6 +1074,14 @@ const Session = if (enabled) struct {
         session.scrollToBottom();
         if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
         session.enqueueTransient(gateway, pty_key, buffer[0..writer.end]);
+    }
+
+    fn macosNaturalTextKeyMask(key: []const u8) u8 {
+        if (comptime builtin.os.tag != .macos) return 0;
+        if (std.ascii.eqlIgnoreCase(key, "arrowleft")) return 1 << 0;
+        if (std.ascii.eqlIgnoreCase(key, "arrowright")) return 1 << 1;
+        if (std.ascii.eqlIgnoreCase(key, "backspace")) return 1 << 2;
+        return 0;
     }
 
     /// Match macOS terminals' "natural text editing" bindings. These are

--- a/src/runtime/terminal_session.zig
+++ b/src/runtime/terminal_session.zig
@@ -1002,11 +1002,24 @@ const Session = if (enabled) struct {
 
     // --------------------------------------------------------- keyboard
 
-    /// Encode one key transition through the emulator's encoder and push
-    /// the bytes toward the child (the example tier's encoding rules
-    /// verbatim: C0 chords, CSI-u exceptions, application cursor-key
-    /// modes, kitty event reporting for releases).
+    /// Encode one key transition and push the bytes toward the child.
+    /// macOS natural-text arrow gestures use the platform's conventional
+    /// shell bindings; everything else follows the emulator's encoder
+    /// (C0 chords, CSI-u exceptions, application cursor-key modes, kitty
+    /// event reporting for releases).
     fn encodeKeyEvent(session: *Session, gateway: ?PtyGateway, pty_key: u64, event: canvas.WidgetKeyboardEvent, action: vt.input.KeyAction) void {
+        if (macosNaturalTextSequence(event)) |sequence| {
+            // Natural-text bindings consume the whole gesture. In
+            // particular, a child using kitty event reporting must not
+            // receive a release for a modified arrow whose press arrived
+            // as legacy editing bytes.
+            if (action == .release) return;
+            const before = session.scrollbarState().offset;
+            session.scrollToBottom();
+            if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
+            session.enqueueTransient(gateway, pty_key, sequence);
+            return;
+        }
         const mods = event.modifiers;
         const key = mapKey(event) orelse blk: {
             // A release of a plain printable never maps (its PRESS came
@@ -1042,6 +1055,28 @@ const Session = if (enabled) struct {
         session.scrollToBottom();
         if (session.scrollbarState().offset != before) session.snapshot_dirty = true;
         session.enqueueTransient(gateway, pty_key, buffer[0..writer.end]);
+    }
+
+    /// Match macOS terminals' "natural text editing" bindings. These are
+    /// exact bare-modifier gestures: shifted or combined chords continue
+    /// through the key encoder so terminal applications can distinguish
+    /// them. The raw bindings intentionally bypass negotiated kitty
+    /// reporting, just as Ghostty's own default keybinds do.
+    fn macosNaturalTextSequence(event: canvas.WidgetKeyboardEvent) ?[]const u8 {
+        if (comptime builtin.os.tag != .macos) return null;
+        const mods = event.modifiers;
+        if (mods.shift or mods.control) return null;
+        if (mods.alt and !mods.super) {
+            if (std.ascii.eqlIgnoreCase(event.key, "arrowleft")) return "\x1bb";
+            if (std.ascii.eqlIgnoreCase(event.key, "arrowright")) return "\x1bf";
+        }
+        if (mods.super and !mods.alt) {
+            if (std.ascii.eqlIgnoreCase(event.key, "arrowleft")) return "\x01";
+            if (std.ascii.eqlIgnoreCase(event.key, "arrowright")) return "\x05";
+            // The physical macOS Delete key is normalized as Backspace.
+            if (std.ascii.eqlIgnoreCase(event.key, "backspace")) return "\x15";
+        }
+        return null;
     }
 
     /// Committed text reaches the child through the emulator's key

--- a/src/runtime/terminal_session_tests.zig
+++ b/src/runtime/terminal_session_tests.zig
@@ -8,6 +8,7 @@
 //! `terminal_vt` seam carries the stub.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const canvas = @import("canvas");
 const effects = @import("effects.zig");
 const terminal_session = @import("terminal_session.zig");
@@ -196,6 +197,45 @@ test "committed text and encoded keys reach the pty through the gateway in stdin
     gw.written.clearRetainingCapacity();
     try testing.expect(store.keyEvent(3, .{ .phase = .key_down, .key = "a" }));
     try testing.expectEqualStrings("", gw.written.items);
+
+    if (comptime builtin.os.tag == .macos) {
+        // Natural text navigation follows macOS terminal conventions:
+        // Option moves by words and Command moves to line boundaries.
+        // These bindings intentionally remain legacy bytes after a TUI
+        // enables kitty reporting, and their releases stay consumed.
+        feedOutput(&store, 3, "\x1b[>11u");
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_down,
+            .key = "arrowleft",
+            .modifiers = .{ .alt = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_down,
+            .key = "arrowright",
+            .modifiers = .{ .alt = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_down,
+            .key = "arrowleft",
+            .modifiers = .{ .super = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_down,
+            .key = "arrowright",
+            .modifiers = .{ .super = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_down,
+            .key = "backspace",
+            .modifiers = .{ .super = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_up,
+            .key = "backspace",
+            .modifiers = .{ .super = true },
+        }));
+        try testing.expectEqualStrings("\x1bb\x1bf\x01\x05\x15", gw.written.items);
+    }
 }
 
 test "clipboard paste uses terminal paste encoding and ended sessions refuse it" {

--- a/src/runtime/terminal_session_tests.zig
+++ b/src/runtime/terminal_session_tests.zig
@@ -210,9 +210,17 @@ test "committed text and encoded keys reach the pty through the gateway in stdin
             .modifiers = .{ .alt = true },
         }));
         try testing.expect(store.keyEvent(3, .{
+            .phase = .key_up,
+            .key = "arrowleft",
+        }));
+        try testing.expect(store.keyEvent(3, .{
             .phase = .key_down,
             .key = "arrowright",
             .modifiers = .{ .alt = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_up,
+            .key = "arrowright",
         }));
         try testing.expect(store.keyEvent(3, .{
             .phase = .key_down,
@@ -220,9 +228,17 @@ test "committed text and encoded keys reach the pty through the gateway in stdin
             .modifiers = .{ .super = true },
         }));
         try testing.expect(store.keyEvent(3, .{
+            .phase = .key_up,
+            .key = "arrowleft",
+        }));
+        try testing.expect(store.keyEvent(3, .{
             .phase = .key_down,
             .key = "arrowright",
             .modifiers = .{ .super = true },
+        }));
+        try testing.expect(store.keyEvent(3, .{
+            .phase = .key_up,
+            .key = "arrowright",
         }));
         try testing.expect(store.keyEvent(3, .{
             .phase = .key_down,
@@ -232,7 +248,6 @@ test "committed text and encoded keys reach the pty through the gateway in stdin
         try testing.expect(store.keyEvent(3, .{
             .phase = .key_up,
             .key = "backspace",
-            .modifiers = .{ .super = true },
         }));
         try testing.expectEqualStrings("\x1bb\x1bf\x01\x05\x15", gw.written.items);
     }

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -5381,11 +5381,17 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                             // this emulator selection. Do not forward the
                             // same Cmd/Ctrl+C chord to the child (where
                             // Ctrl+C would be an interrupt).
-                            const copy_chord = (keyboard_event.keyboard.phase == .key_down or keyboard_event.keyboard.phase == .key_up) and
+                            const clipboard_chord = (keyboard_event.keyboard.phase == .key_down or keyboard_event.keyboard.phase == .key_up) and
                                 keyboard_event.keyboard.modifiers.hasCommandModifier() and
                                 !keyboard_event.keyboard.modifiers.alt and
-                                !keyboard_event.keyboard.modifiers.shift and
-                                std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "c");
+                                !keyboard_event.keyboard.modifiers.shift;
+                            // Cmd/Ctrl+V's key-down was rewritten to a
+                            // provenance-tagged text_input by the runtime
+                            // clipboard pass. Consume its physical key-up
+                            // too, or kitty event reporting would receive
+                            // an orphan modified-V release.
+                            if (clipboard_chord and std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "v")) return;
+                            const copy_chord = clipboard_chord and std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "c");
                             if (copy_chord) {
                                 if (widget.terminal.grid) |grid| {
                                     if (grid.selection_active) return;
@@ -5445,7 +5451,7 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                                 const edit = keyboard_event.keyboard.textEditEvent() orelse return;
                                 if (edit != .insert_text) return;
                                 if (keyboard_event.terminal_paste) {
-                                    // Context-menu paste is provenance-
+                                    // Clipboard paste is provenance-
                                     // sensitive terminal input: the
                                     // session must apply bracketed-paste
                                     // framing and paste sanitization.
@@ -5467,6 +5473,10 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                         }
                     }
                 }
+                // A provenance-tagged terminal paste is terminal-addressed
+                // even when no enabled emulator is wired in this build.
+                // Never leak its clipboard bytes to app-level `on_text`.
+                if (keyboard_event.terminal_paste) return;
                 const text_map = self.options.on_text orelse return;
                 // COMMITTED text only. An IME preedit (`set_composition`)
                 // or a cancel is provisional and must never reach a

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -5381,17 +5381,11 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                             // this emulator selection. Do not forward the
                             // same Cmd/Ctrl+C chord to the child (where
                             // Ctrl+C would be an interrupt).
-                            const clipboard_chord = (keyboard_event.keyboard.phase == .key_down or keyboard_event.keyboard.phase == .key_up) and
+                            const copy_chord = (keyboard_event.keyboard.phase == .key_down or keyboard_event.keyboard.phase == .key_up) and
                                 keyboard_event.keyboard.modifiers.hasCommandModifier() and
                                 !keyboard_event.keyboard.modifiers.alt and
-                                !keyboard_event.keyboard.modifiers.shift;
-                            // Cmd/Ctrl+V's key-down was rewritten to a
-                            // provenance-tagged text_input by the runtime
-                            // clipboard pass. Consume its physical key-up
-                            // too, or kitty event reporting would receive
-                            // an orphan modified-V release.
-                            if (clipboard_chord and std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "v")) return;
-                            const copy_chord = clipboard_chord and std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "c");
+                                !keyboard_event.keyboard.modifiers.shift and
+                                std.ascii.eqlIgnoreCase(keyboard_event.keyboard.key, "c");
                             if (copy_chord) {
                                 if (widget.terminal.grid) |grid| {
                                     if (grid.selection_active) return;

--- a/src/runtime/view.zig
+++ b/src/runtime/view.zig
@@ -165,6 +165,11 @@ pub fn clearImeGraceOnViewBlur(runtime: anytype, view: *RuntimeView) void {
     // other view-local input graces so a later Tab is never mistaken
     // for the tail of the old gesture.
     view.canvas_widget_terminal_focus_entry_tab_held = false;
+    // Same physical-lifetime rule for terminal Paste: a native menu can
+    // synthesize only the key-down, and a real Cmd/Ctrl+V may release its
+    // modifier before V. Blur retires either incomplete gesture so no
+    // later plain V release can inherit it.
+    view.canvas_widget_terminal_paste_v_held = false;
     if ((runtime.targetless_ime_preedit_len > 0 or
         runtime.targetless_ime_commit_grace) and
         runtime.targetless_ime_preedit_window == view.window_id and
@@ -537,6 +542,12 @@ pub const RuntimeView = struct {
     /// suppresses those transitions and clears this on key-up (or view
     /// blur through `clearImeGraceOnViewBlur`).
     canvas_widget_terminal_focus_entry_tab_held: bool = false,
+    /// A Cmd/Ctrl+V key-down the clipboard pass converted into terminal
+    /// paste input. Its physical V release belongs to that paste even if
+    /// the modifier came up first; the raw gpu-input pass consumes it
+    /// and clears this latch. A fresh V key-down clears a stale native-
+    /// menu latch before the clipboard pass may arm it again.
+    canvas_widget_terminal_paste_v_held: bool = false,
     canvas_widget_focus_visible_id: canvas.ObjectId = 0,
     /// True when `canvas_widget_focus_visible_id` was written by the
     /// KEYBOARD focus contract (`setCanvasWidgetFocusFromKeyboard`) —


### PR DESCRIPTION
- Map Option/Cmd navigation and Cmd+Delete to shell-native sequences.
- Route Cmd+V through the bracketed-paste-aware terminal input path.
- Add runtime and example regressions for modified keys and paste.