### PR TITLE
fix: sync webview focus with canvas panes

### DIFF
--- a/changelog.d/workbench-webview-focus.md
+++ b/changelog.d/workbench-webview-focus.md
@@ -1,0 +1,1 @@
+fix: **Workbench pane focus stays truthful**: clicking the embedded page now blurs the address bar and hollows the terminal caret; clicking either canvas pane restores its expected keyboard focus.

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -581,7 +581,7 @@ test "terminal Paste shortcuts and context menus use VT encoding and revalidate 
     try testing.expect(!h.harness.null_platform.contextMenuItems()[1].enabled);
 }
 
-test "the terminal cursor follows app and key-window keyboard ownership" {
+test "terminal and address focus yield to the webview and recover on canvas click" {
     if (comptime !native_sdk.runtime.terminal_sessions_enabled) return error.SkipZigTest;
     var h = try Harness.create();
     defer h.destroy();
@@ -592,11 +592,49 @@ test "the terminal cursor follows app and key-window keyboard ownership" {
 
     const layout = try h.harness.runtime.canvasWidgetLayout(1, app.canvas_label);
     var terminal_id: canvas.ObjectId = 0;
+    var address_id: canvas.ObjectId = 0;
     for (layout.nodes) |node| {
         if (node.widget.kind == .terminal) terminal_id = node.widget.id;
+        if (std.mem.eql(u8, node.widget.semantics.label, "Address")) address_id = node.widget.id;
     }
     try testing.expect(terminal_id != 0);
+    try testing.expect(address_id != 0);
     const view_index = h.harness.runtime.findViewIndex(1, app.canvas_label) orelse return error.TestUnexpectedResult;
+    var webview_index: ?usize = null;
+    for (h.harness.runtime.webviews[0..h.harness.runtime.webview_count], 0..) |webview, index| {
+        if (webview.window_id == 1 and std.mem.eql(u8, webview.label, app.web_view_label)) {
+            webview_index = index;
+            break;
+        }
+    }
+    const web_index = webview_index orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .filled);
+
+    // The toolbar is still canvas content: clicking its address field
+    // moves widget focus within the canvas and hollows the terminal.
+    try h.click(900, 24);
+    try testing.expectEqual(address_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try testing.expect(h.harness.runtime.views[view_index].focused);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .hollow);
+
+    // The embedded page owns its pointer stream, so its host focus edge
+    // names the webview directly. The canvas retains the address id as
+    // focus memory but no longer paints or reports it as keyboard focus.
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .view_focused = .{
+        .window_id = 1,
+        .label = app.web_view_label,
+    } });
+    try testing.expect(!h.harness.runtime.views[view_index].focused);
+    try testing.expect(h.harness.runtime.webviews[web_index].focused);
+    try testing.expectEqual(address_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
+    try expectTerminalCursorPaint(h.harness, terminal_id, .hollow);
+
+    // A canvas click is the symmetric edge: the canvas view retakes
+    // keyboard ownership and normal hit-testing moves widget focus.
+    try h.click(200, 400);
+    try testing.expect(h.harness.runtime.views[view_index].focused);
+    try testing.expect(!h.harness.runtime.webviews[web_index].focused);
     try testing.expectEqual(terminal_id, h.harness.runtime.views[view_index].canvas_widget_focused_id);
     try expectTerminalCursorPaint(h.harness, terminal_id, .filled);
 

--- a/src/platform/linux/gtk_host.c
+++ b/src/platform/linux/gtk_host.c
@@ -2859,6 +2859,46 @@ static void native_sdk_register_zero_scheme(native_sdk_gtk_host_t *host, WebKitW
     host->scheme_registered = 1;
 }
 
+/* WebKit owns its pointer stream, so a press never reaches the runtime's
+ * gpu_surface input seam. Observe without claiming the gesture and report
+ * which WebView the press will focus; the runtime can then blur its canvas
+ * sibling before WebKit receives the same event. */
+static void native_sdk_webview_pointer_pressed(GtkGestureClick *gesture, int n_press, double x, double y, gpointer data) {
+    (void)n_press;
+    (void)x;
+    (void)y;
+    native_sdk_gtk_window_t *win = data;
+    if (!win || !win->host) return;
+    GtkWidget *widget = gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(gesture));
+    const char *label = NULL;
+    if (win->web_view && widget == GTK_WIDGET(win->web_view)) {
+        label = "main";
+    } else {
+        for (int i = 0; i < win->webview_count; i++) {
+            if (win->webviews[i].web_view && widget == GTK_WIDGET(win->webviews[i].web_view)) {
+                label = win->webviews[i].label;
+                break;
+            }
+        }
+    }
+    if (!label) return;
+    native_sdk_emit(win->host, (native_sdk_gtk_event_t){
+        .kind = NATIVE_SDK_GTK_EVENT_VIEW_FOCUSED,
+        .window_id = win->id,
+        .view_label = label,
+        .view_label_len = strlen(label),
+    });
+}
+
+static void native_sdk_watch_webview_pointer_focus(native_sdk_gtk_window_t *win, WebKitWebView *web_view) {
+    if (!win || !web_view) return;
+    GtkGesture *click = gtk_gesture_click_new();
+    gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(click), 0);
+    gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click), GTK_PHASE_CAPTURE);
+    g_signal_connect(click, "pressed", G_CALLBACK(native_sdk_webview_pointer_pressed), win);
+    gtk_widget_add_controller(GTK_WIDGET(web_view), GTK_EVENT_CONTROLLER(click));
+}
+
 /* Create-on-first-use for a window's main WebView (the AppKit host's
  * ensureMainWebViewForWindowId:). Pure peek reads (event emission,
  * bridge completion echoes, reorder passes, focus) keep checking
@@ -2881,6 +2921,7 @@ static WebKitWebView *native_sdk_ensure_main_webview(native_sdk_gtk_window_t *wi
     native_sdk_register_zero_scheme(win->host, wv);
     native_sdk_setup_bridge(win);
     g_signal_connect(wv, "decide-policy", G_CALLBACK(on_decide_policy), win);
+    native_sdk_watch_webview_pointer_focus(win, wv);
 
     /* The overlay's main-child slot, where the eager create used to put
      * it: the overlay allocates its main child the full stack area on the
@@ -4360,6 +4401,7 @@ int native_sdk_gtk_create_webview(native_sdk_gtk_host_t *host, uint64_t window_i
     webview->transparent = transparent != 0;
     webview->bridge_enabled = bridge_enabled != 0;
     webview->content_manager = manager;
+    native_sdk_watch_webview_pointer_focus(win, web_view);
     native_sdk_apply_webview_frame(webview);
     gtk_overlay_add_overlay(GTK_OVERLAY(win->stack_root), GTK_WIDGET(web_view));
     if (transparent) {

--- a/src/platform/linux/gtk_host.h
+++ b/src/platform/linux/gtk_host.h
@@ -30,6 +30,7 @@ typedef enum {
     NATIVE_SDK_GTK_EVENT_APPEARANCE = 16,
     NATIVE_SDK_GTK_EVENT_AUDIO = 17,
     NATIVE_SDK_GTK_EVENT_CONTEXT_MENU_ACTION = 18,
+    NATIVE_SDK_GTK_EVENT_VIEW_FOCUSED = 19,
 } native_sdk_gtk_event_kind_t;
 
 typedef struct {

--- a/src/platform/linux/root.zig
+++ b/src/platform/linux/root.zig
@@ -34,6 +34,7 @@ const GtkEventKind = enum(c_int) {
     appearance = 16,
     audio = 17,
     context_menu_action = 18,
+    view_focused = 19,
 };
 
 const GtkEvent = extern struct {
@@ -571,6 +572,10 @@ fn gtkCallback(context: ?*anyopaque, event: *const GtkEvent) callconv(.c) void {
                 .focused = event.focused != 0,
             } });
         },
+        .view_focused => state.emit(.{ .view_focused = .{
+            .window_id = event.window_id,
+            .label = event.view_label[0..event.view_label_len],
+        } }),
         .shortcut => state.emit(.{ .shortcut = .{
             .id = event.shortcut_id[0..event.shortcut_id_len],
             .key = event.shortcut_key[0..event.shortcut_key_len],
@@ -1832,6 +1837,16 @@ fn viewKindInt(kind: platform_mod.ViewKind) c_int {
 
 test "linux platform module exports type" {
     _ = LinuxPlatform;
+}
+
+test "linux webview presses report the focused child label" {
+    // The capture-phase observer watches without claiming WebKit's
+    // gesture; it exists solely to mirror the focus edge into runtime
+    // state before the page handles the same press.
+    const host_source = @embedFile("gtk_host.c");
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click), GTK_PHASE_CAPTURE)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, ".kind = NATIVE_SDK_GTK_EVENT_VIEW_FOCUSED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "native_sdk_watch_webview_pointer_focus(win, web_view);") != null);
 }
 
 test "linux refuses a .hide main window at platform init instead of a silent quit-on-close" {

--- a/src/platform/macos/appkit_host.h
+++ b/src/platform/macos/appkit_host.h
@@ -33,6 +33,7 @@ typedef enum {
     NATIVE_SDK_APPKIT_EVENT_CONTEXT_MENU_ACTION = 19,
     NATIVE_SDK_APPKIT_EVENT_AUDIO = 20,
     NATIVE_SDK_APPKIT_EVENT_VIDEO = 21,
+    NATIVE_SDK_APPKIT_EVENT_VIEW_FOCUSED = 22,
 } native_sdk_appkit_event_kind_t;
 
 /* Audio player reports (EVENT_AUDIO payloads). LOADED acknowledges a

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -320,6 +320,7 @@ static NSMutableDictionary *NativeSdkCredentialQuery(NSString *service, NSString
 @property(nonatomic, strong) NSArray<NSValue *> *coveredMouseRects;
 @property(nonatomic, assign) NativeSdkAppKitHost *host;
 @property(nonatomic, assign) uint64_t windowId;
+@property(nonatomic, strong) NSString *viewLabel;
 @end
 
 @interface NativeSdkBridgeScriptHandler : NSObject <WKScriptMessageHandler>
@@ -893,6 +894,7 @@ static NSMutableDictionary *NativeSdkCredentialQuery(NSString *service, NSString
 @property(nonatomic, assign) BOOL observesAppearanceChanges;
 @property(nonatomic, assign) NSInteger bridgeFrameKeepalive;
 @property(nonatomic, strong) id shortcutEventMonitor;
+@property(nonatomic, strong) id viewFocusEventMonitor;
 @property(nonatomic, strong) id willTerminateObserver;
 @property(nonatomic, strong) dispatch_source_t sigtermSource;
 @property(nonatomic, strong) NSArray<NativeSdkShortcut *> *shortcuts;
@@ -7300,6 +7302,10 @@ static BOOL NativeSdkScrollDriverCanConsumeHorizontally(NativeSdkScrollDriverVie
         [NSEvent removeMonitor:self.shortcutEventMonitor];
         self.shortcutEventMonitor = nil;
     }
+    if (self.viewFocusEventMonitor) {
+        [NSEvent removeMonitor:self.viewFocusEventMonitor];
+        self.viewFocusEventMonitor = nil;
+    }
     [self removeAllChildBridgeHandlers];
     for (WKWebView *webView in self.webViews.allValues) {
         [webView.configuration.userContentController removeScriptMessageHandlerForName:@"nativeSdkBridge"];
@@ -7518,6 +7524,7 @@ static BOOL NativeSdkScrollDriverCanConsumeHorizontally(NativeSdkScrollDriverVie
     WKWebView *webView = [[NativeSdkWebView alloc] initWithFrame:container.bounds configuration:configuration];
     ((NativeSdkWebView *)webView).host = self;
     ((NativeSdkWebView *)webView).windowId = windowId;
+    ((NativeSdkWebView *)webView).viewLabel = @"main";
     [webView registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
     webView.wantsLayer = YES;
     webView.layer.zPosition = 0;
@@ -8200,6 +8207,7 @@ static BOOL NativeSdkScrollDriverCanConsumeHorizontally(NativeSdkScrollDriverVie
     WKWebView *webview = [[NativeSdkWebView alloc] initWithFrame:[self webViewFrameForWindow:window x:x y:y width:width height:height] configuration:configuration];
     ((NativeSdkWebView *)webview).host = self;
     ((NativeSdkWebView *)webview).windowId = windowId;
+    ((NativeSdkWebView *)webview).viewLabel = label;
     [webview registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
     webview.wantsLayer = YES;
     webview.layer.zPosition = layer;
@@ -8995,6 +9003,31 @@ static void NativeSdkApplyProcessDisplayName(NSString *displayName) {
             return event;
         }];
     }
+    if (!self.viewFocusEventMonitor) {
+        __weak NativeSdkAppKitHost *weakSelf = self;
+        self.viewFocusEventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:
+            (NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown | NSEventMaskOtherMouseDown)
+            handler:^NSEvent *(NSEvent *event) {
+                NativeSdkAppKitHost *strongSelf = weakSelf;
+                NSView *content = event.window.contentView;
+                if (!strongSelf || !content) return event;
+                NSPoint point = [content convertPoint:event.locationInWindow fromView:nil];
+                NSView *hit = [content hitTest:point];
+                while (hit && ![hit isKindOfClass:[NativeSdkWebView class]]) {
+                    hit = hit.superview;
+                }
+                if (![hit isKindOfClass:[NativeSdkWebView class]]) return event;
+                NativeSdkWebView *webView = (NativeSdkWebView *)hit;
+                const char *label = webView.viewLabel.UTF8String ?: "";
+                [strongSelf emitEvent:(native_sdk_appkit_event_t){
+                    .kind = NATIVE_SDK_APPKIT_EVENT_VIEW_FOCUSED,
+                    .window_id = webView.windowId,
+                    .view_label = label,
+                    .view_label_len = strlen(label),
+                }];
+                return event;
+            }];
+    }
 
     [self startApplicationActivationObservers];
     [self startAppearanceObservers];
@@ -9085,6 +9118,10 @@ static void NativeSdkApplyProcessDisplayName(NSString *displayName) {
     if (self.shortcutEventMonitor) {
         [NSEvent removeMonitor:self.shortcutEventMonitor];
         self.shortcutEventMonitor = nil;
+    }
+    if (self.viewFocusEventMonitor) {
+        [NSEvent removeMonitor:self.viewFocusEventMonitor];
+        self.viewFocusEventMonitor = nil;
     }
     [self stopAppearanceObservers];
     [self stopApplicationActivationObservers];

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -16,6 +16,7 @@
 #include "include/cef_client.h"
 #include "include/cef_command_line.h"
 #include "include/cef_application_mac.h"
+#include "include/cef_focus_handler.h"
 #include "include/cef_load_handler.h"
 #include "include/cef_process_message.h"
 #include "include/cef_values.h"
@@ -102,7 +103,7 @@ private:
     IMPLEMENT_REFCOUNTING(NativeSdkCefBridgeV8Handler);
 };
 
-class NativeSdkCefClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler, public CefRequestHandler {
+class NativeSdkCefClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler, public CefRequestHandler, public CefFocusHandler {
 public:
     explicit NativeSdkCefClient(NativeSdkChromiumHost *host, uint64_t window_id) : host_(host), window_id_(window_id) {}
     NativeSdkCefClient(NativeSdkChromiumHost *host, uint64_t window_id, std::string webview_key, uint64_t webview_generation, bool bridge_enabled) : host_(host), window_id_(window_id), webview_key_(webview_key), webview_generation_(webview_generation), bridge_enabled_(bridge_enabled) {}
@@ -119,8 +120,13 @@ public:
         return this;
     }
 
+    CefRefPtr<CefFocusHandler> GetFocusHandler() override {
+        return this;
+    }
+
     void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
     void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+    void OnGotFocus(CefRefPtr<CefBrowser> browser) override;
     void OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) override;
     bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;
     bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) override;
@@ -595,6 +601,7 @@ static const char *NativeSdkCefBridgeScript() {
 - (void)emitWindowFrameForWindowId:(uint64_t)windowId open:(BOOL)open;
 - (void)emitFrame;
 - (void)emitShutdown;
+- (void)emitViewFocusedForWindowId:(uint64_t)windowId label:(NSString *)label;
 - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *)assetRoot entry:(NSString *)entry origin:(NSString *)origin spaFallback:(BOOL)spaFallback;
 - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *)assetRoot entry:(NSString *)entry origin:(NSString *)origin spaFallback:(BOOL)spaFallback windowId:(uint64_t)windowId;
 - (void)setAllowedNavigationOrigins:(NSArray<NSString *> *)origins externalURLs:(NSArray<NSString *> *)externalURLs externalAction:(NSInteger)externalAction;
@@ -1188,6 +1195,18 @@ static const char *NativeSdkCefBridgeScript() {
 
 - (void)emitEvent:(native_sdk_appkit_event_t)event {
     if (self.callback) self.callback(self.context, &event);
+}
+
+- (void)emitViewFocusedForWindowId:(uint64_t)windowId label:(NSString *)label {
+    NSWindow *window = self.windows[@(windowId)] ?: (windowId == 1 ? self.window : nil);
+    if (!window || label.length == 0) return;
+    const char *labelBytes = label.UTF8String ?: "";
+    [self emitEvent:(native_sdk_appkit_event_t){
+        .kind = NATIVE_SDK_APPKIT_EVENT_VIEW_FOCUSED,
+        .window_id = windowId,
+        .view_label = labelBytes,
+        .view_label_len = strlen(labelBytes),
+    }];
 }
 
 - (void)startApplicationActivationObservers {
@@ -2002,6 +2021,18 @@ void NativeSdkCefClient::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
     if (webview_key_.empty()) return;
     NSString *key = [[NSString alloc] initWithBytes:webview_key_.data() length:webview_key_.size() encoding:NSUTF8StringEncoding];
     [host_ cleanupClosedWebViewWithKey:key ?: @"" generation:webview_generation_];
+}
+
+void NativeSdkCefClient::OnGotFocus(CefRefPtr<CefBrowser> browser) {
+    (void)browser;
+    if (!host_) return;
+    if (!webview_key_.empty()) {
+        NSString *key = [[NSString alloc] initWithBytes:webview_key_.data() length:webview_key_.size() encoding:NSUTF8StringEncoding];
+        if (![host_ webViewGeneration:webview_generation_ matchesKey:key ?: @""]) return;
+    }
+    const std::string label = WebViewLabel();
+    NSString *labelString = [[NSString alloc] initWithBytes:label.data() length:label.size() encoding:NSUTF8StringEncoding];
+    [host_ emitViewFocusedForWindowId:window_id_ label:labelString ?: @""];
 }
 
 void NativeSdkCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -40,6 +40,7 @@ const AppKitEventKind = enum(c_int) {
     context_menu_action = 19,
     audio = 20,
     video = 21,
+    view_focused = 22,
 };
 
 const AppKitEvent = extern struct {
@@ -910,6 +911,10 @@ fn appkitCallback(context: ?*anyopaque, event: *const AppKitEvent) callconv(.c) 
                 .hidden = event.hidden != 0,
             } });
         },
+        .view_focused => state.emit(.{ .view_focused = .{
+            .window_id = event.window_id,
+            .label = event.view_label[0..event.view_label_len],
+        } }),
         .shortcut => state.emit(.{ .shortcut = .{
             .id = event.shortcut_id[0..event.shortcut_id_len],
             .key = event.shortcut_key[0..event.shortcut_key_len],
@@ -2406,6 +2411,16 @@ fn flattenFilters(filters: []const platform_mod.FileFilter, buffer: []u8) []cons
 
 test "mac platform module exports type" {
     _ = MacPlatform;
+}
+
+test "mac webview presses report the focused child label" {
+    // WKWebView owns the page's pointer stream, so the AppKit host
+    // observes the down before dispatch and emits the explicit inverse
+    // edge that blurs a sibling canvas view.
+    const host_source = @embedFile("appkit_host.m");
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown | NSEventMaskOtherMouseDown") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, ".kind = NATIVE_SDK_APPKIT_EVENT_VIEW_FOCUSED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, ".view_label = label") != null);
 }
 
 test "mac dock icon fallback renders the embedded toolkit default" {

--- a/src/platform/macos/root.zig
+++ b/src/platform/macos/root.zig
@@ -2423,6 +2423,20 @@ test "mac webview presses report the focused child label" {
     try std.testing.expect(std.mem.indexOf(u8, host_source, ".view_label = label") != null);
 }
 
+test "mac Chromium webview focus reports the focused child label" {
+    // CEF's focus handler is the engine-level ownership edge: it covers
+    // pointer, keyboard, and programmatic focus without predicting from
+    // a press. A generation guard keeps a closing/replaced child from
+    // publishing its old label after runtime storage has moved on.
+    const host_source = @embedFile("cef_host.mm");
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "public CefFocusHandler") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "CefRefPtr<CefFocusHandler> GetFocusHandler() override") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "void NativeSdkCefClient::OnGotFocus") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "webViewGeneration:webview_generation_ matchesKey:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, ".kind = NATIVE_SDK_APPKIT_EVENT_VIEW_FOCUSED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "emitViewFocusedForWindowId:window_id_ label:") != null);
+}
+
 test "mac dock icon fallback renders the embedded toolkit default" {
     // The exact pipeline `defaultDockIconRenderMain` hands the host:
     // decode the embedded default and render the packaging canvas. This

--- a/src/platform/root.zig
+++ b/src/platform/root.zig
@@ -104,6 +104,7 @@ pub const ViewInfo = types.ViewInfo;
 pub const AppInfo = types.AppInfo;
 pub const Surface = types.Surface;
 pub const BridgeMessage = types.BridgeMessage;
+pub const ViewFocusEvent = types.ViewFocusEvent;
 pub const max_dialog_path_bytes = types.max_dialog_path_bytes;
 pub const max_dialog_paths_bytes = types.max_dialog_paths_bytes;
 pub const max_dialog_title_bytes = types.max_dialog_title_bytes;

--- a/src/platform/types.zig
+++ b/src/platform/types.zig
@@ -2187,6 +2187,15 @@ pub const Appearance = struct {
     high_contrast: bool = false,
 };
 
+/// A platform child view gained keyboard focus through native input.
+/// Canvas/GPU input reports its own focus edge with the input event;
+/// native webviews and controls need this explicit inverse edge because
+/// their pointer stream never crosses the runtime.
+pub const ViewFocusEvent = struct {
+    window_id: WindowId = 1,
+    label: []const u8,
+};
+
 pub const Event = union(enum) {
     app_start,
     app_activated,
@@ -2197,6 +2206,7 @@ pub const Event = union(enum) {
     surface_resized: Surface,
     window_frame_changed: WindowState,
     window_focused: WindowId,
+    view_focused: ViewFocusEvent,
     bridge_message: BridgeMessage,
     tray_action: TrayItemId,
     shortcut: ShortcutEvent,
@@ -2233,6 +2243,7 @@ pub const Event = union(enum) {
             .surface_resized => "surface_resized",
             .window_frame_changed => "window_frame_changed",
             .window_focused => "window_focused",
+            .view_focused => "view_focused",
             .bridge_message => "bridge_message",
             .tray_action => "tray_action",
             .shortcut => "shortcut",

--- a/src/platform/windows/root.zig
+++ b/src/platform/windows/root.zig
@@ -35,6 +35,7 @@ const WindowsEventKind = enum(c_int) {
     appearance = 17,
     audio = 18,
     context_menu_action = 19,
+    view_focused = 20,
 };
 
 const WindowsEvent = extern struct {
@@ -586,6 +587,10 @@ fn windowsCallback(context: ?*anyopaque, event: *const WindowsEvent) callconv(.c
                 .hidden = event.hidden != 0,
             } });
         },
+        .view_focused => state.emit(.{ .view_focused = .{
+            .window_id = event.window_id,
+            .label = event.view_label[0..event.view_label_len],
+        } }),
         .shortcut => state.emit(.{ .shortcut = .{
             .id = event.shortcut_id[0..event.shortcut_id_len],
             .key = event.shortcut_key[0..event.shortcut_key_len],
@@ -1856,6 +1861,16 @@ test "windows window focus includes focused native child views" {
     const focus_edge = host_source[focus_edge_at.?..];
     try std.testing.expect(std.mem.indexOf(u8, focus_edge, "HWND root = GetAncestor(hwnd, GA_ROOT);") != null);
     try std.testing.expect(std.mem.indexOf(u8, focus_edge, "entry.second.hwnd == root") != null);
+}
+
+test "windows webview focus reports the focused child label" {
+    // WebView2 owns the page HWND and its input; GotFocus is the
+    // controller-level edge that mirrors keyboard ownership back into
+    // the runtime's per-view register.
+    const host_source = @embedFile("webview2_host.cpp");
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "add_GotFocus(Callback<ICoreWebView2FocusChangedEventHandler>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "event.kind = kViewFocused;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, host_source, "event.view_label = focused->second.label.c_str();") != null);
 }
 
 test "windows audio event maps kinds and payload" {

--- a/src/platform/windows/webview2_host.cpp
+++ b/src/platform/windows/webview2_host.cpp
@@ -131,6 +131,7 @@ enum EventKind {
     kAppearance = 17,
     kAudio = 18,
     kContextMenuAction = 19,
+    kViewFocused = 20,
 };
 
 constexpr uint32_t kShortcutModifierPrimary = 1u << 0;
@@ -4268,6 +4269,7 @@ static const GUID kNativeSdkIID_EnvironmentCompletedHandler = {0x4e8a3389, 0xc9d
 static const GUID kNativeSdkIID_ControllerCompletedHandler = {0x6c4819f3, 0xc9b7, 0x4260, {0x81, 0x27, 0xc9, 0xf5, 0xbd, 0xe7, 0xf6, 0x8c}};
 static const GUID kNativeSdkIID_WebMessageReceivedHandler = {0x57213f19, 0x00e6, 0x49fa, {0x8e, 0x07, 0x89, 0x8e, 0xa0, 0x1e, 0xcb, 0xd2}};
 static const GUID kNativeSdkIID_AcceleratorKeyPressedHandler = {0xb29c7e28, 0xfa79, 0x41a8, {0x8e, 0x44, 0x65, 0x81, 0x1c, 0x76, 0xdc, 0xb2}};
+static const GUID kNativeSdkIID_FocusChangedHandler = {0x05ea24bd, 0x6452, 0x4926, {0x90, 0x14, 0x4b, 0x82, 0xb4, 0x98, 0x13, 0x5d}};
 static const GUID kNativeSdkIID_WebResourceRequestedHandler = {0xab00b74c, 0x15f1, 0x4646, {0x80, 0xe8, 0xe7, 0x63, 0x41, 0xd2, 0x5d, 0x71}};
 static const GUID kNativeSdkIID_NavigationStartingHandler = {0x9adbe429, 0xf36d, 0x432b, {0x9d, 0xdc, 0xf8, 0x88, 0x1f, 0xbd, 0x76, 0xe3}};
 
@@ -4283,6 +4285,9 @@ template <> struct WebView2HandlerIid<ICoreWebView2WebMessageReceivedEventHandle
 };
 template <> struct WebView2HandlerIid<ICoreWebView2AcceleratorKeyPressedEventHandler> {
     static const GUID &value() { return kNativeSdkIID_AcceleratorKeyPressedHandler; }
+};
+template <> struct WebView2HandlerIid<ICoreWebView2FocusChangedEventHandler> {
+    static const GUID &value() { return kNativeSdkIID_FocusChangedHandler; }
 };
 template <> struct WebView2HandlerIid<ICoreWebView2WebResourceRequestedEventHandler> {
     static const GUID &value() { return kNativeSdkIID_WebResourceRequestedHandler; }
@@ -4622,6 +4627,23 @@ static bool createChildWebView(Host *host, const std::string &key) {
                     controller->put_Bounds(bounds);
                     controller->put_ZoomFactor(found->second.zoom);
                     controller->put_IsVisible(TRUE);
+                    EventRegistrationToken focus_token = {};
+                    controller->add_GotFocus(Callback<ICoreWebView2FocusChangedEventHandler>(
+                        [host, key, lifetime](ICoreWebView2Controller *, IUnknown *) -> HRESULT {
+                            auto token = lifetime.lock();
+                            if (!token) return S_OK;
+                            std::lock_guard<std::recursive_mutex> guard(token->mutex);
+                            if (!token->alive || !host->callback) return S_OK;
+                            auto focused = host->webviews.find(key);
+                            if (focused == host->webviews.end()) return S_OK;
+                            WindowsEvent event = {};
+                            event.kind = kViewFocused;
+                            event.window_id = focused->second.window_id;
+                            event.view_label = focused->second.label.c_str();
+                            event.view_label_len = focused->second.label.size();
+                            host->callback(host->callback_context, &event);
+                            return S_OK;
+                        }).Get(), &focus_token);
                     if (found->second.webview) {
                         if (found->second.bridge_enabled) {
                             found->second.webview->AddScriptToExecuteOnDocumentCreated(nativeSdkBridgeScript(), nullptr);

--- a/src/runtime/flow.zig
+++ b/src/runtime/flow.zig
@@ -342,6 +342,17 @@ pub fn RuntimeFlow(comptime Runtime: type) type {
                     if (WindowViewMethods().findWindowIndexById(self, window_id)) |index| try WindowViewMethods().setFocusedIndex(self, index);
                     self.invalidated = true;
                 },
+                .view_focused => |focus| {
+                    // Native children (notably embedded webviews) own
+                    // their pointer stream, so the host reports the
+                    // focus edge explicitly. Keep the canvas widget id
+                    // as per-view focus memory while its view blurs:
+                    // inactive terminal/text carets paint honestly, and
+                    // clicking back into the canvas resumes its normal
+                    // pointer-driven widget focus path.
+                    try WindowViewMethods().setFocusedView(self, focus.window_id, focus.label);
+                    self.invalidated = true;
+                },
                 .frame_requested => try frame(self, app),
                 .bridge_message => |message| try handleBridgeMessage(self, app, message),
                 .tray_action => |item_id| {

--- a/src/runtime/session_journal.zig
+++ b/src/runtime/session_journal.zig
@@ -178,6 +178,7 @@ fn formatLayoutDescription(comptime epoch: u32) []const u8 {
             "surface_resized=" ++ layout_fingerprint.describe(platform.Surface) ++ "\n" ++
             "window_frame_changed=" ++ layout_fingerprint.describe(platform.WindowState) ++ "\n" ++
             "window_focused=" ++ layout_fingerprint.describe(platform.WindowId) ++ "\n" ++
+            "view_focused=" ++ layout_fingerprint.describe(platform.ViewFocusEvent) ++ "\n" ++
             "bridge_message=" ++ layout_fingerprint.describe(platform.BridgeMessage) ++ "\n" ++
             "tray_action=" ++ layout_fingerprint.describe(platform.TrayItemId) ++ "\n" ++
             "shortcut=" ++ layout_fingerprint.describe(platform.ShortcutEvent) ++ "\n" ++
@@ -462,6 +463,7 @@ const EventTag = enum(u8) {
     widget_accessibility_action = 23,
     audio = 24,
     video = 25,
+    view_focused = 26,
 };
 
 // The bit assignments below are hand-written wire layout: they are
@@ -568,6 +570,11 @@ pub fn encodeEvent(event: platform.Event, buffer: []u8) JournalError![]const u8 
         .window_focused => |window_id| {
             try cursor.writeEnum(EventTag.window_focused);
             try cursor.writeInt(u64, window_id);
+        },
+        .view_focused => |focus| {
+            try cursor.writeEnum(EventTag.view_focused);
+            try cursor.writeInt(u64, focus.window_id);
+            try cursor.writeStr(focus.label);
         },
         .bridge_message => |message| {
             try cursor.writeEnum(EventTag.bridge_message);
@@ -779,6 +786,10 @@ pub fn decodeEvent(bytes: []const u8, storage: *EventDecodeStorage) JournalError
             } };
         },
         .window_focused => .{ .window_focused = try cursor.readInt(u64) },
+        .view_focused => .{ .view_focused = .{
+            .window_id = try cursor.readInt(u64),
+            .label = try cursor.readStr(),
+        } },
         .bridge_message => blk: {
             const message_bytes = try cursor.readStr();
             const origin = try cursor.readStr();
@@ -1577,6 +1588,11 @@ test "event codec round-trips every payload variant" {
     {
         const decoded = try roundTripEvent(.{ .window_focused = 4 });
         try testing.expectEqual(@as(u64, 4), decoded.window_focused);
+    }
+    {
+        const decoded = try roundTripEvent(.{ .view_focused = .{ .window_id = 4, .label = "preview" } });
+        try testing.expectEqual(@as(u64, 4), decoded.view_focused.window_id);
+        try testing.expectEqualStrings("preview", decoded.view_focused.label);
     }
     {
         const decoded = try roundTripEvent(.{ .gpu_surface_resized = .{


### PR DESCRIPTION
- Report native webview focus changes across macOS, Linux, and Windows.
- Preserve and journal canvas focus state with a workbench pane regression.