### PR TITLE
fix: sync pointer text selections to model

### DIFF
--- a/changelog.d/pointer-text-selection-model-sync.md
+++ b/changelog.d/pointer-text-selection-model-sync.md
@@ -1,0 +1,1 @@
+fix: **Pointer-selected text edits**: editable fields now send pointer caret and selection changes through `on-input`, so model-owned text buffers delete or replace the highlighted span instead of editing at a stale caret.

--- a/examples/workbench/src/tests.zig
+++ b/examples/workbench/src/tests.zig
@@ -44,6 +44,22 @@ fn countKind(widget: canvas.Widget, kind: canvas.WidgetKind) usize {
     return total;
 }
 
+/// Find a point that the text field's own hit mapper resolves to the
+/// requested byte offset. Tests can select exact URL spans without
+/// duplicating font metrics or hard-coding glyph widths.
+fn pointForTextOffset(widget: canvas.Widget, tokens: canvas.DesignTokens, target: usize) ?geometry.PointF {
+    var y: f32 = widget.frame.y + 2;
+    while (y < widget.frame.y + widget.frame.height) : (y += 4) {
+        var x: f32 = widget.frame.x + 1;
+        while (x < widget.frame.x + widget.frame.width) : (x += 0.5) {
+            const point = geometry.PointF.init(x, y);
+            const offset = canvas.textOffsetForWidgetPoint(widget, point, tokens) orelse continue;
+            if (offset == target) return point;
+        }
+    }
+    return null;
+}
+
 /// A booted model: the history seeded and the shell spawn requested,
 /// exactly as `init_fx` leaves it.
 fn bootedModel(fx: *app.Effects) Model {
@@ -410,6 +426,70 @@ const Harness = struct {
         return lookup.resolve(lookup.context, app.shell_effect_key) orelse error.TestExpectedGrid;
     }
 };
+
+test "deleting a pointer-selected address span updates the model-owned buffer" {
+    var h = try Harness.create();
+    defer h.destroy();
+
+    const url = "https://test.com";
+    h.app_state.model.address_field.set(url);
+    try h.app_state.rebuild(&h.harness.runtime, 1);
+
+    const layout = try h.harness.runtime.canvasWidgetLayout(1, app.canvas_label);
+    var address: ?canvas.Widget = null;
+    for (layout.nodes) |node| {
+        if (std.mem.eql(u8, node.widget.semantics.label, "Address")) {
+            address = node.widget;
+            break;
+        }
+    }
+    const field = address orelse return error.TestUnexpectedResult;
+    const view_index = h.harness.runtime.findViewIndex(1, app.canvas_label) orelse return error.TestUnexpectedResult;
+    const tokens = h.harness.runtime.views[view_index].widget_tokens;
+    const selection_start = pointForTextOffset(field, tokens, "https://".len) orelse return error.TestUnexpectedResult;
+    const selection_end = pointForTextOffset(field, tokens, "https://test".len) orelse return error.TestUnexpectedResult;
+
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .pointer_down,
+        .x = selection_start.x,
+        .y = selection_start.y,
+    } });
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .pointer_drag,
+        .x = selection_end.x,
+        .y = selection_end.y,
+    } });
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .pointer_up,
+        .x = selection_end.x,
+        .y = selection_end.y,
+    } });
+
+    try testing.expectEqualDeep(
+        canvas.TextSelection{ .anchor = "https://".len, .focus = "https://test".len },
+        h.app_state.model.address_field.selection,
+    );
+
+    // A MacBook's Delete key is the backward-delete key: the selected
+    // "test" span must win over the buffer's old end-of-value caret.
+    try h.harness.runtime.dispatchPlatformEvent(h.app_iface, .{ .gpu_surface_input = .{
+        .window_id = 1,
+        .label = app.canvas_label,
+        .kind = .key_down,
+        .key = "backspace",
+    } });
+
+    try testing.expectEqualStrings("https://.com", h.app_state.model.address());
+    const retained = try h.harness.runtime.canvasWidgetLayout(1, app.canvas_label);
+    const retained_address = retained.findById(field.id) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("https://.com", retained_address.widget.text);
+}
 
 test "a live pty session flows through the <terminal> element: output, typing, resize" {
     if (comptime !native_sdk.runtime.terminal_sessions_enabled) return error.SkipZigTest;

--- a/src/runtime/api.zig
+++ b/src/runtime/api.zig
@@ -65,11 +65,12 @@ pub const CanvasWidgetPointerEvent = struct {
     /// cursor, and text selection stay on `target`.
     press_target: ?canvas.WidgetHit = null,
     route: []const canvas.WidgetEventRouteEntry = &.{},
-    /// A text edit this pointer gesture performed on `target` (the
-    /// search field's built-in clear affordance). The runtime already
-    /// applied it (the optimistic echo; the source tree is truth on the
-    /// next rebuild); `UiApp` maps it through the tree's handler table
-    /// to the field's `on_input` Msg so a model-owned buffer clears too.
+    /// A text edit this pointer gesture performed on `target` (an
+    /// editable field's caret/selection move, or the search field's
+    /// built-in clear affordance). The runtime already applied it (the
+    /// optimistic echo; the source tree is truth on the next rebuild);
+    /// `UiApp` maps it through the tree's handler table to the field's
+    /// `on_input` Msg so a model-owned buffer stays in lockstep too.
     edit: ?canvas.TextInputEvent = null,
 };
 

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2080,6 +2080,11 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                 }
             }
             if (target_id == 0) return;
+            const target_index = self.views[index].canvasWidgetNodeIndexById(target_id) orelse return;
+            const target_widget = self.views[index].widget_layout_nodes[target_index].widget;
+            const mirrors_editable_selection =
+                canvas_widget_runtime.canvasWidgetEditableTextKind(target_widget.kind) and
+                !target_widget.state.disabled;
 
             // The search field's built-in clear affordance: a press
             // inside the trailing clear region clears through the
@@ -2098,8 +2103,29 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                 pointer_event.pointer.point,
                 pointer_event.pointer.phase == .move,
                 pointer_event.pointer.click_count,
-            ) orelse return;
-            if (canvasDirtyRegionForView(self.views[index].frame, dirty)) |dirty_region| {
+            );
+            // Pointer placement lives first in the retained editor, but a
+            // controlled field's model owns the TextBuffer that the next
+            // keyboard edit will reduce. Stamp the resulting selection
+            // onto the SAME pointer event so `UiApp` delivers
+            // `.set_selection` through `on_input` before a later delete,
+            // insert, or IME edit reaches that model. Without this echo,
+            // the highlight was honest only in the runtime: selecting a
+            // middle span and pressing Backspace let the model delete at
+            // its stale end caret, and its rebuild overwrote the runtime's
+            // correct optimistic edit.
+            //
+            // Stamp even when the retained state did not change. This is
+            // the pointer counterpart of keyboard clear's resync rule: a
+            // divergent model mirror must still hear the selection the
+            // user established.
+            if (mirrors_editable_selection) {
+                const edited_widget = self.views[index].widget_layout_nodes[target_index].widget;
+                const selection = edited_widget.text_selection orelse canvas.TextSelection.collapsed(edited_widget.text.len);
+                pointer_event.edit = .{ .set_selection = selection };
+            }
+            const dirty_bounds = dirty orelse return;
+            if (canvasDirtyRegionForView(self.views[index].frame, dirty_bounds)) |dirty_region| {
                 self.invalidateFor(.state, dirty_region);
             } else {
                 self.invalidateFor(.state, self.views[index].frame);

--- a/src/runtime/gpu_surface_events.zig
+++ b/src/runtime/gpu_surface_events.zig
@@ -313,8 +313,8 @@ pub fn RuntimeGpuSurfaceEvents(comptime Runtime: type) type {
                 } else {
                     try CanvasWidgetEventMethods().updateCanvasWidgetControlFromPointer(self, pointer_event.*);
                     try CanvasWidgetEventMethods().updateCanvasWidgetInteractionFromPointer(self, pointer_event.*);
-                    // The text pass may stamp a clear edit onto the
-                    // event for the app dispatch below.
+                    // The text pass may stamp a caret/selection or clear
+                    // edit onto the event for the app dispatch below.
                     try CanvasWidgetEventMethods().updateCanvasWidgetTextFromPointer(self, pointer_event);
                     try CanvasWidgetEventMethods().updateCanvasWidgetScrollFromPointer(self, pointer_event.*);
                     try CanvasWidgetEventMethods().updateCanvasWidgetFocusFromPointer(self, pointer_event.*);

--- a/src/runtime/session_tests.zig
+++ b/src/runtime/session_tests.zig
@@ -582,10 +582,11 @@ test "a recorded session replays to identical model state and fingerprints" {
     try std.testing.expect(recorded.model.stamp_ms != 0);
     try std.testing.expectEqual(@as(u32, 1), recorded.model.spectrum_count);
     try std.testing.expect(recorded.model.band_checksum != 0);
-    // The typed insert, the DERIVED Escape-clear, and the sanitized
-    // multi-line paste all reached the model's `on_input` mirror — the
-    // paste landing STRIPPED of its line breaks (single-line rule).
-    try std.testing.expectEqual(@as(u32, 3), recorded.model.query_edits);
+    // Both pointer caret placements, the typed insert, the DERIVED
+    // Escape-clear, and the sanitized multi-line paste all reached the
+    // model's `on_input` mirror — five edits total, with the paste
+    // landing STRIPPED of its line breaks (single-line rule).
+    try std.testing.expectEqual(@as(u32, 5), recorded.model.query_edits);
     try std.testing.expectEqualStrings("line oneline two", recorded.model.queryText());
     // Both pinch gestures reached the model: the raw stream's product
     // (1.25 * 0.75 = 0.9375) times the verb's exact 1.5.

--- a/src/runtime/ui_app.zig
+++ b/src/runtime/ui_app.zig
@@ -4543,10 +4543,11 @@ pub fn UiAppWithFeatures(comptime ModelT: type, comptime MsgT: type, comptime fe
                 },
                 else => {},
             }
-            // A pointer gesture that performed a text edit (the search
-            // field's built-in clear) maps to the field's `on_input`
-            // Msg — the runtime already applied the edit; the model
-            // hears it here so a source-owned buffer clears too.
+            // A pointer gesture that performed a text edit (editable
+            // caret/selection placement or the search field's built-in
+            // clear) maps to the field's `on_input` Msg — the runtime
+            // already applied the edit; the model hears it here so a
+            // source-owned buffer stays in lockstep too.
             if (pointer_event.edit) |edit| {
                 if (pointer_event.target) |edit_target| {
                     if (tree.msgForTextEdit(edit_target.id, edit)) |msg| {


### PR DESCRIPTION
- Route pointer caret and selection changes through on-input.
- Cover workbench address deletion with an end-to-end regression.
- Update session replay expectations and changelog.