### PR TITLE
chore: prepare v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,22 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.6.0
+## 0.6.1
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Layered macOS cursors**: GPU surfaces now yield their cursor regions to higher-layer embedded webviews, so links, selectable text, and canvas widgets use the correct cursor in mixed canvas/webview windows such as Workbench.
+- **Pointer-selected text edits**: editable fields now send pointer caret and selection changes through `on-input`, so model-owned text buffers delete or replace the highlighted span instead of editing at a stale caret.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.6.0
 
 ### New Features
 
@@ -72,8 +85,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 
 - @ctate
 - @startewho
-
-<!-- release:end -->
 
 ## 0.5.4
 

--- a/changelog.d/macos-layered-cursors.md
+++ b/changelog.d/macos-layered-cursors.md
@@ -1,1 +1,0 @@
-fix: **Layered macOS cursors**: GPU surfaces now yield their cursor regions to higher-layer embedded webviews, so links, selectable text, and canvas widgets use the correct cursor in mixed canvas/webview windows such as Workbench.

--- a/changelog.d/pointer-text-selection-model-sync.md
+++ b/changelog.d/pointer-text-selection-model-sync.md
@@ -1,1 +1,0 @@
-fix: **Pointer-selected text edits**: editable fields now send pointer caret and selection changes through `on-input`, so model-owned text buffers delete or replace the highlighted span instead of editing at a stale caret.

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.6.0"
+    "@native-sdk/core": "0.6.1"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.6.0"
+    "@native-sdk/core": "0.6.1"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@typescript/old": "npm:typescript@6.0.3",
         "@typescript/typescript6": "6.0.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The TypeScript authoring tier: the app-core subset, its dev-time transpiler to arena-backed Zig, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -32,14 +32,14 @@
     "@typescript/typescript6": "6.0.2"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.6.0",
-    "@native-sdk/cli-darwin-x64": "0.6.0",
-    "@native-sdk/cli-linux-arm64-gnu": "0.6.0",
-    "@native-sdk/cli-linux-arm64-musl": "0.6.0",
-    "@native-sdk/cli-linux-x64-gnu": "0.6.0",
-    "@native-sdk/cli-linux-x64-musl": "0.6.0",
-    "@native-sdk/cli-win32-arm64": "0.6.0",
-    "@native-sdk/cli-win32-x64": "0.6.0"
+    "@native-sdk/cli-darwin-arm64": "0.6.1",
+    "@native-sdk/cli-darwin-x64": "0.6.1",
+    "@native-sdk/cli-linux-arm64-gnu": "0.6.1",
+    "@native-sdk/cli-linux-arm64-musl": "0.6.1",
+    "@native-sdk/cli-linux-x64-gnu": "0.6.1",
+    "@native-sdk/cli-linux-x64-musl": "0.6.1",
+    "@native-sdk/cli-win32-arm64": "0.6.1",
+    "@native-sdk/cli-win32-x64": "0.6.1"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.6.0";
+const version = "0.6.1";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Sync CLI, core, platform, and example package versions to 0.6.1.
- Merge pending fixes into the marked v0.6.1 release notes and credit contributors.