### PR TITLE
Fix layout container background rendering

### DIFF
--- a/changelog.d/layout-container-backgrounds.md
+++ b/changelog.d/layout-container-backgrounds.md
@@ -1,0 +1,1 @@
+fix: **Container backgrounds render**: explicit backgrounds on `stack`, `row`, and `column` now paint across the laid-out frame with their configured radius.

--- a/src/primitives/canvas/widget_render.zig
+++ b/src/primitives/canvas/widget_render.zig
@@ -209,7 +209,11 @@ fn emitWidgetDepthContent(builder: *Builder, widget: Widget, tokens: DesignToken
     const paint_widget = widgetWithFrame(widget, pixelSnapGeometryRect(tokens, widget.frame));
     try emitWidgetBackdropBlur(builder, paint_widget, tokens);
     switch (paint_widget.kind) {
-        .stack, .row, .column, .grid, .list, .breadcrumb, .pagination, .radio_group, .toggle_group, .split, .tree => try emitWidgetClippedChildren(builder, paint_widget, tokens, depth),
+        .stack, .row, .column => {
+            try emitLayoutContainerBackground(builder, paint_widget);
+            try emitWidgetClippedChildren(builder, paint_widget, tokens, depth);
+        },
+        .grid, .list, .breadcrumb, .pagination, .radio_group, .toggle_group, .split, .tree => try emitWidgetClippedChildren(builder, paint_widget, tokens, depth),
         .button_group => try emitButtonGroupWidget(builder, paint_widget, tokens, depth),
         .table, .data_grid => {
             try emitWidgetClippedChildren(builder, paint_widget, tokens, depth);
@@ -488,7 +492,8 @@ fn emitWidgetLayoutNodeContent(
     const paint_widget = widgetWithFrame(widget, pixelSnapGeometryRect(tokens, widget.frame));
     try emitWidgetBackdropBlur(builder, paint_widget, tokens);
     switch (paint_widget.kind) {
-        .stack, .row, .column, .breadcrumb, .button_group, .pagination, .radio_group, .toggle_group, .split, .tree => {},
+        .stack, .row, .column => try emitLayoutContainerBackground(builder, paint_widget),
+        .breadcrumb, .button_group, .pagination, .radio_group, .toggle_group, .split, .tree => {},
         .data_row => try emitDataRowWidgetWash(builder, paint_widget, tokens),
         .tabs => try widget_render_surfaces.emitTabsListWidgetChrome(builder, paint_widget, tokens),
         .table, .data_grid => {
@@ -621,6 +626,20 @@ fn emitWidgetLayoutNodeContent(
     }
 
     try emitWidgetLayoutClippedChildren(builder, layout, node_index, tokens, state, paint_widget);
+}
+
+/// Flow and stacking containers have no implicit surface treatment, but
+/// an author background is real chrome: it fills the laid-out frame
+/// before any children, with the same optional radius accepted by the
+/// builder and markup grammar.
+fn emitLayoutContainerBackground(builder: *Builder, widget: Widget) Error!void {
+    const background = widget.style.background orelse return;
+    try builder.fillRoundedRect(.{
+        .id = widgetPartId(widget.id, 1),
+        .rect = widget.frame,
+        .radius = Radius.all(nonNegative(widget.style.radius orelse 0)),
+        .fill = colorFill(background),
+    });
 }
 
 fn emitWidgetLayoutScrollableChildren(

--- a/src/primitives/canvas/widget_runtime_tests.zig
+++ b/src/primitives/canvas/widget_runtime_tests.zig
@@ -1352,6 +1352,57 @@ test "widget tree emits panel button text and progress commands" {
     }
 }
 
+test "stack row and column backgrounds paint in tree and layout emission" {
+    const kinds = [_]WidgetKind{ .stack, .row, .column };
+    const frame = geometry.RectF.init(10, 12, 140, 72);
+    const background = Color.rgb8(18, 52, 86);
+
+    for (kinds, 0..) |kind, index| {
+        const id: ObjectId = @intCast(index + 1);
+        const widget = Widget{
+            .id = id,
+            .kind = kind,
+            .frame = frame,
+            .style = .{
+                .background = background,
+                .radius = 7,
+            },
+        };
+
+        var tree_commands: [1]CanvasCommand = undefined;
+        var tree_builder = Builder.init(&tree_commands);
+        try emitWidgetTree(&tree_builder, widget, .{});
+        const tree_display_list = tree_builder.displayList();
+        try std.testing.expectEqual(@as(usize, 1), tree_display_list.commandCount());
+        switch (tree_display_list.commands[0]) {
+            .fill_rounded_rect => |fill| {
+                try std.testing.expectEqual(widgetPartId(id, 1), fill.id);
+                try expectRect(frame, fill.rect);
+                try std.testing.expectEqualDeep(Radius.all(7), fill.radius);
+                try expectFillColor(background, fill.fill);
+            },
+            else => return error.TestUnexpectedResult,
+        }
+
+        var nodes: [1]WidgetLayoutNode = undefined;
+        const layout = try layoutWidgetTree(widget, frame, &nodes);
+        var layout_commands: [1]CanvasCommand = undefined;
+        var layout_builder = Builder.init(&layout_commands);
+        try emitWidgetLayout(&layout_builder, layout, .{});
+        const layout_display_list = layout_builder.displayList();
+        try std.testing.expectEqual(@as(usize, 1), layout_display_list.commandCount());
+        switch (layout_display_list.commands[0]) {
+            .fill_rounded_rect => |fill| {
+                try std.testing.expectEqual(widgetPartId(id, 1), fill.id);
+                try expectRect(frame, fill.rect);
+                try std.testing.expectEqualDeep(Radius.all(7), fill.radius);
+                try expectFillColor(background, fill.fill);
+            },
+            else => return error.TestUnexpectedResult,
+        }
+    }
+}
+
 test "widget tree emits backdrop blur before widget content" {
     const children = [_]Widget{.{
         .id = 2,


### PR DESCRIPTION
- Paint explicit stack, row, and column backgrounds before their children.
- Preserve configured corner radii in tree and retained-layout emission.
- Cover all three container kinds with regression tests.