### PR TITLE
chore: prepare v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,24 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.6.2
+## 0.6.3
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Native textarea editing shortcuts**: Up/Down now moves or extends the caret across visual lines, Command+Left/Right uses the current line boundary even through unbroken soft wraps, Command+Up/Down reaches the document boundary, and Command+Z / Command+Shift+Z provides bounded per-editor undo and redo from either the keyboard or macOS Edit menu while keeping controlled `TextBuffer` models synchronized.
+- **Textarea indentation**: spaces typed at the start of an empty line now remain visible and advance the caret under word wrapping.
+- **Textarea pointer selection**: Shift-click now extends the selection from the existing caret instead of replacing it.
+- **Textarea line endings**: caret movement, deletion, and controlled selections now treat CRLF line endings as one indivisible boundary.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.6.2
 
 ### New Features
 
@@ -25,8 +40,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 - @ctate
 - @jasonkneen
 - @sepehr-safari
-
-<!-- release:end -->
 
 ## 0.6.1
 

--- a/changelog.d/textarea-native-editing-shortcuts.md
+++ b/changelog.d/textarea-native-editing-shortcuts.md
@@ -1,4 +1,0 @@
-fix: **Native textarea editing shortcuts**: Up/Down now moves or extends the caret across visual lines, Command+Left/Right uses the current line boundary even through unbroken soft wraps, Command+Up/Down reaches the document boundary, and Command+Z / Command+Shift+Z provides bounded per-editor undo and redo from either the keyboard or macOS Edit menu while keeping controlled `TextBuffer` models synchronized.
-- **Textarea indentation**: spaces typed at the start of an empty line now remain visible and advance the caret under word wrapping.
-- **Textarea pointer selection**: Shift-click now extends the selection from the existing caret instead of replacing it.
-- **Textarea line endings**: caret movement, deletion, and controlled selections now treat CRLF line endings as one indivisible boundary.

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.6.2"
+    "@native-sdk/core": "0.6.3"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.6.2"
+    "@native-sdk/core": "0.6.3"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "devDependencies": {
         "@typescript/old": "npm:typescript@6.0.3",
         "@typescript/typescript6": "6.0.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The TypeScript authoring tier: the app-core subset, its dev-time transpiler to arena-backed Zig, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -32,14 +32,14 @@
     "@typescript/typescript6": "6.0.2"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.6.2",
-    "@native-sdk/cli-darwin-x64": "0.6.2",
-    "@native-sdk/cli-linux-arm64-gnu": "0.6.2",
-    "@native-sdk/cli-linux-arm64-musl": "0.6.2",
-    "@native-sdk/cli-linux-x64-gnu": "0.6.2",
-    "@native-sdk/cli-linux-x64-musl": "0.6.2",
-    "@native-sdk/cli-win32-arm64": "0.6.2",
-    "@native-sdk/cli-win32-x64": "0.6.2"
+    "@native-sdk/cli-darwin-arm64": "0.6.3",
+    "@native-sdk/cli-darwin-x64": "0.6.3",
+    "@native-sdk/cli-linux-arm64-gnu": "0.6.3",
+    "@native-sdk/cli-linux-arm64-musl": "0.6.3",
+    "@native-sdk/cli-linux-x64-gnu": "0.6.3",
+    "@native-sdk/cli-linux-x64-musl": "0.6.3",
+    "@native-sdk/cli-win32-arm64": "0.6.3",
+    "@native-sdk/cli-win32-x64": "0.6.3"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.6.2";
+const version = "0.6.3";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Sync all CLI, core, platform, and example version references to 0.6.3.
- Merge the textarea fixes into the marked v0.6.3 changelog entry.