### PR TITLE
fix(runtime): prevent console windows for background child processes

### DIFF
--- a/changelog.d/windows-child-process-console.md
+++ b/changelog.d/windows-child-process-console.md
@@ -1,0 +1,1 @@
+fix: **Quiet Windows child processes**: spawned jobs no longer flash a transient console window.

--- a/src/runtime/effects.zig
+++ b/src/runtime/effects.zig
@@ -12556,6 +12556,7 @@ pub fn Effects(comptime Msg: type) type {
                 .stdin = if (ctx.stdin_len > 0) .pipe else .ignore,
                 .stdout = .pipe,
                 .stderr = if (ctx.output_mode == .collect) .pipe else .ignore,
+                .create_no_window = builtin.os.tag == .windows,
                 // POSIX: land the child in its OWN process group (id ==
                 // its pid, set before exec) so `killPublishedChild` can
                 // signal the whole descendant tree. Killing only the


### PR DESCRIPTION
## Summary

- set Zig's Windows `create_no_window` option for subprocesses launched through `Effects.spawn`
- keep the existing stdin/stdout/stderr pipes and POSIX process-group behavior unchanged
- add a changelog fragment for the Windows behavior change

## Testing

- `zig build test-desktop-runtime-core`
- `scripts/gate.sh fast origin/main` (the broad Windows checkout remains red only in failures reproduced on clean `main` and local example dependency/symlink setup)

Fixes #238