### PR TITLE
fix: keep Windows effect spawns hidden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
       # include path, or a conformance error in the embedded layer — is a
       # compile failure here, not a silent WebViewNotFound at runtime.
       - run: zig build test-webview-system-link -Dplatform=windows
+      # Effects.spawn is a pipe-backed background transport. Run its
+      # Windows-only PowerShell probe natively so removing CREATE_NO_WINDOW
+      # cannot leave the platform-neutral and Wine lanes green.
+      - run: zig build test-windows-effects-no-console
       # The registered-font receipt, natively on Windows: runs the
       # font-registry suite — registration validation, the glyph-budget
       # gate, present/reference pixel parity, and the Chinese-receipt

--- a/build.zig
+++ b/build.zig
@@ -1250,6 +1250,12 @@ pub fn build(b: *std.Build) void {
     // on a Windows runner makes that a Windows-native receipt. The same
     // tests also run inside `zig build test` via the canvas-frame shard.
     addTestStep(b, "test-canvas-fonts", "Run the runtime font-registry tests (includes the registered-CJK Chinese receipt)", filteredTestArtifact(b, desktop_mod, "canvas-fonts-tests", &.{"runtime.canvas_font_tests.test"}));
+    // The console-attachment regression is Windows-only, so the general
+    // Linux `zig build test` lane can only compile and skip it. Expose the
+    // exact test as a focused step for the real-Windows CI runner; this
+    // keeps CREATE_NO_WINDOW behavior covered without making that runner
+    // execute the entire framework runtime suite.
+    addTestStep(b, "test-windows-effects-no-console", "Verify Windows effect spawns run without an attached console", filteredTestArtifact(b, desktop_mod, "windows-effects-no-console-tests", &.{"runtime.effects_tests.test.Windows background spawns run without an attached console"}));
     addTestStep(b, "test-automation-protocol", "Run automation protocol tests", automation_protocol_tests);
     addTestStep(b, "test-automation-cli", "Run native automate CLI tests", automation_cli_tests);
     addTestStep(b, "test-markup-cli", "Run native markup CLI tests", markup_cli_tests);

--- a/changelog.d/windows-effects-spawn-no-console.md
+++ b/changelog.d/windows-effects-spawn-no-console.md
@@ -1,0 +1,1 @@
+fix: **Quiet Windows subprocesses**: `Effects.spawn` no longer opens or flashes a console window when a GUI or tray app launches a console-subsystem helper such as `node.exe`; interactive terminal children remain on the separate PTY API.

--- a/src/runtime/effects.zig
+++ b/src/runtime/effects.zig
@@ -12556,6 +12556,12 @@ pub fn Effects(comptime Msg: type) type {
                 .stdin = if (ctx.stdin_len > 0) .pipe else .ignore,
                 .stdout = .pipe,
                 .stderr = if (ctx.output_mode == .collect) .pipe else .ignore,
+                // A job spawn is a background transport, not a terminal:
+                // release-shaped Windows hosts are GUI-subsystem processes,
+                // so starting a console-subsystem helper without this flag
+                // would allocate a visible console behind the app. Interactive
+                // children belong to ptySpawn's separate ConPTY path.
+                .create_no_window = builtin.os.tag == .windows,
                 // POSIX: land the child in its OWN process group (id ==
                 // its pid, set before exec) so `killPublishedChild` can
                 // signal the whole descendant tree. Killing only the

--- a/src/runtime/effects_tests.zig
+++ b/src/runtime/effects_tests.zig
@@ -805,6 +805,36 @@ fn sawLine(model: *const StreamModel) bool {
     return model.line_count > 0;
 }
 
+test "Windows background spawns run without an attached console" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var h = try Harness.create();
+    defer h.destroy();
+
+    // Ask the spawned process itself, rather than inferring from window
+    // enumeration: a GUI-subsystem host used to omit CREATE_NO_WINDOW, so a
+    // console-subsystem helper received a console even though Effects.spawn
+    // exposes only pipes. PowerShell's redirected stdout still works with no
+    // console and carries the direct GetConsoleWindow verdict back to us.
+    test_argv = &.{
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Add-Type -Namespace NativeSdk -Name ConsoleProbe -MemberDefinition '[System.Runtime.InteropServices.DllImport(\"kernel32.dll\")] public static extern System.IntPtr GetConsoleWindow();'; if ([NativeSdk.ConsoleProbe]::GetConsoleWindow() -eq [IntPtr]::Zero) { 'detached' } else { 'attached' }",
+    };
+    test_stdin = null;
+    try h.app_state.dispatch(&h.harness.runtime, 1, .start);
+    try waitForRealCompletion(&h, sawExit);
+
+    try std.testing.expectEqual(@as(usize, 1), h.app_state.model.line_count);
+    // Spawn line framing removes LF; a Windows child's CRLF leaves CR in the
+    // delivered bytes, matching the effect's byte-honest stream contract.
+    try std.testing.expectEqualStrings("detached\r", h.app_state.model.lineAt(0));
+    try std.testing.expectEqual(@as(i32, 0), h.app_state.model.exit_code);
+    try std.testing.expectEqual(effects_mod.EffectExitReason.exited, h.app_state.model.exit_reason.?);
+}
+
 test "real executor streams a process's stdout lines into the model" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
     var h = try Harness.create();


### PR DESCRIPTION
- Pass CREATE_NO_WINDOW for background Effects.spawn children on Windows.
- Verify redirected child output remains available without an attached console.
- Document the user-visible Windows fix in a changelog fragment.