### PR TITLE
ci: switch to vercel setup-zig

### DIFF
--- a/.github/workflows/cef-runtime.yml
+++ b/.github/workflows/cef-runtime.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4
@@ -80,7 +80,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - run: zig build test-webview-system-link
@@ -107,7 +107,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       # Percentile perf check: 5 cold launches asserting p90
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - name: Install WebKitGTK dependencies
@@ -150,7 +150,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       # Builds the WebView example with the system engine, compiling the
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4
@@ -219,7 +219,7 @@ jobs:
             step: test-examples-native-shard-4
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       # Declare-to-use, proven on real Windows executables: the
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       # Deliberately NO libwebkitgtk-6.0-dev: ui-inbox declares no web
@@ -296,7 +296,7 @@ jobs:
       # C diagnostics on failure, which is exactly the escalation this
       # step pins against. The throwaway cache dir keeps the compile
       # cold: on a cache hit zig replays nothing, stderr included, so a
-      # warm cache (setup-zig restores one) would hide the diagnostics
+      # warm compiler cache would hide the diagnostics
       # this step exists to catch.
       - name: WebKitGTK stub compile is diagnostic-free
         run: |
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4
@@ -382,7 +382,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - name: Install Wine, Xvfb, and xdotool
@@ -418,7 +418,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - name: Install Wine and Xvfb
@@ -437,7 +437,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - run: zig build test-examples-frontends
@@ -447,7 +447,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - run: zig build test-examples-mobile
@@ -457,7 +457,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: vercel-labs/setup-zig@v1
         with:
           version: 0.16.0
 

--- a/changelog.d/vercel-setup-zig.md
+++ b/changelog.d/vercel-setup-zig.md
@@ -1,0 +1,1 @@
+improvement: **Verified Zig setup**: repository and generated CI workflows now install Zig with `vercel-labs/setup-zig`, including signed archive and checksum verification.

--- a/docs/src/app/docs/testing/ci/page.mdx
+++ b/docs/src/app/docs/testing/ci/page.mdx
@@ -53,7 +53,7 @@ Both jobs fetch the framework into that path when it is missing, so the app's `b
 The `test` job is tier 1:
 
 ```yaml
-- uses: mlugg/setup-zig@v2
+- uses: vercel-labs/setup-zig@v1
   with:
     version: 0.16.0
 - run: zig build test -Dplatform=null

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -1199,7 +1199,7 @@ fn nativeCiYaml(allocator: std.mem.Allocator, names: TemplateNames, framework_pa
         \\    runs-on: ubuntu-latest
         \\    steps:
         \\      - uses: actions/checkout@v4
-        \\      - uses: mlugg/setup-zig@v2
+        \\      - uses: vercel-labs/setup-zig@v1
         \\        with:
         \\          version: 0.16.0
         \\
@@ -1222,7 +1222,7 @@ fn nativeCiYaml(allocator: std.mem.Allocator, names: TemplateNames, framework_pa
         \\    runs-on: ubuntu-latest
         \\    steps:
         \\      - uses: actions/checkout@v4
-        \\      - uses: mlugg/setup-zig@v2
+        \\      - uses: vercel-labs/setup-zig@v1
         \\        with:
         \\          version: 0.16.0
         \\
@@ -1298,7 +1298,7 @@ fn frontendCiYaml(allocator: std.mem.Allocator, names: TemplateNames) ![]const u
         \\    runs-on: ubuntu-latest
         \\    steps:
         \\      - uses: actions/checkout@v4
-        \\      - uses: mlugg/setup-zig@v2
+        \\      - uses: vercel-labs/setup-zig@v1
         \\        with:
         \\          version: 0.16.0
         \\      - name: Fetch native-sdk
@@ -3924,7 +3924,7 @@ test "writeDefaultApp emits Vite project files" {
     defer std.testing.allocator.free(ci_yaml_text);
     try expectBasicYaml(ci_yaml_text);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "zig build test -Dplatform=null -Dnative-sdk-path=\"$NATIVE_SDK_PATH\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "mlugg/setup-zig@v2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "vercel-labs/setup-zig@v1") != null);
     // Web-frontend workflows stop at logic tests: the automation smoke
     // recipe is native-app specific.
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "smoke:") == null);
@@ -4163,7 +4163,7 @@ test "writeDefaultApp --full ts-core emits a CI workflow with the node tier" {
     // automation smoke, no WebKitGTK for a native-rendered app.
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "  test:") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "  smoke:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "mlugg/setup-zig@v2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "vercel-labs/setup-zig@v1") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "zig build test -Dplatform=null") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "libgtk-4-dev xvfb") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "libwebkitgtk-6.0-dev") == null);
@@ -4190,7 +4190,7 @@ test "writeDefaultApp emits a CI workflow for native apps" {
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "jobs:") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "  test:") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "  smoke:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "mlugg/setup-zig@v2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "vercel-labs/setup-zig@v1") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "version: 0.16.0") != null);
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "zig build test -Dplatform=null") != null);
     // The smoke job builds with automation, launches under Xvfb, and drives


### PR DESCRIPTION
- Replace Zig setup across CI and release workflows.
- Keep generated scaffolds, tests, docs, and changelog aligned.