### PR TITLE
fix(effects): send a zero-length body for payload-free POST, PUT and PATCH

### DIFF
--- a/src/runtime/effects.zig
+++ b/src/runtime/effects.zig
@@ -12860,6 +12860,15 @@ pub fn Effects(comptime Msg: type) type {
                 try body.writer.writeAll(slot.fetchPayload());
                 try body.end();
                 try request.connection.?.flush();
+            } else if (slot.method.requestHasBody()) {
+                // POST, PUT and PATCH carry a body by definition, so
+                // `sendBodiless` asserts against them. A payload-free
+                // request of one of those methods is still valid HTTP;
+                // send an explicit zero-length body instead.
+                request.transfer_encoding = .{ .content_length = 0 };
+                var body = try request.sendBodyUnflushed(&.{});
+                try body.end();
+                try request.connection.?.flush();
             } else {
                 try request.sendBodiless();
             }

--- a/src/runtime/effects_fetch_tests.zig
+++ b/src/runtime/effects_fetch_tests.zig
@@ -923,6 +923,27 @@ test "real fetch round-trips a POST payload through the echo route" {
     try std.testing.expectEqualStrings("the payload rides in the fetch buffer", h.app_state.model.body());
 }
 
+test "real fetch sends a payload-free POST as an explicit zero-length body" {
+    var h = try Harness.create();
+    defer h.destroy();
+    const fixture = try Fixture.start(std.testing.allocator);
+    defer fixture.stop();
+
+    var url_buffer: [128]u8 = undefined;
+    test_url = fixture.url(&url_buffer, "/echo");
+    test_method = .POST;
+    test_headers = &.{};
+    test_payload = null;
+    test_timeout_ms = effects_mod.default_effect_fetch_timeout_ms;
+    try h.app_state.dispatch(&h.harness.runtime, 1, .start);
+    try waitForResponse(&h);
+
+    try std.testing.expectEqual(effects_mod.EffectFetchOutcome.ok, h.app_state.model.outcome.?);
+    try std.testing.expectEqual(@as(u16, 200), h.app_state.model.status);
+    try std.testing.expectEqual(@as(usize, 0), h.app_state.model.body_len);
+    try std.testing.expect(fixture.headContains("content-length: 0"));
+}
+
 test "real fetch preserves binary bodies byte for byte" {
     var h = try Harness.create();
     defer h.destroy();


### PR DESCRIPTION
## Problem

`runFetch` sends every request without a payload through `std.http.Client.sendBodiless`, which asserts the method carries no body. A POST, PUT or PATCH with no payload hits that assert: the process aborts with SIGABRT in Debug builds. In ReleaseFast the assert is compiled out and the request goes out with no `Content-Length` at all.

Found while calling an OAuth endpoint that documents POST with a bearer token and no body. Several OAuth endpoints work that way, so the crash is reachable from ordinary code.

## Change

Send an explicit `content-length: 0` for methods that carry a body, and keep `sendBodiless` for the rest.

One behavior change worth flagging: `transfer_encoding` goes from `.none` to `content_length = 0`, so a 307 or 308 now returns `error.RedirectRequiresResend` instead of being followed. A 301, 302 or 303 still follows, because the client rewrites those to GET and clears the body. Any request that sends a body already behaves this way, and a 307 on a POST requires a resend per RFC 9110.

## How to check

`zig build test` runs a new case in `effects_fetch_tests.zig` that drives a payload-free POST through the fixture server and asserts `content-length: 0` in the request head. Without the change it terminates with SIGABRT in `sendBodilessUnflushed`.
