### PR TITLE
Fix explicit zero padding

### DIFF
--- a/src/primitives/canvas/ui.zig
+++ b/src/primitives/canvas/ui.zig
@@ -618,7 +618,7 @@ pub fn Ui(comptime Msg: type) type {
             min_width: f32 = 0,
             grow: f32 = 0,
             gap: f32 = 0,
-            padding: f32 = 0,
+            padding: ?f32 = null,
             main: canvas.WidgetMainAlignment = .start,
             cross: canvas.WidgetCrossAlignment = .stretch,
             /// Line policy for `text` leaves. `true`: word-wrap through
@@ -3614,7 +3614,7 @@ pub fn Ui(comptime Msg: type) type {
         /// default gap. Explicit spacing always wins for its own field.
         fn applyKindDefaultLayout(kind: WidgetKind, options: ElementOptions, layout: *canvas.WidgetLayoutStyle) void {
             const defaults = canvas.widgetKindDefaultLayout(kind, options.size) orelse return;
-            if (options.padding == 0) {
+            if (options.padding == null) {
                 layout.padding = defaults.padding;
                 layout.padding_is_kind_default = true;
             }
@@ -3654,12 +3654,7 @@ pub fn Ui(comptime Msg: type) type {
                     .disabled = options.disabled,
                 },
                 .layout = .{
-                    .padding = .{
-                        .top = options.padding,
-                        .right = options.padding,
-                        .bottom = options.padding,
-                        .left = options.padding,
-                    },
+                    .padding = geometry.InsetsF.all(options.padding orelse 0),
                     .gap = options.gap,
                     .grow = options.grow,
                     .main_alignment = options.main,

--- a/src/primitives/canvas/ui_markup_compiled.zig
+++ b/src/primitives/canvas/ui_markup_compiled.zig
@@ -2032,9 +2032,18 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                     };
                 },
                 .bool => @field(options, zig_field) = evalExpr(node, entries, raw, ui, model, scope).truthy(),
-                // Optional bools (`expanded`): the attribute's PRESENCE
-                // makes the state non-null; the value sets it.
-                .optional => @field(options, zig_field) = evalExpr(node, entries, raw, ui, model, scope).truthy(),
+                .optional => |optional| switch (@typeInfo(optional.child)) {
+                    .bool => @field(options, zig_field) = evalExpr(node, entries, raw, ui, model, scope).truthy(),
+                    .float => {
+                        comptime requireVariant(variant, &.{ .float, .integer }, node, "expected a number");
+                        @field(options, zig_field) = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                            .float => |float| float,
+                            .integer => |int| @floatFromInt(int),
+                            else => runtimeFail(optional.child, ui),
+                        };
+                    },
+                    else => runtimeFail(optional.child, ui),
+                },
                 .int => {
                     comptime requireVariant(variant, &.{.integer}, node, "expected a whole number");
                     // Range-checked against the field's own integer type

--- a/src/primitives/canvas/ui_markup_compiled_tests.zig
+++ b/src/primitives/canvas/ui_markup_compiled_tests.zig
@@ -12,6 +12,7 @@
 
 const std = @import("std");
 const canvas = @import("root.zig");
+const geometry = @import("geometry");
 const markup_view = @import("ui_markup_view.zig");
 const fixture = @import("ui_markup_view_tests.zig");
 
@@ -90,6 +91,32 @@ fn expectSameTexts(expected: canvas.Widget, actual: canvas.Widget) !void {
 const InboxUi = canvas.Ui(fixture.Msg);
 const InboxInterpreter = markup_view.MarkupView(fixture.Model, fixture.Msg);
 const InboxCompiled = canvas.CompiledMarkupView(fixture.Model, fixture.Msg, fixture.inbox_markup_source);
+
+const zero_card_padding_markup =
+    \\<card padding="0">
+    \\  <text>Flush</text>
+    \\</card>
+;
+const ZeroCardPaddingCompiled = canvas.CompiledMarkupView(fixture.Model, fixture.Msg, zero_card_padding_markup);
+
+test "explicit zero card padding survives interpreted and compiled markup" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const model = fixture.testModel();
+
+    var interpreter = try InboxInterpreter.init(arena, zero_card_padding_markup);
+    var interpreter_ui = InboxUi.init(arena);
+    const interpreted = try interpreter_ui.finalize(try interpreter.build(&interpreter_ui, &model));
+    var compiled_ui = InboxUi.init(arena);
+    const compiled = try compiled_ui.finalize(ZeroCardPaddingCompiled.build(&compiled_ui, &model));
+
+    try testing.expectEqual(canvas.WidgetKind.card, interpreted.root.kind);
+    try testing.expectEqual(geometry.InsetsF{}, interpreted.root.layout.padding);
+    try testing.expect(!interpreted.root.layout.padding_is_kind_default);
+    try testing.expectEqualDeep(interpreted.root.layout.padding, compiled.root.layout.padding);
+    try testing.expect(!compiled.root.layout.padding_is_kind_default);
+}
 
 fn interpretInbox(arena: std.mem.Allocator, model: *const fixture.Model) !InboxUi.Tree {
     var view = try InboxInterpreter.init(arena, fixture.inbox_markup_source);

--- a/src/primitives/canvas/ui_markup_view.zig
+++ b/src/primitives/canvas/ui_markup_view.zig
@@ -1986,9 +1986,15 @@ pub fn MarkupView(comptime ModelT: type, comptime MsgT: type) type {
                     else => return self.failVoid(node, "expected a number"),
                 },
                 .bool => @field(options, field) = value.truthy(),
-                // Optional bools (`expanded`): the attribute's PRESENCE
-                // makes the state non-null; the value sets it.
-                .optional => @field(options, field) = value.truthy(),
+                .optional => |optional| switch (@typeInfo(optional.child)) {
+                    .bool => @field(options, field) = value.truthy(),
+                    .float => @field(options, field) = switch (value) {
+                        .float => |float| float,
+                        .integer => |int| @floatFromInt(int),
+                        else => return self.failVoid(node, "expected a number"),
+                    },
+                    else => return self.failVoid(node, "attribute is not settable from markup"),
+                },
                 // Range-checked against the FIELD's own integer type
                 // before the cast (the grid-lines teaching, generalized):
                 // expression values are i64, so a literal or model

--- a/src/primitives/canvas/ui_markup_view_tests.zig
+++ b/src/primitives/canvas/ui_markup_view_tests.zig
@@ -1311,7 +1311,12 @@ test "the registry's attr value classes match the ElementOptions field types" {
         const expected: contract.AttrClass = switch (@typeInfo(FieldType)) {
             .float => .number,
             .int => .whole,
-            .bool, .optional => .truthy,
+            .bool => .truthy,
+            .optional => |optional| switch (@typeInfo(optional.child)) {
+                .bool => .truthy,
+                .float => .number,
+                else => unreachable,
+            },
             .@"enum" => .option,
             .pointer => .text,
             else => unreachable,

--- a/src/primitives/canvas/ui_tests.zig
+++ b/src/primitives/canvas/ui_tests.zig
@@ -137,6 +137,20 @@ test "ui builder distinguishes inherited tab padding from an equal author value"
     try testing.expect(!explicit.widget.layout.padding_is_kind_default);
 }
 
+test "explicit zero padding overrides card kind default" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var ui = InboxUi.init(arena_state.allocator());
+    const inherited = ui.el(.card, .{}, .{});
+    try testing.expectEqual(@as(f32, 24), inherited.widget.layout.padding.top);
+    try testing.expect(inherited.widget.layout.padding_is_kind_default);
+
+    const explicit = ui.el(.card, .{ .padding = 0 }, .{});
+    try testing.expectEqual(geometry.InsetsF{}, explicit.widget.layout.padding);
+    try testing.expect(!explicit.widget.layout.padding_is_kind_default);
+}
+
 test "structural ids are stable across rebuilds" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
## Summary

Treat omitted padding and `padding="0"` as distinct values so widget defaults do not replace an explicit zero.

## Tests

- `zig build`
- `zig build test-desktop-canvas-widget`
- `scripts/gate.sh fast origin/main` passed engine tests and validation; TypeScript examples could not install `@typescript/old` from the configured registry