### PR TITLE
docs: coerce terminal scrollback to integer

### DIFF
--- a/docs/src/app/docs/terminal/page.mdx
+++ b/docs/src/app/docs/terminal/page.mdx
@@ -27,7 +27,7 @@ export function update(model: Model, msg: Msg): Model {
   switch (msg.kind) {
     // The runtime-applied view state (scrollback, history, cols, rows).
     // Echo scrollback back and user scrollback survives rebuilds.
-    case "termState": return { ...model, scrollback: msg.state.scrollback };
+    case "termState": return { ...model, scrollback: msg.state.scrollback | 0 };
   }
 }
 ```


### PR DESCRIPTION
Fixes #251

The TypeScript terminal example now coerces the host-filled `TerminalState.scrollback` value with `| 0` before binding it back to the whole-number `scrollback` attribute.

Admission review: no CONTRIBUTING.md exists; `.github/workflows/ci.yml`, `cef-runtime.yml`, and `release.yml` contain no require-issue, auto-close, or assignment automation.

local verification not run; relying on upstream CI