### PR TITLE
docs: fix TypeScript terminal shell key

### DIFF
--- a/docs/src/app/docs/terminal/page.mdx
+++ b/docs/src/app/docs/terminal/page.mdx
@@ -17,7 +17,7 @@ The declarative shape is one element. Spawn a pty from your model (`fx.ptySpawn`
 ```ts
 import { Cmd } from "@native-sdk/core";
 
-const shellKey = 1;
+const shellKey = "shell";
 
 export function view(model: Model) {
   return terminal({ pty: shellKey, scrollback: model.scrollback, grow: 1, label: "Shell", onTerminal: "termState" });
@@ -90,7 +90,7 @@ The pty key is ordinary model data — pick it like an effect key. Spawn the she
 ```ts
 import { Cmd, asciiBytes } from "@native-sdk/core";
 
-const shellKey = 1;
+const shellKey = "shell";
 
 export function update(model: Model, msg: Msg): Model | [Model, Cmd<Msg>] {
   switch (msg.kind) {


### PR DESCRIPTION
## Summary

- Fix the TypeScript `/terminal` documentation to use the string shell key `"shell"` in both examples.
- This matches the terminal command API's string-key contract.

## Verification

- `git apply --check --recount` passed.
- `git diff --check` passed.
- local verification not run; relying on upstream CI

Fixes #252
