### PR TITLE
chore: prepare v0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,33 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.8.1
+## 0.8.2
 
 <!-- release:start -->
+
+### New Features
+
+- **Native drag and drop for TypeScript apps**: Native markup's new `on-drag` channel delivers live, release, and cancellation geometry to compiled cores while the renderer lifts the source under the pointer, preserves one globally keyed insertion slot, animates neighboring items, and supports Escape cancellation; TypeScript cores can also map native multi-file drops into ordinary deterministic messages through `dropMsg` (#285).
+- **Desktop notifications from model cores**: TypeScript apps can return fire-and-forget `Cmd.showNotification` effects and Zig apps can call `fx.showNotification`, with bounded validation and suppression during fake execution and session replay (#283).
+
+### Bug Fixes
+
+- **Explicit zero canvas padding**: Programmatic and compiled or interpreted Native markup views now preserve `padding="0"` instead of replacing it with the widget kind's default padding (#288).
+
+### Improvements
+
+- **TypeScript-first app authoring guidance**: Repository instructions, bundled skills, examples, package documentation, and the docs site now consistently lead with TypeScript cores and Native markup for new apps while keeping Zig as the explicit alternative and toolkit-extension tier (#284).
+- **Agent ticket Kanban showcase**: The TypeScript Kanban example now presents numbered OpenAI- and Claude-assigned tickets, uses an icon-only add action, keeps columns scrollable, and extends its end-to-end coverage for the updated drag geometry (#295).
+
+### Contributors
+
+- @ctate
+- @johnlindquist
+- @Railly
+
+<!-- release:end -->
+
+## 0.8.1
 
 ### New Features
 
@@ -23,8 +47,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 
 - @ctate
 - @Railly
-
-<!-- release:end -->
 
 ## 0.8.0
 

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.8.1"
+    "@native-sdk/core": "0.8.2"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.1"
+    "@native-sdk/core": "0.8.2"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.1"
+    "@native-sdk/core": "0.8.2"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "scriptc": "0.0.22"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -34,14 +34,14 @@
     "scriptc": "0.0.22"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.8.1",
-    "@native-sdk/cli-darwin-x64": "0.8.1",
-    "@native-sdk/cli-linux-arm64-gnu": "0.8.1",
-    "@native-sdk/cli-linux-arm64-musl": "0.8.1",
-    "@native-sdk/cli-linux-x64-gnu": "0.8.1",
-    "@native-sdk/cli-linux-x64-musl": "0.8.1",
-    "@native-sdk/cli-win32-arm64": "0.8.1",
-    "@native-sdk/cli-win32-x64": "0.8.1"
+    "@native-sdk/cli-darwin-arm64": "0.8.2",
+    "@native-sdk/cli-darwin-x64": "0.8.2",
+    "@native-sdk/cli-linux-arm64-gnu": "0.8.2",
+    "@native-sdk/cli-linux-arm64-musl": "0.8.2",
+    "@native-sdk/cli-linux-x64-gnu": "0.8.2",
+    "@native-sdk/cli-linux-x64-musl": "0.8.2",
+    "@native-sdk/cli-win32-arm64": "0.8.2",
+    "@native-sdk/cli-win32-x64": "0.8.2"
   },
   "repository": {
     "type": "git",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://native-sdk.dev",
   "scripts": {
-    "version": "npm run version:sync && git add ../../tools/native-sdk/main.zig ../../packages/core/package.json ../../packages/core/package-lock.json ../../examples/soundboard-ts/package.json ../../examples/system-monitor-ts/package.json npm/*/package.json package.json",
+    "version": "npm run version:sync && git add ../../tools/native-sdk/main.zig ../../packages/core/package.json ../../packages/core/package-lock.json ../../examples/kanban/package.json ../../examples/soundboard-ts/package.json ../../examples/system-monitor-ts/package.json npm/*/package.json package.json",
     "version:sync": "node scripts/sync-version.js",
     "version:check": "node scripts/check-version-sync.js",
     "scripts:check": "node --check bin/native.js && node --check scripts/copy-native.js && node --check scripts/copy-framework.js && node --check scripts/sync-version.js && node --check scripts/check-version-sync.js && node --check scripts/check-framework-sync.js && node --check scripts/check-runtime-types.js && node scripts/copy-framework.js && node scripts/check-framework-sync.js && node scripts/check-runtime-types.js",

--- a/packages/native-sdk/scripts/check-version-sync.js
+++ b/packages/native-sdk/scripts/check-version-sync.js
@@ -140,7 +140,7 @@ if (coreLock.version !== expectedVersion || coreLock.packages?.['']?.version !==
   console.error(`Version mismatch: packages/core/package-lock.json=${coreLock.version}/${coreLock.packages?.['']?.version}, expected ${expectedVersion}`);
   errors++;
 }
-for (const example of ['examples/soundboard-ts', 'examples/system-monitor-ts']) {
+for (const example of ['examples/kanban', 'examples/soundboard-ts', 'examples/system-monitor-ts']) {
   const exampleJson = JSON.parse(readFileSync(join(repoRoot, ...example.split('/'), 'package.json'), 'utf-8'));
   const pin = exampleJson.dependencies?.['@native-sdk/core'];
   if (pin !== expectedVersion) {

--- a/packages/native-sdk/scripts/sync-version.js
+++ b/packages/native-sdk/scripts/sync-version.js
@@ -117,7 +117,7 @@ for (const entry of readdirSync(npmDir, { withFileTypes: true })) {
 // The committed TS examples' @native-sdk/core pins (exact, like the
 // scaffold's, so a post-publish `npm install` resolves the same content
 // the CLI materializes).
-for (const example of ['examples/soundboard-ts', 'examples/system-monitor-ts']) {
+for (const example of ['examples/kanban', 'examples/soundboard-ts', 'examples/system-monitor-ts']) {
   const examplePath = join(repoRoot, ...example.split('/'), 'package.json');
   const exampleJson = JSON.parse(readFileSync(examplePath, 'utf-8'));
   if (exampleJson.dependencies?.['@native-sdk/core'] !== version) {

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.8.1";
+const version = "0.8.2";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Bump CLI, core, platform packages, and TypeScript examples to v0.8.2.
- Add complete release notes and contributors for the v0.8.2 range.
- Keep the Kanban core pin covered by release version sync and validation.