### PR TITLE
fix(macos): smooth dialog backdrop blur

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1017,6 +1017,8 @@ pub fn build(b: *std.Build) void {
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-appkit-gpu-packet-blur-effects", "Verify AppKit GPU packet presenter applies blur effects", &.{
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NativeSdkPacketApplyBlur" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "CGBitmapContextGetData(context)" },
+        .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NativeSdkGaussianBoxRadii" },
+        .{ .path = "src/platform/macos/appkit_host.m", .pattern = "vImageBoxConvolve_ARGB8888" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NSIntersectionRect(rect, clipRect)" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "NativeSdkPacketTransformRect(transformValue, NativeSdkPacketRect(effect[@\"rect\"]))" },
         .{ .path = "src/platform/macos/appkit_host.m", .pattern = "return NativeSdkPacketApplyBlur(effect, opacity, context, scale, transformValue, hasClip, clipRect)" },

--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -1749,6 +1749,29 @@ static CGFloat NativeSdkPacketTransformScale(id value) {
     return fmax(0.0001, fmax(xScale, yScale));
 }
 
+/* Three box filters approximate a Gaussian closely while retaining the
+ * O(pixels) sliding-window implementation in vImage. `sigma` is the CSS-like
+ * blur radius in device pixels; the widths below are the standard optimal
+ * three-box approximation, split between the neighboring odd widths whose
+ * combined variance is closest to sigma squared. */
+static void NativeSdkGaussianBoxRadii(NSUInteger sigma, NSUInteger radii[3]) {
+    const double passCount = 3.0;
+    const double idealWidth = sqrt((12.0 * (double)sigma * (double)sigma / passCount) + 1.0);
+    NSUInteger lowerWidth = (NSUInteger)floor(idealWidth);
+    if ((lowerWidth & 1u) == 0) lowerWidth -= 1;
+    lowerWidth = MAX((NSUInteger)1, lowerWidth);
+    const NSUInteger upperWidth = lowerWidth + 2;
+    const double lowerCountValue =
+        (12.0 * (double)sigma * (double)sigma - passCount * (double)lowerWidth * (double)lowerWidth -
+            4.0 * passCount * (double)lowerWidth - 3.0 * passCount) /
+        (-4.0 * (double)lowerWidth - 4.0);
+    const NSInteger lowerCount = MAX((NSInteger)0, MIN((NSInteger)3, (NSInteger)llround(lowerCountValue)));
+    for (NSUInteger pass = 0; pass < 3; pass++) {
+        const NSUInteger width = pass < (NSUInteger)lowerCount ? lowerWidth : upperWidth;
+        radii[pass] = (width - 1) / 2;
+    }
+}
+
 static BOOL NativeSdkPacketApplyBlur(NSDictionary *effect, CGFloat opacity, CGContextRef context, CGFloat scale, id transformValue, BOOL hasClip, NSRect clipRect) {
     if (!effect || !context) return NO;
     void *contextData = CGBitmapContextGetData(context);
@@ -1780,16 +1803,19 @@ static BOOL NativeSdkPacketApplyBlur(NSDictionary *effect, CGFloat opacity, CGCo
     NSUInteger maxY = (NSUInteger)maxYFloat;
     if (maxX <= minX || maxY <= minY) return YES;
 
-    NSUInteger radius = (NSUInteger)llround(fmax(0.0, NativeSdkPacketNumber(effect[@"radius"], 0) * normalizedScale * NativeSdkPacketTransformScale(transformValue)));
-    radius = MIN(radius, (NSUInteger)64);
-    if (radius == 0) return YES;
+    NSUInteger sigma = (NSUInteger)llround(fmax(0.0, NativeSdkPacketNumber(effect[@"radius"], 0) * normalizedScale * NativeSdkPacketTransformScale(transformValue)));
+    sigma = MIN(sigma, (NSUInteger)64);
+    if (sigma == 0) return YES;
     CGFloat mix = fmax(0.0, fmin(1.0, opacity));
     if (mix <= 0) return YES;
 
-    NSUInteger expandedMinX = minX > radius ? minX - radius : 0;
-    NSUInteger expandedMaxX = MIN((NSUInteger)width, maxX + radius);
-    NSUInteger expandedMinY = minY > radius ? minY - radius : 0;
-    NSUInteger expandedMaxY = MIN((NSUInteger)height, maxY + radius);
+    NSUInteger boxRadii[3] = {0, 0, 0};
+    NativeSdkGaussianBoxRadii(sigma, boxRadii);
+    const NSUInteger sampleExtent = boxRadii[0] + boxRadii[1] + boxRadii[2];
+    NSUInteger expandedMinX = minX > sampleExtent ? minX - sampleExtent : 0;
+    NSUInteger expandedMaxX = MIN((NSUInteger)width, maxX + sampleExtent);
+    NSUInteger expandedMinY = minY > sampleExtent ? minY - sampleExtent : 0;
+    NSUInteger expandedMaxY = MIN((NSUInteger)height, maxY + sampleExtent);
     if (expandedMaxX <= expandedMinX || expandedMaxY <= expandedMinY) return YES;
 
     NSUInteger regionWidth = expandedMaxX - expandedMinX;
@@ -1797,11 +1823,13 @@ static BOOL NativeSdkPacketApplyBlur(NSDictionary *effect, CGFloat opacity, CGCo
     size_t regionBytesPerRow = regionWidth * 4;
     size_t regionByteLength = regionBytesPerRow * regionHeight;
     NSMutableData *sourceData = [NSMutableData dataWithLength:regionByteLength];
-    NSMutableData *horizontalData = [NSMutableData dataWithLength:regionByteLength];
-    if (!sourceData || !horizontalData) return NO;
+    NSMutableData *firstPassData = [NSMutableData dataWithLength:regionByteLength];
+    NSMutableData *secondPassData = [NSMutableData dataWithLength:regionByteLength];
+    if (!sourceData || !firstPassData || !secondPassData) return NO;
     uint8_t *destination = (uint8_t *)contextData;
     uint8_t *source = (uint8_t *)sourceData.mutableBytes;
-    uint8_t *horizontal = (uint8_t *)horizontalData.mutableBytes;
+    uint8_t *firstPass = (uint8_t *)firstPassData.mutableBytes;
+    uint8_t *secondPass = (uint8_t *)secondPassData.mutableBytes;
     for (NSUInteger row = 0; row < regionHeight; row++) {
         memcpy(
             source + row * regionBytesPerRow,
@@ -1810,91 +1838,37 @@ static BOOL NativeSdkPacketApplyBlur(NSDictionary *effect, CGFloat opacity, CGCo
         );
     }
 
-    /* Both passes keep the ORIGINAL clamped-window box average — the
-     * window shrinks at the surface edges exactly as before — but slide
-     * the window incrementally (add the entering sample, subtract the
-     * leaving one), turning O(region x radius) into O(region). The sums
-     * are the same integers the per-pixel rescan produced, so the output
-     * is byte-identical; a full-window dirty pass that repaints a
-     * backdrop-blurred popover stops costing milliseconds of scalar
-     * resampling. */
-    for (NSUInteger y = expandedMinY; y < expandedMaxY; y++) {
-        const uint8_t *sourceRow = source + (y - expandedMinY) * regionBytesPerRow;
-        uint8_t *horizontalRow = horizontal + (y - expandedMinY) * regionBytesPerRow;
-        NSUInteger windowMinX = minX > radius ? minX - radius : 0;
-        NSUInteger windowMaxX = MIN((NSUInteger)width - 1, minX + radius);
-        uint64_t sums[4] = {0, 0, 0, 0};
-        for (NSUInteger sx = windowMinX; sx <= windowMaxX; sx++) {
-            const uint8_t *pixel = sourceRow + (sx - expandedMinX) * 4;
-            sums[0] += pixel[0];
-            sums[1] += pixel[1];
-            sums[2] += pixel[2];
-            sums[3] += pixel[3];
+    vImage_Buffer buffers[3] = {
+        { .data = source, .height = regionHeight, .width = regionWidth, .rowBytes = regionBytesPerRow },
+        { .data = firstPass, .height = regionHeight, .width = regionWidth, .rowBytes = regionBytesPerRow },
+        { .data = secondPass, .height = regionHeight, .width = regionWidth, .rowBytes = regionBytesPerRow },
+    };
+    const Pixel_8888 edgeColor = {0, 0, 0, 0};
+    for (NSUInteger pass = 0; pass < 3; pass++) {
+        const vImage_Buffer *input = pass == 0 ? &buffers[0] : (pass == 1 ? &buffers[1] : &buffers[2]);
+        const vImage_Buffer *output = pass == 1 ? &buffers[2] : &buffers[1];
+        const uint32_t kernelSize = (uint32_t)(boxRadii[pass] * 2 + 1);
+        if (kernelSize == 1) {
+            memcpy(output->data, input->data, regionByteLength);
+            continue;
         }
-        for (NSUInteger x = minX; x < maxX; x++) {
-            NSUInteger sampleMinX = x > radius ? x - radius : 0;
-            NSUInteger sampleMaxX = MIN((NSUInteger)width - 1, x + radius);
-            while (windowMaxX < sampleMaxX) {
-                windowMaxX += 1;
-                const uint8_t *pixel = sourceRow + (windowMaxX - expandedMinX) * 4;
-                sums[0] += pixel[0];
-                sums[1] += pixel[1];
-                sums[2] += pixel[2];
-                sums[3] += pixel[3];
-            }
-            while (windowMinX < sampleMinX) {
-                const uint8_t *pixel = sourceRow + (windowMinX - expandedMinX) * 4;
-                sums[0] -= pixel[0];
-                sums[1] -= pixel[1];
-                sums[2] -= pixel[2];
-                sums[3] -= pixel[3];
-                windowMinX += 1;
-            }
-            NSUInteger count = sampleMaxX - sampleMinX + 1;
-            uint8_t *out = horizontalRow + (x - expandedMinX) * 4;
-            out[0] = (uint8_t)(sums[0] / count);
-            out[1] = (uint8_t)(sums[1] / count);
-            out[2] = (uint8_t)(sums[2] / count);
-            out[3] = (uint8_t)(sums[3] / count);
-        }
+        const vImage_Error error = vImageBoxConvolve_ARGB8888(
+            input, output, NULL, 0, 0, kernelSize, kernelSize, edgeColor, kvImageEdgeExtend
+        );
+        if (error != kvImageNoError) return NO;
     }
 
-    for (NSUInteger x = minX; x < maxX; x++) {
-        const uint8_t *horizontalColumn = horizontal + (x - expandedMinX) * 4;
-        NSUInteger windowMinY = minY > radius ? minY - radius : 0;
-        NSUInteger windowMaxY = MIN((NSUInteger)height - 1, minY + radius);
-        uint64_t sums[4] = {0, 0, 0, 0};
-        for (NSUInteger sy = windowMinY; sy <= windowMaxY; sy++) {
-            const uint8_t *pixel = horizontalColumn + (sy - expandedMinY) * regionBytesPerRow;
-            sums[0] += pixel[0];
-            sums[1] += pixel[1];
-            sums[2] += pixel[2];
-            sums[3] += pixel[3];
-        }
-        for (NSUInteger y = minY; y < maxY; y++) {
-            NSUInteger sampleMinY = y > radius ? y - radius : 0;
-            NSUInteger sampleMaxY = MIN((NSUInteger)height - 1, y + radius);
-            while (windowMaxY < sampleMaxY) {
-                windowMaxY += 1;
-                const uint8_t *pixel = horizontalColumn + (windowMaxY - expandedMinY) * regionBytesPerRow;
-                sums[0] += pixel[0];
-                sums[1] += pixel[1];
-                sums[2] += pixel[2];
-                sums[3] += pixel[3];
-            }
-            while (windowMinY < sampleMinY) {
-                const uint8_t *pixel = horizontalColumn + (windowMinY - expandedMinY) * regionBytesPerRow;
-                sums[0] -= pixel[0];
-                sums[1] -= pixel[1];
-                sums[2] -= pixel[2];
-                sums[3] -= pixel[3];
-                windowMinY += 1;
-            }
-            NSUInteger count = sampleMaxY - sampleMinY + 1;
+    /* The third pass lands in firstPass. Preserve command opacity by
+     * mixing that Gaussian approximation with the untouched backdrop. */
+    for (NSUInteger y = minY; y < maxY; y++) {
+        const NSUInteger regionY = y - expandedMinY;
+        for (NSUInteger x = minX; x < maxX; x++) {
+            const NSUInteger regionX = x - expandedMinX;
+            const size_t regionIndex = regionY * regionBytesPerRow + regionX * 4;
             uint8_t *out = destination + y * bytesPerRow + x * 4;
             for (NSUInteger channel = 0; channel < 4; channel++) {
-                CGFloat blurred = (CGFloat)(sums[channel] / count);
-                CGFloat original = (CGFloat)source[(y - expandedMinY) * regionBytesPerRow + (x - expandedMinX) * 4 + channel];
+                const CGFloat original = (CGFloat)source[regionIndex + channel];
+                const CGFloat blurred = (CGFloat)firstPass[regionIndex + channel];
                 out[channel] = (uint8_t)llround(original + (blurred - original) * mix);
             }
         }
@@ -4033,7 +4007,7 @@ static const char *NativeSdkGpuShotDir(void) {
  *     through the same CG code, clipped to the repaint region, and draw
  *     as transient textured quads;
  *   - blur reads the backdrop, so the pass splits around it: commit +
- *     wait, read the target back, run the existing scalar box blur on
+ *     wait, read the target back, run the vImage Gaussian approximation on
  *     the readback, upload the blurred rect, and continue — a hybrid
  *     frame, CPU only where the effect is inherently a backdrop read.
  * Scissor/dirty-rect semantics mirror the CPU path: full passes clear
@@ -4520,7 +4494,7 @@ static BOOL NativeSdkCompositeBlurWriteRegion(NSDictionary *command, CGFloat sca
         if (op->type == 0) continue;
         if (op->type == 3) {
             /* Blur sandwich: flush the pass, read the target back, run
-             * the reference scalar blur on the readback, upload the
+             * the vImage Gaussian approximation on the readback, upload the
              * blurred rect, and continue compositing above it. */
             [encoder endEncoding];
             encoder = nil;

--- a/src/primitives/canvas/frame.zig
+++ b/src/primitives/canvas/frame.zig
@@ -457,6 +457,11 @@ pub const CanvasFrameOptions = struct {
     timestamp_ns: u64 = 0,
     surface_size: geometry.SizeF = .{},
     scale: f32 = 1,
+    /// Renderer-specific read support relative to `Blur.radius`. The
+    /// reference and Windows renderers consume one radius; AppKit's
+    /// three-box Gaussian consumes at most three. Runtime-owned frame
+    /// planning sets this from the active platform.
+    backdrop_blur_sample_extent_multiplier: f32 = 1,
     full_repaint: bool = false,
     budget: CanvasFrameBudget = .{},
     previous_pipeline_cache: []const RenderPipelineCacheEntry = &.{},
@@ -615,7 +620,11 @@ pub fn buildCanvasFrame(previous: ?DisplayList, next: DisplayList, options: Canv
         // pixels so a fractional dirty edge cannot erase an unchanged
         // neighbor's boundary-pixel coverage without redrawing it.
         dirty_bounds = bleedAlignedDirtyBounds(unionOptionalBounds(dirtyBoundsFromChanges(changes), render_override_dirty_bounds), options.scale, 1, options.surface_size);
-        if (incrementalDamageIntersectsBackdropBlur(render_plan.commands, dirty_bounds)) {
+        if (incrementalDamageIntersectsBackdropBlurWithSampleExtent(
+            render_plan.commands,
+            dirty_bounds,
+            options.backdrop_blur_sample_extent_multiplier,
+        )) {
             // A backdrop blur reads pixels around its output from the
             // destination as it existed at this point in draw order.
             // Retained pixels outside an incremental scissor already
@@ -666,8 +675,23 @@ pub fn buildCanvasFrame(previous: ?DisplayList, next: DisplayList, options: Canv
 /// outside the scissor hold the previous fully composited frame rather
 /// than the backdrop at the blur command's position in draw order.
 pub fn incrementalDamageIntersectsBackdropBlur(commands: []const RenderCommand, dirty_bounds: ?geometry.RectF) bool {
+    return incrementalDamageIntersectsBackdropBlurWithSampleExtent(commands, dirty_bounds, 1);
+}
+
+/// Backend-aware form of `incrementalDamageIntersectsBackdropBlur`. Values
+/// below one are normalized to the shared one-radius floor; wider renderers
+/// pass their conservative maximum sampling support.
+pub fn incrementalDamageIntersectsBackdropBlurWithSampleExtent(
+    commands: []const RenderCommand,
+    dirty_bounds: ?geometry.RectF,
+    requested_sample_extent_multiplier: f32,
+) bool {
     const dirty = dirty_bounds orelse return false;
     const normalized_dirty = dirty.normalized();
+    const sample_extent_multiplier = if (std.math.isFinite(requested_sample_extent_multiplier))
+        @max(1, requested_sample_extent_multiplier)
+    else
+        1;
     for (commands) |command| {
         switch (command.command) {
             .blur => |blur| {
@@ -677,14 +701,25 @@ pub fn incrementalDamageIntersectsBackdropBlur(commands: []const RenderCommand, 
                 if (output.isEmpty()) continue;
 
                 // Do not use `command.bounds` here: the render planner
-                // intersects that inflated bound with the output clip,
-                // while a clipped output pixel still samples backdrop
-                // pixels up to `radius` OUTSIDE the clip. Transforming
-                // the full local read footprint is a conservative AABB
-                // for every sample the surviving output can consume.
-                const read_footprint = command.transform.transformRect(
-                    blur.rect.normalized().inflate(geometry.InsetsF.all(@max(0, blur.radius))),
-                ).normalized();
+                // intersects that radius-inflated bound with the output
+                // clip, while a clipped output pixel still samples backdrop
+                // outside the clip. Preserve the established local-radius
+                // footprint for one-radius renderers. Wider renderers operate
+                // on the transformed output with an isotropic device-space
+                // kernel, so scale their support by the transform's largest
+                // axis before inflating that output.
+                const read_footprint = if (sample_extent_multiplier == 1)
+                    command.transform.transformRect(
+                        blur.rect.normalized().inflate(geometry.InsetsF.all(@max(0, blur.radius))),
+                    ).normalized()
+                else extended: {
+                    const transform = command.transform;
+                    const x_scale = @sqrt(transform.a * transform.a + transform.b * transform.b);
+                    const y_scale = @sqrt(transform.c * transform.c + transform.d * transform.d);
+                    const transform_scale = @max(0.0001, @max(x_scale, y_scale));
+                    const sample_extent = @max(0, blur.radius) * transform_scale * sample_extent_multiplier;
+                    break :extended output.normalized().inflate(geometry.InsetsF.all(sample_extent));
+                };
                 if (read_footprint.intersects(normalized_dirty)) return true;
             },
             else => {},

--- a/src/primitives/canvas/root.zig
+++ b/src/primitives/canvas/root.zig
@@ -299,6 +299,7 @@ pub const CanvasFrame = frame_model.CanvasFrame;
 pub const max_canvas_frame_dirty_rects = frame_model.max_canvas_frame_dirty_rects;
 pub const buildCanvasFrame = frame_model.buildCanvasFrame;
 pub const incrementalDamageIntersectsBackdropBlur = frame_model.incrementalDamageIntersectsBackdropBlur;
+pub const incrementalDamageIntersectsBackdropBlurWithSampleExtent = frame_model.incrementalDamageIntersectsBackdropBlurWithSampleExtent;
 
 // Canvas GPU packet and encoder data live in `gpu.zig`; root keeps the public API stable.
 pub const CanvasRenderPassLoadAction = gpu_model.CanvasRenderPassLoadAction;

--- a/src/runtime/canvas_frame.zig
+++ b/src/runtime/canvas_frame.zig
@@ -220,6 +220,7 @@ pub fn RuntimeCanvasFrames(comptime Runtime: type) type {
 
             var frame_options = options;
             if (frame_options.surface_size.isEmpty()) frame_options.surface_size = self.views[index].frame.size();
+            frame_options.backdrop_blur_sample_extent_multiplier = backdropBlurSampleExtentMultiplier(self.options.platform.name);
             return self.views[index].canvasDisplayList().framePlan(previous, frame_options, storage);
         }
 
@@ -874,6 +875,7 @@ pub fn RuntimeCanvasFrames(comptime Runtime: type) type {
             launch_timing.lapOnce("first_plan_begin");
             defer launch_timing.lapOnce("first_plan_done");
             var frame_options = options;
+            frame_options.backdrop_blur_sample_extent_multiplier = backdropBlurSampleExtentMultiplier(self.options.platform.name);
             if (frame_options.surface_size.isEmpty()) {
                 frame_options.surface_size = if (self.views[index].gpu_size.isEmpty()) self.views[index].frame.size() else self.views[index].gpu_size;
             }
@@ -1134,6 +1136,7 @@ pub fn RuntimeCanvasFrames(comptime Runtime: type) type {
                 render_plan.commands,
                 dirty_bounds,
                 dirty_rects[0..dirty_rect_count],
+                frame_options.backdrop_blur_sample_extent_multiplier,
             )) {
                 // A blur's apron must be reconstructed from the scene as
                 // it existed before that command. Retained pixels beyond
@@ -1316,12 +1319,20 @@ fn incrementalCanvasDamageIntersectsBackdropBlur(
     commands: []const canvas.RenderCommand,
     dirty_bounds: ?geometry.RectF,
     dirty_rects: []const geometry.RectF,
+    sample_extent_multiplier: f32,
 ) bool {
-    if (dirty_rects.len == 0) return canvas.incrementalDamageIntersectsBackdropBlur(commands, dirty_bounds);
+    if (dirty_rects.len == 0) return canvas.incrementalDamageIntersectsBackdropBlurWithSampleExtent(commands, dirty_bounds, sample_extent_multiplier);
     for (dirty_rects) |dirty_rect| {
-        if (canvas.incrementalDamageIntersectsBackdropBlur(commands, dirty_rect)) return true;
+        if (canvas.incrementalDamageIntersectsBackdropBlurWithSampleExtent(commands, dirty_rect, sample_extent_multiplier)) return true;
     }
     return false;
+}
+
+/// AppKit approximates its Gaussian with three consecutive box filters, so
+/// one output pixel can depend on the sum of three box radii. Other renderers
+/// retain the shared one-radius footprint.
+fn backdropBlurSampleExtentMultiplier(platform_name: []const u8) f32 {
+    return if (std.mem.eql(u8, platform_name, "macos")) 3 else 1;
 }
 
 /// Rework a planned frame's incremental damage for the present's

--- a/src/runtime/canvas_frame_invalidation_tests.zig
+++ b/src/runtime/canvas_frame_invalidation_tests.zig
@@ -438,10 +438,13 @@ test "backdrop blur promotes intersecting damage to a full repaint" {
         }
     };
 
-    const surface = geometry.SizeF.init(100, 40);
+    const surface = geometry.SizeF.init(120, 40);
     const harness = try TestHarness().create(std.testing.allocator, .{});
     defer harness.destroy(std.testing.allocator);
     harness.null_platform.gpu_surfaces = true;
+    // Exercise the AppKit-specific three-box sampling footprint while the
+    // null host keeps the test deterministic and headless.
+    harness.runtime.options.platform.name = "macos";
     harness.runtime.options.pixel_present_retained_baseline = true;
     var app_state: TestApp = .{};
     try harness.start(app_state.app());
@@ -452,14 +455,14 @@ test "backdrop blur promotes intersecting damage to a full repaint" {
         .kind = .gpu_surface,
         .frame = geometry.RectF.init(0, 0, surface.width, surface.height),
     });
-    var pixels: [100 * 40 * 4]u8 = undefined;
-    var scratch: [100 * 40 * 4]u8 = undefined;
+    var pixels: [120 * 40 * 4]u8 = undefined;
+    var scratch: [120 * 40 * 4]u8 = undefined;
     const clear = canvas.Color.rgb8(0, 0, 0);
 
     const initial = [_]canvas.CanvasCommand{
         .{ .fill_rect = .{ .id = 1, .rect = geometry.RectF.init(4, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(255, 0, 0) } } },
         .{ .fill_rect = .{ .id = 2, .rect = geometry.RectF.init(44, 15, 4, 4), .fill = .{ .color = canvas.Color.rgb8(255, 0, 0) } } },
-        .{ .fill_rect = .{ .id = 5, .rect = geometry.RectF.init(90, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(255, 0, 0) } } },
+        .{ .fill_rect = .{ .id = 5, .rect = geometry.RectF.init(110, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(255, 0, 0) } } },
         .{ .push_clip = .{ .id = 3, .rect = geometry.RectF.init(50, 10, 20, 20) } },
         .{ .blur = .{ .id = 4, .rect = geometry.RectF.init(50, 10, 20, 20), .radius = 8 } },
         .pop_clip,
@@ -471,12 +474,13 @@ test "backdrop blur promotes intersecting damage to a full repaint" {
     }, canvasFrameScratchStorage(&harness.runtime), &pixels, &scratch, clear);
     try std.testing.expect(first.full_repaint);
 
-    // Two damage islands well outside the blur's radius keep the retained
-    // path even though their bounding union crosses the blur apron.
+    // Two damage islands well outside the three-pass blur's conservative
+    // sampling extent keep the retained path even though their bounding
+    // union crosses the blur apron.
     const far_changed = [_]canvas.CanvasCommand{
         .{ .fill_rect = .{ .id = 1, .rect = geometry.RectF.init(4, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(0, 255, 0) } } },
         initial[1],
-        .{ .fill_rect = .{ .id = 5, .rect = geometry.RectF.init(90, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(0, 255, 0) } } },
+        .{ .fill_rect = .{ .id = 5, .rect = geometry.RectF.init(110, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(0, 255, 0) } } },
         initial[3],
         initial[4],
         initial[5],
@@ -490,20 +494,41 @@ test "backdrop blur promotes intersecting damage to a full repaint" {
     try std.testing.expect(incremental.dirty_bounds != null);
     try std.testing.expectEqual(@as(usize, 2), incremental.dirtyRects().len);
 
+    // AppKit's radius-8 Gaussian uses three boxes whose combined support
+    // reaches beyond the declared radius. Moving this rect to twenty points
+    // past the blur output must therefore replay the whole list; the old
+    // radius-only apron left the affected blur pixels stale.
+    const gaussian_apron_changed = [_]canvas.CanvasCommand{
+        far_changed[0],
+        far_changed[1],
+        .{ .fill_rect = .{ .id = 5, .rect = geometry.RectF.init(90, 4, 4, 4), .fill = .{ .color = canvas.Color.rgb8(0, 0, 255) } } },
+        initial[3],
+        initial[4],
+        initial[5],
+    };
+    _ = try harness.runtime.setCanvasDisplayList(1, "canvas", .{ .commands = &gaussian_apron_changed });
+    const gaussian_promoted = try harness.runtime.presentNextCanvasFramePixels(1, "canvas", .{
+        .frame_index = 3,
+        .surface_size = surface,
+    }, canvasFrameScratchStorage(&harness.runtime), &pixels, &scratch, clear);
+    try std.testing.expect(gaussian_promoted.full_repaint);
+    try std.testing.expectEqual(@as(usize, 0), gaussian_promoted.changes.len);
+    try std.testing.expectEqualDeep(geometry.RectF.init(0, 0, surface.width, surface.height), gaussian_promoted.dirty_bounds.?);
+
     // This changed rect stops two points before the blur output, but it
     // lies inside the radius-8 sampling apron. A scissored replay would
     // sample the prior composited frame outside its dirty boundary.
     const apron_changed = [_]canvas.CanvasCommand{
-        far_changed[0],
+        gaussian_apron_changed[0],
         .{ .fill_rect = .{ .id = 2, .rect = geometry.RectF.init(44, 15, 4, 4), .fill = .{ .color = canvas.Color.rgb8(0, 0, 255) } } },
-        far_changed[2],
+        gaussian_apron_changed[2],
         initial[3],
         initial[4],
         initial[5],
     };
     _ = try harness.runtime.setCanvasDisplayList(1, "canvas", .{ .commands = &apron_changed });
     const promoted = try harness.runtime.presentNextCanvasFramePixels(1, "canvas", .{
-        .frame_index = 3,
+        .frame_index = 4,
         .surface_size = surface,
     }, canvasFrameScratchStorage(&harness.runtime), &pixels, &scratch, clear);
     try std.testing.expect(promoted.full_repaint);


### PR DESCRIPTION
- Replace the flat box blur with an optimized three-pass Gaussian approximation.
- Preserve shadcn-compatible blur and scrim values while covering the host path with a build check.