### PR TITLE
Fix TS core PTY event key contract

### DIFF
--- a/packages/core/sdk/core.d.ts
+++ b/packages/core/sdk/core.d.ts
@@ -86,7 +86,7 @@ export interface AudioCaptureRoute<M extends Msgish> {
 export type PtyState = "output" | "exit";
 export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "spawn_failed";
 export type PtyEventArm = {
-    readonly key: string;
+    readonly key: Uint8Array;
     readonly state: PtyState;
     readonly bytes: Uint8Array;
     readonly code: number;

--- a/packages/core/sdk/core.ts
+++ b/packages/core/sdk/core.ts
@@ -639,8 +639,9 @@ export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "
 
 /// The payload shape of a pty event arm — seven fields, matched by NAME
 /// (the AudioEventArm convention). `key` is the app's own session key
-/// (the `Cmd.ptySpawn` `key`, or "" when the spawn named none) — two
-/// sessions routing one event arm are told apart by this field. `state`
+/// as byte text (the `Cmd.ptySpawn` `key`, or empty bytes when the spawn
+/// named none) — two sessions routing one event arm are told apart by
+/// this field. `state`
 /// must be a named string-literal-union alias carrying exactly the two
 /// PtyState members and `reason` one carrying exactly the five
 /// PtyExitReason members (any declaration order — the host matches
@@ -651,7 +652,7 @@ export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "
 /// payloads refused over the session's life — zero means every write
 /// reached the child, never a silent drop.
 export type PtyEventArm = {
-  readonly key: string;
+  readonly key: Uint8Array;
   readonly state: PtyState;
   readonly bytes: Uint8Array;
   readonly code: number;
@@ -661,7 +662,7 @@ export type PtyEventArm = {
 };
 
 /// The Msg arms a pty session may target: arms whose payload is exactly
-/// the six PtyEventArm fields. The `state` and `reason` checks run BOTH
+/// the seven PtyEventArm fields. The `state` and `reason` checks run BOTH
 /// directions (the AudioEventKind convention): the `&` constraint holds
 /// the arm's unions to PtyState/PtyExitReason, and the tuple-wrapped
 /// reverse checks hold them to the arm's — a narrower union would
@@ -682,7 +683,7 @@ export type PtyEventKind<M extends Msgish> = M extends Msgish
   : never;
 
 /// `Cmd.ptySpawn` routing: every session event dispatches the `event`
-/// arm (the six-field PtyEventArm record, matched by field name).
+/// arm (the seven-field PtyEventArm record, matched by field name).
 /// `cols`/`rows` are the initial grid the child observes (80x24 when
 /// omitted); `term` is the TERM the child starts with (omitted = the
 /// engine's default). The optional `key` names the session for

--- a/packages/core/test/conformance.test.ts
+++ b/packages/core/test/conformance.test.ts
@@ -3560,7 +3560,7 @@ export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "
 export interface Model { readonly chunks: number; readonly errs: number; }
 export type Msg =
   | { readonly kind: "go"; readonly which: number }
-  | { readonly kind: "pty_evt"; readonly key: string; readonly state: PtyState; readonly bytes: Uint8Array; readonly code: number; readonly reason: PtyExitReason; readonly signal: number; readonly droppedWrites: number };
+  | { readonly kind: "pty_evt"; readonly key: Uint8Array; readonly state: PtyState; readonly bytes: Uint8Array; readonly code: number; readonly reason: PtyExitReason; readonly signal: number; readonly droppedWrites: number };
 export function initialModel(): Model { return { chunks: 0, errs: 0 }; }
 `;
 
@@ -4417,7 +4417,7 @@ export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "
 export interface Model { readonly chunks: number; readonly errs: number; }
 export type Msg =
   | { readonly kind: "go"; readonly which: number }
-  | { readonly kind: "pty_evt"; readonly key: string; readonly state: NarrowState; readonly bytes: Uint8Array; readonly code: number; readonly reason: PtyExitReason; readonly signal: number; readonly droppedWrites: number };
+  | { readonly kind: "pty_evt"; readonly key: Uint8Array; readonly state: NarrowState; readonly bytes: Uint8Array; readonly code: number; readonly reason: PtyExitReason; readonly signal: number; readonly droppedWrites: number };
 export function initialModel(): Model { return { chunks: 0, errs: 0 }; }
 export function update(model: Model, msg: Msg): Model | [Model, Cmd<Msg>] {
   switch (msg.kind) {
@@ -4521,7 +4521,7 @@ export type NarrowReason = "exited" | "cancelled";
 export interface Model { readonly chunks: number; readonly errs: number; }
 export type Msg =
   | { readonly kind: "go"; readonly which: number }
-  | { readonly kind: "pty_evt"; readonly key: string; readonly state: PtyState; readonly bytes: Uint8Array; readonly code: number; readonly reason: NarrowReason; readonly signal: number; readonly droppedWrites: number };
+  | { readonly kind: "pty_evt"; readonly key: Uint8Array; readonly state: PtyState; readonly bytes: Uint8Array; readonly code: number; readonly reason: NarrowReason; readonly signal: number; readonly droppedWrites: number };
 export function initialModel(): Model { return { chunks: 0, errs: 0 }; }
 export function update(model: Model, msg: Msg): Model | [Model, Cmd<Msg>] {
   switch (msg.kind) {

--- a/tests/ts-core/fixture.ts
+++ b/tests/ts-core/fixture.ts
@@ -5,7 +5,9 @@
 // clipboard) plus the one-shot delay, and the streaming ops (a line-
 // streamed fetch, a real subprocess spawn with line/exit routing and
 // mid-stream cancel, and the audio and video event streams with their
-// control verbs).
+// control verbs), plus pty spawn and its seven-field event
+// record. Keeping pty here makes the generated facade compile as part of
+// the real external-core lane, not only the frontend conformance pass.
 // Transpiled at build time by the repo's own transpiler (never committed
 // as Zig) and driven through the real runtime by
 // tests/ts-core/host_e2e_tests.zig.
@@ -23,6 +25,10 @@ export type ImageState =
   | "alloc_failed";
 
 export type ChannelState = "data" | "closed" | "rejected";
+
+export type PtyState = "output" | "exit";
+
+export type PtyExitReason = "exited" | "signaled" | "cancelled" | "rejected" | "spawn_failed";
 
 export interface Model {
   readonly polling: boolean;
@@ -146,7 +152,9 @@ export type Msg =
   | { readonly kind: "mix_reject" }
   | { readonly kind: "mix_reject_flip" }
   | { readonly kind: "chan_evt"; readonly key: number; readonly state: ChannelState; readonly bytes: Uint8Array; readonly droppedPending: number; readonly droppedTotal: number }
-  | { readonly kind: "notify" };
+  | { readonly kind: "notify" }
+  | { readonly kind: "open_pty" }
+  | { readonly kind: "pty_evt"; readonly key: Uint8Array; readonly state: PtyState; readonly bytes: Uint8Array; readonly code: number; readonly reason: PtyExitReason; readonly signal: number; readonly droppedWrites: number };
 
 export function initialModel(): [Model, Cmd<Msg>] {
   return [
@@ -444,6 +452,10 @@ export function update(model: Model, msg: Msg): [Model, Cmd<Msg>] {
         subtitle: asciiBytes("native-sdk"),
         body: asciiBytes("TS core notification"),
       })];
+    case "open_pty":
+      return [model, Cmd.ptySpawn([asciiBytes("/bin/sh")], { key: "fixture-pty", event: "pty_evt" })];
+    case "pty_evt":
+      return [{ ...model, status: msg.key }, Cmd.none];
   }
 }
 


### PR DESCRIPTION
- Align echoed PTY keys with the byte-text host and facade contract.
- Regenerate SDK declarations and update PTY conformance coverage.
- Compile the PTY event arm through the external-core E2E fixture.