### PR TITLE
chore(release): prepare v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,36 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.8.3
+## 0.8.4
 
 <!-- release:start -->
+
+### New Features
+
+- **Streaming fetch responses for TypeScript cores**: `Cmd.fetch` can now deliver line-framed HTTP responses through typed message arms with deterministic terminal errors, loud cancellation, duplicate-key rejection, and bounded line sizes; the rebuilt Chatbot example streams Vercel AI Gateway replies with live model selection and a Stop action (#300).
+- **Desktop audio capture**: TypeScript cores can start bounded, timestamped microphone or system-output PCM streams on macOS and Windows with explicit lifecycle, permission, drop-count, and replay handling; the new Voice Memo example records, saves, and plays WAV files (#303).
+- **Customizable macOS DMG packaging**: `native package` now creates polished drag-to-Applications disk images with generated or custom Retina backgrounds, configurable Finder geometry, positioned app and Applications entries, and staged files, directories, or links (#304).
+- **Live TypeScript theme packs**: zero-config TypeScript apps can export `themePack(model)` to switch the built-in theme pack from app state without losing live system scheme, accessibility, accent, or scale inputs (#308).
+
+### Bug Fixes
+
+- **Smooth macOS dialog blur**: Host backdrop blur now uses an optimized three-pass Gaussian approximation and correct dirty-region invalidation, eliminating flat or stale dialog backgrounds while preserving the established scrim treatment (#299).
+- **Byte-accurate PTY event keys**: TypeScript PTY event routes now expose echoed session keys as `Uint8Array`, matching the byte-text host, generated facade, and external-core contract (#307).
+- **Reliable keyboard widget navigation**: Interactive canvas lists, trees, menus, and anchored controls now retain logical focus across clipped rows, scroll keyboard targets into view, and paint active and focus-visible states consistently (#308).
+
+### Improvements
+
+- **TypeScript component gallery**: The GPU component showcase is now a TypeScript core and Native markup app with isolated interactive specimens, model-driven Default and Geist switching, clearer navigation, and dedicated smoke coverage (#308).
+
+### Contributors
+
+- @ctate
+- @marcusschiesser
+- @NyxTools-M
+
+<!-- release:end -->
+
+## 0.8.3
 
 ### Bug Fixes
 
@@ -18,8 +45,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.8.2
 

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.8.4"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.8.4"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.8.4"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "scriptc": "0.0.22"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -34,14 +34,14 @@
     "scriptc": "0.0.22"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.8.3",
-    "@native-sdk/cli-darwin-x64": "0.8.3",
-    "@native-sdk/cli-linux-arm64-gnu": "0.8.3",
-    "@native-sdk/cli-linux-arm64-musl": "0.8.3",
-    "@native-sdk/cli-linux-x64-gnu": "0.8.3",
-    "@native-sdk/cli-linux-x64-musl": "0.8.3",
-    "@native-sdk/cli-win32-arm64": "0.8.3",
-    "@native-sdk/cli-win32-x64": "0.8.3"
+    "@native-sdk/cli-darwin-arm64": "0.8.4",
+    "@native-sdk/cli-darwin-x64": "0.8.4",
+    "@native-sdk/cli-linux-arm64-gnu": "0.8.4",
+    "@native-sdk/cli-linux-arm64-musl": "0.8.4",
+    "@native-sdk/cli-linux-x64-gnu": "0.8.4",
+    "@native-sdk/cli-linux-x64-musl": "0.8.4",
+    "@native-sdk/cli-win32-arm64": "0.8.4",
+    "@native-sdk/cli-win32-x64": "0.8.4"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.8.3";
+const version = "0.8.4";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Add v0.8.4 release notes and contributor credits.
- Synchronize CLI, core, platform, tool, and example version pins.