### PR TITLE
fix(docs): redirect /docs to the introduction page

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -58,6 +58,13 @@ const nextConfig = {
     return [
       // The Philosophy page became the Introduction, the opening page of the docs.
       { source: "/philosophy", destination: "/docs/introduction", permanent: true },
+      // docsSlugs() only yields nested slugs, so the /docs segment itself has
+      // neither a route nor a generated redirect and 404s. It is the parent of
+      // every documentation link on the site and the likeliest hand-typed entry
+      // point, so open it on the Introduction instead. The .md sibling keeps the
+      // Markdown surface whole for agents that reach for it.
+      { source: "/docs", destination: "/docs/introduction", permanent: true },
+      { source: "/docs.md", destination: "/docs/introduction.md", permanent: true },
       ...legacyDocsRedirects,
     ];
   },


### PR DESCRIPTION
Fixes #331.

## Problem

`https://native-sdk.dev/docs` returns 404, while every page beneath it resolves and every other URL form already redirects into `/docs/*`:

| URL | Before |
| --- | --- |
| `/cli` | 308 to `/docs/cli` |
| `/cli.md` | 308 to `/docs/cli.md` |
| `/md/cli` | 308 to `/docs/cli.md` |
| `/philosophy` | 308 to `/docs/introduction` |
| `/docs/` | 308 to `/docs`, which 404s |
| `/docs` | **404** |
| `/docs.md` | **404** |

`docs/src/app/docs/` has no `page.mdx`, so the App Router has no route for the `/docs` segment, and `docsSlugs()` only collects pages where `segments.length > 0`, so `docs` is never emitted as a redirect source either. `/docs/` is the sharpest edge, since it redirects into a path that 404s.

This matters most for agents and LLM tooling. `/docs` is the parent of every documentation link on the homepage and the likeliest hand-typed entry point, so a tool that builds a docs URL from the site root, or truncates `/docs/components/button` looking for an index, hits the 404 and can conclude the documentation is missing. The `.md` siblings, `llms.txt`, and the legacy redirect table all exist to make this site machine-readable, and `/docs` is the one gap left in it.

## Change

Two entries added to the existing `redirects()` array in `docs/next.config.mjs`, next to the `/philosophy` precedent:

```js
{ source: "/docs", destination: "/docs/introduction", permanent: true },
{ source: "/docs.md", destination: "/docs/introduction.md", permanent: true },
```

The `.md` pairing matches what `legacyDocsRedirects` already does for every slug. There is no collision with the generated sources, since `docsSlugs()` never yields `docs`.

## Verification

`pnpm --dir docs check` passes in full: 99 canonical pages, Markdown siblings, and query-preserving legacy redirects verified, plus the code-toggle and WASM preview gates.

Against `pnpm --dir docs start` on the production build:

| URL | After |
| --- | --- |
| `/docs` | 308 to `/docs/introduction`, resolves 200 |
| `/docs/` | 308 to `/docs`, resolves 200 |
| `/docs.md` | 308 to `/docs/introduction.md`, resolves 200 `text/markdown; charset=utf-8` |
| `/docs?a=1` | 308 to `/docs/introduction?a=1`, query preserved |
| `/cli`, `/philosophy` | unchanged |

`routes-manifest.json` shows both new entries as 308 config redirects.

## Note on approach

I went with a redirect because it matches the precedent already in the file and keeps the diff small. If you would rather `/docs` be a real landing page that indexes the sections, say the word and I will redo it that way.
