### PR TITLE
fix(docs): redirect /docs to the introduction page

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -58,6 +58,13 @@ const nextConfig = {
     return [
       // The Philosophy page became the Introduction, the opening page of the docs.
       { source: "/philosophy", destination: "/docs/introduction", permanent: true },
+      // docsSlugs() only yields nested slugs, so the /docs segment itself has
+      // neither a route nor a generated redirect and 404s. It is the parent of
+      // every documentation link on the site and the likeliest hand-typed entry
+      // point, so open it on the Introduction instead. The .md sibling keeps the
+      // Markdown surface whole for agents that reach for it.
+      { source: "/docs", destination: "/docs/introduction", permanent: true },
+      { source: "/docs.md", destination: "/docs/introduction.md", permanent: true },
       ...legacyDocsRedirects,
     ];
   },


### PR DESCRIPTION
Recreates #332 by @camilocbarrera with a signed commit. Cris is preserved as co-author in the commit trailer.

Fixes #331.

## Problem

`https://native-sdk.dev/docs` returns 404, while every page beneath it resolves and every other URL form already redirects into `/docs/*`. `/docs/` redirects into `/docs`, which is currently a dead end.

This matters most for agents and LLM tooling. `/docs` is the parent of every documentation link on the homepage and the likeliest hand-typed entry point. The `.md` siblings, `llms.txt`, and legacy redirect table make the site machine-readable, and `/docs` is the remaining gap.

## Change

Add two entries to the existing `redirects()` array in `docs/next.config.mjs`:

```js
{ source: "/docs", destination: "/docs/introduction", permanent: true },
{ source: "/docs.md", destination: "/docs/introduction.md", permanent: true },
```

The `.md` pairing matches `legacyDocsRedirects`. There is no collision with generated sources because `docsSlugs()` never yields `docs`.

## Verification

- Docs check passed: 100 canonical pages, Markdown siblings, query-preserving redirects, code toggles, and WASM previews.
- `/docs` returns 308 to `/docs/introduction`, then 200.
- `/docs.md` returns 308 to `/docs/introduction.md`, then 200 with `text/markdown; charset=utf-8`.
- `/docs?a=1` preserves the query string.
- `/docs/` normalizes through `/docs`.
- Commit signature is verified by GitHub.

Co-authored-by: Cris <cristian.correa.cs@gmail.com>