### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,41 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.8.4
+## 0.9.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Ordinary TypeScript services behind a typed boundary**: Apps can place filesystem, process, JSON, regex, class, and exact-vendored npm work under `src/services/`; Native SDK generates the checked client and codecs, compiles a pinned static service executable, and carries keyed requests, typed streaming, cooperative cancellation, deadlines, supervision, and deterministic replay across the isolated boundary (#317, #321).
+- **Optional in-process TypeScript services**: Services can use the same boundary through a linked, runtime-localized worker pool with per-key FIFO ordering, parallel independent keys, streaming, timeout and trap isolation, and replay that never starts the carrier; the explicit opt-in now follows the compiler's Windows, Linux, macOS, and cross-target matrix while the isolated child remains the automatic default (#334, #337).
+- **Engine-owned model persistence**: TypeScript cores can persist committed models through capability-gated, atomically replaced snapshots with generated codecs, debounced writes, backup recovery, explicit restore and migration routes, rollback safety, and journal/replay support (#316).
+- **SQLite record storage**: TypeScript and Zig apps can use a capability-gated record store for deterministic atomic CRUD effects backed by bundled SQLite across desktop and mobile hosts, with devhost parity and a complete Record Store example (#320).
+- **Checked relational SQLite**: Append-only migrations, build-validated named SQL, transactions, generated typed commands and live-query subscriptions, replay, and the Relational Notes example make relational SQLite a first-class offline data layer across desktop and mobile (#326).
+- **Model-driven menu-bar apps**: TypeScript apps can derive status-item labels, icons, tooltips, and rich menus from committed model state, while new macOS effects control hidden startup, fullscreen, Dock visibility, and launch-at-login behavior across both native hosts (#311, #314).
+- **Platform services for TypeScript cores**: Typed effects now open external URLs, reveal filesystem paths, and format local time through validated macOS, Linux, and Windows backends (#315).
+- **App-scoped credentials**: TypeScript and Zig cores can store, load, and delete credentials through capability- and permission-gated native providers, with redacted journals, deterministic replay placeholders, and hermetic devhost stores across desktop and mobile (#335).
+- **Cross-compiled TypeScript cores**: The external core compiler now builds Linux and Windows GNU targets from macOS, Linux, or Windows and macOS targets from macOS, with target-independent contracts and cross-platform end-to-end batteries for Windows and Linux musl (#340).
+
+### Bug Fixes
+
+- **Working documentation root**: `/docs`, `/docs/`, and the matching Markdown route now resolve to the Introduction instead of ending at a 404 (#338).
+
+### Improvements
+
+- **Faster retained desktop frames**: Animation pumping and Windows wake scheduling now avoid stalled or redundant work, profiling uses monotonic frame-correlated telemetry, and physical macOS and Windows performance gates protect input latency and frame budgets (#313).
+- **Measured, compiler-truth service tooling**: A dedicated TypeScript Services reference documents the two-tier model and failure semantics; production-carrier benchmarks measure cold start, latency, and throughput; generated compiler-surface references and manifest diffs keep capability claims mechanically honest; and scriptc advances through 0.0.28 with refreshed contracts and calibration (#325, #327, #328, #329, #333, #336).
+
+### Contributors
+
+- @ctate
+- @carvalab
+- @Railly
+- @camilocbarrera
+
+<!-- release:end -->
+
+## 0.8.4
 
 ### New Features
 
@@ -28,8 +60,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 - @ctate
 - @marcusschiesser
 - @NyxTools-M
-
-<!-- release:end -->
 
 ## 0.8.3
 

--- a/examples/gpu-components/package.json
+++ b/examples/gpu-components/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.8.4"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/menu-bar/package.json
+++ b/examples/menu-bar/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "TypeScript + Native markup menu-bar lifecycle example.",
   "dependencies": {
-    "@native-sdk/core": "0.8.4"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/record-store/package.json
+++ b/examples/record-store/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/relational-notes/package.json
+++ b/examples/relational-notes/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.4"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.4"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.4"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/examples/voice-memo/package.json
+++ b/examples/voice-memo/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.8.3"
+    "@native-sdk/core": "0.9.0"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "dependencies": {
         "scriptc": "0.0.28"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -35,14 +35,14 @@
     "scriptc": "0.0.28"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.8.4",
-    "@native-sdk/cli-darwin-x64": "0.8.4",
-    "@native-sdk/cli-linux-arm64-gnu": "0.8.4",
-    "@native-sdk/cli-linux-arm64-musl": "0.8.4",
-    "@native-sdk/cli-linux-x64-gnu": "0.8.4",
-    "@native-sdk/cli-linux-x64-musl": "0.8.4",
-    "@native-sdk/cli-win32-arm64": "0.8.4",
-    "@native-sdk/cli-win32-x64": "0.8.4"
+    "@native-sdk/cli-darwin-arm64": "0.9.0",
+    "@native-sdk/cli-darwin-x64": "0.9.0",
+    "@native-sdk/cli-linux-arm64-gnu": "0.9.0",
+    "@native-sdk/cli-linux-arm64-musl": "0.9.0",
+    "@native-sdk/cli-linux-x64-gnu": "0.9.0",
+    "@native-sdk/cli-linux-x64-musl": "0.9.0",
+    "@native-sdk/cli-win32-arm64": "0.9.0",
+    "@native-sdk/cli-win32-x64": "0.9.0"
   },
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
   },
   "homepage": "https://native-sdk.dev",
   "scripts": {
-    "version": "npm run version:sync && git add ../../tools/native-sdk/main.zig ../../packages/core/package.json ../../packages/core/package-lock.json ../../examples/kanban/package.json ../../examples/soundboard-ts/package.json ../../examples/system-monitor-ts/package.json npm/*/package.json package.json",
+    "version": "npm run version:sync && git add ../../tools/native-sdk/main.zig ../../packages/core/package.json ../../packages/core/package-lock.json ../../examples/*/package.json npm/*/package.json package.json",
     "version:sync": "node scripts/sync-version.js",
     "version:check": "node scripts/check-version-sync.js",
     "scripts:check": "node --check bin/native.js && node --check scripts/copy-native.js && node --check scripts/copy-framework.js && node --check scripts/sync-version.js && node --check scripts/check-version-sync.js && node --check scripts/check-framework-sync.js && node --check scripts/check-runtime-types.js && node scripts/copy-framework.js && node scripts/check-framework-sync.js && node scripts/check-runtime-types.js",

--- a/packages/native-sdk/scripts/check-version-sync.js
+++ b/packages/native-sdk/scripts/check-version-sync.js
@@ -10,7 +10,7 @@
 // repository rename that only updates the main package fails the publish.
 // CI runs this before publish so a half-bumped release cannot ship.
 
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -140,8 +140,14 @@ if (coreLock.version !== expectedVersion || coreLock.packages?.['']?.version !==
   console.error(`Version mismatch: packages/core/package-lock.json=${coreLock.version}/${coreLock.packages?.['']?.version}, expected ${expectedVersion}`);
   errors++;
 }
-for (const example of ['examples/kanban', 'examples/soundboard-ts', 'examples/system-monitor-ts']) {
-  const exampleJson = JSON.parse(readFileSync(join(repoRoot, ...example.split('/'), 'package.json'), 'utf-8'));
+const examplesDir = join(repoRoot, 'examples');
+for (const entry of readdirSync(examplesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const examplePath = join(examplesDir, entry.name, 'package.json');
+  if (!existsSync(examplePath)) continue;
+  const exampleJson = JSON.parse(readFileSync(examplePath, 'utf-8'));
+  if (!exampleJson.dependencies?.['@native-sdk/core']) continue;
+  const example = `examples/${entry.name}`;
   const pin = exampleJson.dependencies?.['@native-sdk/core'];
   if (pin !== expectedVersion) {
     console.error(`Version mismatch: ${example}/package.json pins @native-sdk/core ${pin}, expected ${expectedVersion}`);

--- a/packages/native-sdk/scripts/sync-version.js
+++ b/packages/native-sdk/scripts/sync-version.js
@@ -15,10 +15,10 @@
 // scaffold pins (templates read the bundled manifest) and the editor copy
 // the CLI materializes match the npm publish the moment the package goes
 // public. The committed TS examples pin the bundled version by hand, so
-// they are stamped here too (tests/ts-core/scaffold_ide_e2e_tests.zig
-// fails the build when an example pin drifts from the bundled version).
+// they are stamped here too (version:check fails when any example pin
+// drifts from the bundled version).
 
-import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -114,13 +114,20 @@ for (const entry of readdirSync(npmDir, { withFileTypes: true })) {
   }
 }
 
-// The committed TS examples' @native-sdk/core pins (exact, like the
+// Every committed TS example's @native-sdk/core pin (exact, like the
 // scaffold's, so a post-publish `npm install` resolves the same content
-// the CLI materializes).
-for (const example of ['examples/kanban', 'examples/soundboard-ts', 'examples/system-monitor-ts']) {
-  const examplePath = join(repoRoot, ...example.split('/'), 'package.json');
+// the CLI materializes). Discover these instead of maintaining a list:
+// new examples often exercise the release's new SDK surface and must not
+// accidentally keep the version that happened to be current at creation.
+const examplesDir = join(repoRoot, 'examples');
+for (const entry of readdirSync(examplesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const examplePath = join(examplesDir, entry.name, 'package.json');
+  if (!existsSync(examplePath)) continue;
   const exampleJson = JSON.parse(readFileSync(examplePath, 'utf-8'));
-  if (exampleJson.dependencies?.['@native-sdk/core'] !== version) {
+  if (!exampleJson.dependencies?.['@native-sdk/core']) continue;
+  const example = `examples/${entry.name}`;
+  if (exampleJson.dependencies['@native-sdk/core'] !== version) {
     exampleJson.dependencies['@native-sdk/core'] = version;
     writeFileSync(examplePath, JSON.stringify(exampleJson, null, 2) + '\n');
     console.log(`  Updated ${example}/package.json`);

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.8.4";
+const version = "0.9.0";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Add complete v0.9.0 release notes and contributor credits.
- Synchronize CLI, core, platform, tool, and example version pins.
- Discover every TypeScript example during version synchronization.