### PR TITLE
fix(linux): avoid GTK alert dialog crash

### DIFF
--- a/src/platform/linux/gtk_host.c
+++ b/src/platform/linux/gtk_host.c
@@ -6583,7 +6583,8 @@ static void native_sdk_alert_done(GObject *source, GAsyncResult *result, gpointe
 }
 
 int native_sdk_gtk_show_message_dialog(native_sdk_gtk_host_t *host, const native_sdk_gtk_message_dialog_opts_t *opts) {
-    GtkAlertDialog *dialog = gtk_alert_dialog_new(NULL);
+    /* The constructor requires a non-NULL printf-style format string. */
+    GtkAlertDialog *dialog = gtk_alert_dialog_new("");
     char *title = native_sdk_bytes_to_string(opts->title, opts->title_len);
     char *message = native_sdk_bytes_to_string(opts->message, opts->message_len);
     char *informative = native_sdk_bytes_to_string(opts->informative_text, opts->informative_text_len);

--- a/src/platform/linux/root.zig
+++ b/src/platform/linux/root.zig
@@ -1892,6 +1892,23 @@ test "linux platform module exports type" {
     _ = LinuxPlatform;
 }
 
+test "linux message dialogs construct alerts with a non-null format string" {
+    // gtk_alert_dialog_new takes a required printf-style format string.
+    // The host sets the real message below, but NULL still makes GTK
+    // dereference an invalid format pointer during construction.
+    const host_source = @embedFile("gtk_host.c");
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        host_source,
+        "GtkAlertDialog *dialog = gtk_alert_dialog_new(\"\");",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        host_source,
+        "gtk_alert_dialog_new(NULL)",
+    ) == null);
+}
+
 test "linux notification actions use process-scoped opaque tokens" {
     const host_source = @embedFile("gtk_host.c");
     try std.testing.expect(std.mem.indexOf(


### PR DESCRIPTION
- Initialize GtkAlertDialog with a valid empty format string.
- Add regression coverage preventing a NULL constructor argument.