### PR TITLE
fix(runtime): reveal autofocus targets and carets

### DIFF
--- a/src/primitives/canvas/widget_routing.zig
+++ b/src/primitives/canvas/widget_routing.zig
@@ -413,6 +413,26 @@ pub fn focusWidgetTargetById(layout: anytype, id: ObjectId, scroll_semantics_fn:
     return focusTargetFromLayoutNode(layout, index, scroll_semantics_fn);
 }
 
+/// Resolve every ordinary focus gate except ancestor geometry. Runtime
+/// reveal paths use this to name a clipped target before scrolling it, while
+/// keeping the exact same hidden, disclosure, disabled, and scroll-semantic
+/// eligibility as `focusWidgetTargetById`.
+pub fn logicalFocusWidgetTargetAtIndex(layout: anytype, index: usize, scroll_semantics_fn: anytype) ?WidgetFocusTarget {
+    if (index >= layout.nodes.len) return null;
+    if (isWidgetHiddenInAncestors(layout, index)) return null;
+    if (widget_tree.isWidgetConcealedByDisclosure(layout, index)) return null;
+    const node = layout.nodes[index];
+    if (node.widget.id == 0) return null;
+    if (!widget_access.isFocusable(node.widget) and (node.widget.state.disabled or !scroll_semantics_fn(layout, index).scrollable)) return null;
+    return .{
+        .id = node.widget.id,
+        .kind = node.widget.kind,
+        .bounds = node.frame,
+        .index = index,
+        .state = node.widget.state,
+    };
+}
+
 fn focusForward(layout: anytype, current_index: ?usize, scroll_semantics_fn: anytype) ?WidgetFocusTarget {
     var index: usize = if (current_index) |value| value + 1 else 0;
     while (index < layout.nodes.len) : (index += 1) {
@@ -466,23 +486,9 @@ fn focusSpatial(layout: anytype, current_index: usize, direction: WidgetFocusDir
 }
 
 fn focusTargetFromLayoutNode(layout: anytype, index: usize, scroll_semantics_fn: anytype) ?WidgetFocusTarget {
-    if (index >= layout.nodes.len) return null;
-    if (isWidgetHiddenInAncestors(layout, index)) return null;
-    // Concealed disclosure content never joins the focus order: a
-    // closed section's controls are unreachable by tab or arrows, and
-    // mid-reveal content stays unreachable until the reveal settles.
-    if (widget_tree.isWidgetConcealedByDisclosure(layout, index)) return null;
+    const target = logicalFocusWidgetTargetAtIndex(layout, index, scroll_semantics_fn) orelse return null;
     if (!isWidgetFrameVisibleInWidgetAncestors(layout, index)) return null;
-    const node = layout.nodes[index];
-    if (node.widget.id == 0) return null;
-    if (!widget_access.isFocusable(node.widget) and (node.widget.state.disabled or !scroll_semantics_fn(layout, index).scrollable)) return null;
-    return .{
-        .id = node.widget.id,
-        .kind = node.widget.kind,
-        .bounds = node.frame,
-        .index = index,
-        .state = node.widget.state,
-    };
+    return target;
 }
 
 fn spatialFocusCandidate(

--- a/src/primitives/canvas/widget_runtime.zig
+++ b/src/primitives/canvas/widget_runtime.zig
@@ -162,6 +162,10 @@ pub const WidgetLayoutTree = struct {
         return widget_routing.focusWidgetTargetById(self, id, widgetScrollSemantics);
     }
 
+    pub fn logicalFocusTargetAtIndex(self: WidgetLayoutTree, index: usize) ?WidgetFocusTarget {
+        return widget_routing.logicalFocusWidgetTargetAtIndex(self, index, widgetScrollSemantics);
+    }
+
     pub fn collectSemantics(self: WidgetLayoutTree, output: []WidgetSemanticsNode) Error![]const WidgetSemanticsNode {
         return collectWidgetSemantics(self, output);
     }

--- a/src/runtime/automation_widget_dispatch.zig
+++ b/src/runtime/automation_widget_dispatch.zig
@@ -476,7 +476,12 @@ pub fn RuntimeAutomationWidgetDispatch(comptime Runtime: type) type {
 
         pub fn focusAutomationCanvasWidget(self: *Runtime, view_index: usize, id: canvas.ObjectId) anyerror!void {
             if (view_index >= self.view_count) return error.ViewNotFound;
-            const target = self.views[view_index].widgetLayoutTree().focusTargetById(id) orelse return error.InvalidCommand;
+            // Programmatic focus names logical targets before applying the
+            // pointer path's geometry clip. The shared keyboard/autofocus
+            // reveal seam scrolls every runtime-owned ancestor, reconciles,
+            // and only then returns an ordinary visible focus target.
+            const reveal = try CanvasWidgetEventMethods().revealCanvasWidgetFocusTarget(self, view_index, id) orelse return error.InvalidCommand;
+            const target = reveal.target;
             try self.focusView(self.views[view_index].window_id, self.views[view_index].label);
             // Programmatic focus (autofocus, automation `focus`) follows
             // the pointer contract, not the keyboard one: buttons and
@@ -486,8 +491,9 @@ pub fn RuntimeAutomationWidgetDispatch(comptime Runtime: type) type {
             // window-level default focus landing on a button dressed an
             // idle control in the focus ring.
             const focus_visible_id: canvas.ObjectId = if (canvas_widget_runtime.canvasWidgetShowsPointerFocusRing(target.kind)) target.id else 0;
-            if (self.views[view_index].canvas_widget_focused_id != target.id or self.views[view_index].canvas_widget_focus_visible_id != focus_visible_id) {
-                const previous_state = self.views[view_index].canvasWidgetRenderState();
+            const previous_state = self.views[view_index].canvasWidgetRenderState();
+            const focus_changed = self.views[view_index].canvas_widget_focused_id != target.id or self.views[view_index].canvas_widget_focus_visible_id != focus_visible_id;
+            if (focus_changed) {
                 self.views[view_index].canvas_widget_focused_id = target.id;
                 self.views[view_index].canvas_widget_focus_visible_id = focus_visible_id;
                 // Pointer-contract provenance: a programmatic ring
@@ -501,14 +507,47 @@ pub fn RuntimeAutomationWidgetDispatch(comptime Runtime: type) type {
                 // widget whose focus-shown tooltip is up with the ring
                 // intact is not a move, and leaves it alone.
                 try CanvasWidgetEventMethods().updateCanvasTooltipIntentForProgrammaticFocusMove(self, view_index);
-                // A focus change repaints; record the automation input so
-                // the completing frame publishes (same contract as select
+            }
+
+            // The established programmatic-selection contract is a collapsed
+            // caret at text.len when no source/retained selection exists.
+            // Preserve an existing selection, then reveal its focus endpoint
+            // inside the editor after the outer ancestor reveal has made the
+            // editability/visibility gate truthful.
+            const caret_initialized = try self.views[view_index].ensureCanvasWidgetFocusedTextCaret();
+            var inner_scroll_changed = false;
+            if (self.views[view_index].canEditCanvasWidgetText(target.id)) {
+                if (self.views[view_index].canvasWidgetNodeIndexById(target.id)) |node_index| {
+                    const before = self.views[view_index].widget_layout_nodes[node_index].widget;
+                    self.views[view_index].scrollCanvasTextInputCaretIntoView(node_index);
+                    const after = self.views[view_index].widget_layout_nodes[node_index].widget;
+                    inner_scroll_changed = before.value != after.value or before.value_x != after.value_x;
+                }
+            }
+            if (inner_scroll_changed) {
+                try self.views[view_index].refreshCanvasWidgetSemantics();
+                if (!caret_initialized) self.views[view_index].widget_revision += 1;
+            }
+
+            if (focus_changed or caret_initialized or inner_scroll_changed or reveal.scroll_dirty != null) {
+                // A focus/reveal change repaints; record the automation input
+                // so the completing frame publishes (same contract as select
                 // and text edits). Callers that dispatch a follow-up input
                 // event simply overwrite this with their own timestamp.
                 self.views[view_index].recordGpuSurfaceInputTimestamp(automationInputTimestampNs());
-                try CanvasWidgetEventMethods().invalidateForCanvasWidgetRenderStateChange(self, view_index, previous_state, self.views[view_index].canvasWidgetRenderState());
             }
-            _ = try self.views[view_index].ensureCanvasWidgetFocusedTextCaret();
+            if (focus_changed) {
+                try CanvasWidgetEventMethods().invalidateForCanvasWidgetRenderStateChange(self, view_index, previous_state, self.views[view_index].canvasWidgetRenderState());
+            } else if (caret_initialized or inner_scroll_changed) {
+                if (self.views[view_index].canvasWidgetNodeIndexById(target.id)) |node_index| {
+                    if (self.views[view_index].canvasWidgetDirtyBounds(node_index, self.views[view_index].widget_layout_nodes[node_index].frame)) |dirty| {
+                        try CanvasWidgetEventMethods().invalidateForCanvasWidgetDirty(self, view_index, dirty);
+                    }
+                }
+            }
+            if (reveal.scroll_dirty != null) {
+                _ = try CanvasWidgetDisplayMethods().refreshCanvasWidgetDisplayListIfOwned(self, view_index);
+            }
         }
 
         pub fn dispatchAutomationWidgetKey(self: *Runtime, app: runtime_api.App(Runtime), view_index: usize, id: canvas.ObjectId, key: []const u8) anyerror!void {

--- a/src/runtime/automation_widget_dispatch.zig
+++ b/src/runtime/automation_widget_dispatch.zig
@@ -478,11 +478,14 @@ pub fn RuntimeAutomationWidgetDispatch(comptime Runtime: type) type {
             if (view_index >= self.view_count) return error.ViewNotFound;
             // Programmatic focus names logical targets before applying the
             // pointer path's geometry clip. The shared keyboard/autofocus
-            // reveal seam scrolls every runtime-owned ancestor, reconciles,
-            // and only then returns an ordinary visible focus target.
+            // reveal seam scrolls every runtime-owned ancestor. Preflight
+            // the reveal before platform focus, then focus the view before
+            // committing any retained scroll mutation: a rejected platform
+            // focus leaves the canvas byte-for-byte where it was.
+            if (!CanvasWidgetEventMethods().canRevealCanvasWidgetFocusTarget(self, view_index, id)) return error.InvalidCommand;
+            try self.focusView(self.views[view_index].window_id, self.views[view_index].label);
             const reveal = try CanvasWidgetEventMethods().revealCanvasWidgetFocusTarget(self, view_index, id) orelse return error.InvalidCommand;
             const target = reveal.target;
-            try self.focusView(self.views[view_index].window_id, self.views[view_index].label);
             // Programmatic focus (autofocus, automation `focus`) follows
             // the pointer contract, not the keyboard one: buttons and
             // rows take focus QUIETLY (no ring), editable text kinds show

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2878,14 +2878,25 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             try setCanvasWidgetFocusFromKeyboardWithVisibility(self, view_index, target_id, true);
         }
 
-        fn setCanvasWidgetFocusFromKeyboardWithVisibility(self: *Runtime, view_index: usize, target_id: canvas.ObjectId, focus_visible: bool) anyerror!void {
-            const next_focus_visible_id: canvas.ObjectId = if (focus_visible) target_id else 0;
-            if (self.views[view_index].canvas_widget_focused_id == target_id and self.views[view_index].canvas_widget_focus_visible_id == next_focus_visible_id) return;
+        pub const CanvasWidgetFocusReveal = struct {
+            target: canvas.WidgetFocusTarget,
+            scroll_dirty: ?geometry.RectF,
+        };
 
-            // Roving tree/list navigation may resolve a logical row that
-            // is currently clipped. Reveal it before the focus write so
-            // keyboard routing, semantics, and rendering all see an
-            // ordinary visible target during this same key event.
+        /// Resolve a programmatic focus target without applying the pointer
+        /// path's geometry clip first, reveal it through runtime-owned scroll
+        /// ancestors, then re-verify the ordinary visible focus contract.
+        /// Keyboard traversal, autofocus, and automation all enter through
+        /// this seam so an offscreen logical target is never focused before
+        /// its retained geometry and semantics have caught up with the scroll.
+        pub fn revealCanvasWidgetFocusTarget(self: *Runtime, view_index: usize, target_id: canvas.ObjectId) anyerror!?CanvasWidgetFocusReveal {
+            if (view_index >= self.view_count or target_id == 0) return null;
+            const layout = self.views[view_index].widgetLayoutTree();
+            if (layout.focusTargetById(target_id) == null) {
+                const node_index = canvas_widget_runtime.canvasWidgetLayoutNodeIndexById(layout, target_id) orelse return null;
+                _ = canvas_widget_runtime.canvasWidgetLogicalFocusTarget(layout, node_index) orelse return null;
+            }
+
             const scroll_dirty = try self.views[view_index].scrollCanvasWidgetIntoView(target_id);
             if (scroll_dirty) |dirty| {
                 const previous_cursor = self.views[view_index].canvas_widget_cursor;
@@ -2897,12 +2908,19 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                     self.invalidateFor(.state, self.views[view_index].frame);
                 }
             }
-            // Logical tree/list navigation may name a row before geometry
-            // filtering so a scroll viewport can reveal it. If no runtime-
-            // owned scroll ancestor actually made the row visible (for
-            // example, a fixed clip_content card), keep focus on the current
-            // target instead of committing an invisible, unroutable id.
-            if (target_id != 0 and self.views[view_index].widgetLayoutTree().focusTargetById(target_id) == null) return;
+
+            // A fixed clip cannot be repaired by scrolling. Re-check the
+            // pointer-visible contract only after every scrollable ancestor
+            // has had its chance to reveal the logical target.
+            const target = self.views[view_index].widgetLayoutTree().focusTargetById(target_id) orelse return null;
+            return .{ .target = target, .scroll_dirty = scroll_dirty };
+        }
+
+        fn setCanvasWidgetFocusFromKeyboardWithVisibility(self: *Runtime, view_index: usize, target_id: canvas.ObjectId, focus_visible: bool) anyerror!void {
+            const next_focus_visible_id: canvas.ObjectId = if (focus_visible) target_id else 0;
+            if (self.views[view_index].canvas_widget_focused_id == target_id and self.views[view_index].canvas_widget_focus_visible_id == next_focus_visible_id) return;
+
+            const reveal = try revealCanvasWidgetFocusTarget(self, view_index, target_id) orelse return;
             const previous_state = self.views[view_index].canvasWidgetRenderState();
             self.views[view_index].canvas_widget_focused_id = target_id;
             self.views[view_index].canvas_widget_focus_visible_id = next_focus_visible_id;
@@ -2935,7 +2953,7 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
                 }
             }
             try invalidateForCanvasWidgetRenderStateChange(self, view_index, previous_state, self.views[view_index].canvasWidgetRenderState());
-            if (scroll_dirty != null) {
+            if (reveal.scroll_dirty != null) {
                 _ = try runtime_canvas_widget_display.RuntimeCanvasWidgetDisplay(Runtime).refreshCanvasWidgetDisplayListIfOwned(self, view_index);
             }
         }

--- a/src/runtime/canvas_widget_events.zig
+++ b/src/runtime/canvas_widget_events.zig
@@ -2883,6 +2883,20 @@ pub fn RuntimeCanvasWidgetEvents(comptime Runtime: type) type {
             scroll_dirty: ?geometry.RectF,
         };
 
+        /// Validate a programmatic focus reveal without changing retained
+        /// geometry. Automation uses this before asking the platform to
+        /// focus the view, keeping both halves of the operation untouched
+        /// when either the target or the platform focus request is invalid.
+        pub fn canRevealCanvasWidgetFocusTarget(self: *const Runtime, view_index: usize, target_id: canvas.ObjectId) bool {
+            if (view_index >= self.view_count or target_id == 0) return false;
+            const layout = self.views[view_index].widgetLayoutTree();
+            if (layout.focusTargetById(target_id) == null) {
+                const node_index = canvas_widget_runtime.canvasWidgetLayoutNodeIndexById(layout, target_id) orelse return false;
+                _ = canvas_widget_runtime.canvasWidgetLogicalFocusTarget(layout, node_index) orelse return false;
+            }
+            return self.views[view_index].canScrollCanvasWidgetIntoView(target_id);
+        }
+
         /// Resolve a programmatic focus target without applying the pointer
         /// path's geometry clip first, reveal it through runtime-owned scroll
         /// ancestors, then re-verify the ordinary visible focus contract.

--- a/src/runtime/canvas_widget_runtime.zig
+++ b/src/runtime/canvas_widget_runtime.zig
@@ -1879,18 +1879,7 @@ fn canvasWidgetTreeRowFocusTarget(layout: canvas.WidgetLayoutTree, node_index: u
 /// geometry clip check performed by `WidgetLayoutTree.focusTargetById`. The
 /// shared reveal seam scrolls this target into view before focus commits.
 pub fn canvasWidgetLogicalFocusTarget(layout: canvas.WidgetLayoutTree, node_index: usize) ?canvas.WidgetFocusTarget {
-    if (node_index >= layout.nodes.len) return null;
-    if (canvas.isWidgetHiddenInAncestors(layout, node_index)) return null;
-    if (canvas.isWidgetConcealedByDisclosure(layout, node_index)) return null;
-    const node = layout.nodes[node_index];
-    if (!canvas.widgetIsFocusable(node.widget)) return null;
-    return .{
-        .id = node.widget.id,
-        .kind = node.widget.kind,
-        .bounds = node.frame,
-        .index = node_index,
-        .state = node.widget.state,
-    };
+    return layout.logicalFocusTargetAtIndex(node_index);
 }
 
 /// The tree keymap's focus moves. Up/Down walk the scope's rows in node

--- a/src/runtime/canvas_widget_runtime.zig
+++ b/src/runtime/canvas_widget_runtime.zig
@@ -1872,13 +1872,13 @@ fn canvasWidgetTreeRowFocusTarget(layout: canvas.WidgetLayoutTree, node_index: u
     return canvasWidgetLogicalFocusTarget(layout, node_index);
 }
 
-/// A roving group must be able to name its next LOGICAL row even when a
-/// scroll ancestor clips that row out of the current viewport. Keep every
-/// other focus gate (identity, disabled/hidden state, hidden ancestors,
-/// concealed disclosure content), but deliberately omit only the geometry
-/// clip check performed by `WidgetLayoutTree.focusTargetById`. The runtime
-/// scrolls this target into view before it commits focus.
-fn canvasWidgetLogicalFocusTarget(layout: canvas.WidgetLayoutTree, node_index: usize) ?canvas.WidgetFocusTarget {
+/// Keyboard roving and programmatic focus must be able to name a LOGICAL
+/// target even when a scroll ancestor clips it out of the current viewport.
+/// Keep every other focus gate (identity, disabled/hidden state, hidden
+/// ancestors, concealed disclosure content), but deliberately omit only the
+/// geometry clip check performed by `WidgetLayoutTree.focusTargetById`. The
+/// shared reveal seam scrolls this target into view before focus commits.
+pub fn canvasWidgetLogicalFocusTarget(layout: canvas.WidgetLayoutTree, node_index: usize) ?canvas.WidgetFocusTarget {
     if (node_index >= layout.nodes.len) return null;
     if (canvas.isWidgetHiddenInAncestors(layout, node_index)) return null;
     if (canvas.isWidgetConcealedByDisclosure(layout, node_index)) return null;

--- a/src/runtime/canvas_widget_scroll_tests.zig
+++ b/src/runtime/canvas_widget_scroll_tests.zig
@@ -2031,9 +2031,17 @@ test "a surface anchored to the scroll region itself never rides its content" {
         .{ .widget = .{ .id = 1, .kind = .scroll_view, .frame = geometry.RectF.init(0, 0, 180, 72) }, .frame = geometry.RectF.init(0, 0, 180, 72), .depth = 0 },
         .{ .widget = .{ .id = 2, .kind = .panel, .frame = geometry.RectF.init(0, 0, 160, 200) }, .frame = geometry.RectF.init(0, 0, 160, 200), .depth = 1, .parent_index = 0 },
         .{ .widget = .{ .id = 4, .kind = .popover, .frame = geometry.RectF.init(20, 40, 100, 30), .layout = .{ .anchor = .{ .placement = .below } } }, .frame = geometry.RectF.init(20, 40, 100, 30), .depth = 2, .parent_index = 1 },
-        .{ .widget = .{ .id = 3, .kind = .popover, .frame = geometry.RectF.init(10, 72, 100, 30), .layout = .{ .anchor = .{ .placement = .below } } }, .frame = geometry.RectF.init(10, 72, 100, 30), .depth = 1, .parent_index = 0 },
+        .{ .widget = .{ .id = 3, .kind = .popover, .frame = geometry.RectF.init(10, 72, 100, 30), .layout = .{ .anchor = .{ .placement = .below } }, .semantics = .{ .focusable = true } }, .frame = geometry.RectF.init(10, 72, 100, 30), .depth = 1, .parent_index = 0 },
     };
     _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", .{ .nodes = &nodes });
+
+    // Programmatic reveal recognizes that the target itself is hoisted:
+    // it can take focus without scrolling the region behind it.
+    _ = try harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 3, .action = .focus });
+    var retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    try std.testing.expectEqual(@as(canvas.ObjectId, 3), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(f32, 0), retained.findById(1).?.widget.value);
+    try std.testing.expectEqualDeep(geometry.RectF.init(10, 72, 100, 30), retained.findById(3).?.frame);
 
     try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
         .window_id = 1,
@@ -2045,7 +2053,7 @@ test "a surface anchored to the scroll region itself never rides its content" {
         .delta_y = 24,
     } });
 
-    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
     try std.testing.expectEqual(@as(f32, 24), retained.findById(1).?.widget.value);
     // Content and the content-anchored surface moved up together...
     try std.testing.expectEqualDeep(geometry.RectF.init(0, -24, 160, 200), retained.findById(2).?.frame);

--- a/src/runtime/canvas_widget_semantics_tests.zig
+++ b/src/runtime/canvas_widget_semantics_tests.zig
@@ -690,10 +690,11 @@ test "runtime applies source-driven autofocus on the edge, never on the level" {
     try std.testing.expectEqual(@as(canvas.ObjectId, 0), harness.runtime.views[0].canvas_widget_focused_id);
 
     // An editor MOUNTING with autofocus takes keyboard focus (view focus
-    // included) on the rebuild that applies it.
+    // included) on the rebuild that applies it. With no source selection,
+    // programmatic focus collapses the caret at the END of non-empty text.
     const editing = [_]canvas.Widget{
         .{ .id = 2, .kind = .button, .frame = geometry.RectF.init(10, 10, 96, 32), .text = "New" },
-        .{ .id = 7, .kind = .text_field, .frame = geometry.RectF.init(10, 56, 200, 32), .autofocus = true },
+        .{ .id = 7, .kind = .text_field, .frame = geometry.RectF.init(10, 56, 200, 32), .text = "Draft", .autofocus = true },
     };
     var editing_nodes: [3]canvas.WidgetLayoutNode = undefined;
     const editing_layout = try canvas.layoutWidgetTree(.{ .kind = .stack, .children = &editing }, geometry.RectF.init(0, 0, 320, 240), &editing_nodes);
@@ -702,7 +703,7 @@ test "runtime applies source-driven autofocus on the edge, never on the level" {
     try std.testing.expectEqual(@as(canvas.ObjectId, 7), harness.runtime.views[0].canvas_widget_focus_visible_id);
     try std.testing.expect(harness.runtime.views[0].focused);
     const focused_layout = try harness.runtime.canvasWidgetLayout(1, "canvas");
-    try std.testing.expectEqualDeep(canvas.TextSelection.collapsed(0), focused_layout.findById(7).?.widget.text_selection.?);
+    try std.testing.expectEqualDeep(canvas.TextSelection.collapsed(5), focused_layout.findById(7).?.widget.text_selection.?);
 
     // The user moves focus; re-applying the SAME layout (flag held true)
     // must not steal it back — edge-triggered, level-ignored.
@@ -728,6 +729,155 @@ test "runtime applies source-driven autofocus on the edge, never on the level" {
     _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", plain_layout);
     _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", editing_layout);
     try std.testing.expectEqual(@as(canvas.ObjectId, 7), harness.runtime.views[0].canvas_widget_focused_id);
+}
+
+test "runtime autofocus reveals an offscreen textarea and its end caret" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-autofocus-reveal", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    try harness.start(app_state.app());
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 180, 64),
+    });
+
+    const text = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight";
+    const children = [_]canvas.Widget{.{
+        .id = 2,
+        .kind = .textarea,
+        .frame = geometry.RectF.init(0, 96, 0, 48),
+        .text = text,
+        .autofocus = true,
+    }};
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .scroll_view, .children = &children },
+        geometry.RectF.init(0, 0, 180, 64),
+        &nodes,
+    );
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focus_visible_id);
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    const scroll = retained.findById(1).?;
+    const editor = retained.findById(2).?;
+    const viewport = scroll.frame.normalized();
+    try std.testing.expect(scroll.widget.value > 0);
+    try std.testing.expect(editor.frame.y >= viewport.y);
+    try std.testing.expect(editor.frame.maxY() <= viewport.maxY());
+    try std.testing.expectEqualDeep(canvas.TextSelection.collapsed(text.len), editor.widget.text_selection.?);
+    try std.testing.expect(editor.widget.value > 0);
+
+    const editor_viewport = canvas.textInputViewportForWidget(editor.widget, harness.runtime.views[0].widget_tokens).?;
+    const text_geometry = try harness.runtime.canvasWidgetTextGeometry(1, "canvas", 2);
+    const caret = text_geometry.caret_bounds.?;
+    try std.testing.expect(caret.y >= editor_viewport.y - 0.001);
+    try std.testing.expect(caret.maxY() <= editor_viewport.maxY() + 0.001);
+}
+
+test "runtime autofocus preserves a source-declared text selection" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-autofocus-selection", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    try harness.start(app_state.app());
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 240, 120),
+    });
+
+    const selection = canvas.TextSelection{ .anchor = 2, .focus = 8 };
+    const children = [_]canvas.Widget{.{
+        .id = 2,
+        .kind = .text_field,
+        .frame = geometry.RectF.init(12, 16, 180, 32),
+        .text = "A selected draft",
+        .text_selection = selection,
+        .autofocus = true,
+    }};
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(.{ .kind = .stack, .children = &children }, geometry.RectF.init(0, 0, 240, 120), &nodes);
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    try std.testing.expectEqualDeep(selection, retained.findById(2).?.widget.text_selection.?);
+}
+
+test "automation focus reveals an offscreen field and its end caret" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-automation-focus-reveal", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    const app = app_state.app();
+    try harness.start(app);
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 180, 64),
+    });
+
+    const text = "This field is deliberately much wider than its viewport";
+    const children = [_]canvas.Widget{.{
+        .id = 2,
+        .kind = .text_field,
+        .frame = geometry.RectF.init(0, 96, 96, 32),
+        .text = text,
+    }};
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .scroll_view, .children = &children },
+        geometry.RectF.init(0, 0, 180, 64),
+        &nodes,
+    );
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 0), harness.runtime.views[0].canvas_widget_focused_id);
+
+    _ = try harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 2, .action = .focus });
+
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    const scroll = retained.findById(1).?;
+    const field = retained.findById(2).?;
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expect(scroll.widget.value > 0);
+    try std.testing.expect(field.frame.y >= scroll.frame.y);
+    try std.testing.expect(field.frame.maxY() <= scroll.frame.maxY());
+    try std.testing.expectEqualDeep(canvas.TextSelection.collapsed(text.len), field.widget.text_selection.?);
+    try std.testing.expect(field.widget.value > 0);
+
+    const field_viewport = canvas.textInputViewportForWidget(field.widget, harness.runtime.views[0].widget_tokens).?;
+    const text_geometry = try harness.runtime.canvasWidgetTextGeometry(1, "canvas", 2);
+    const caret = text_geometry.caret_bounds.?;
+    try std.testing.expect(caret.x >= field_viewport.x - 0.001);
+    try std.testing.expect(caret.maxX() <= field_viewport.maxX() + 0.001);
 }
 
 test "runtime keeps programmatic focus quiet on buttons and rings editables" {

--- a/src/runtime/canvas_widget_semantics_tests.zig
+++ b/src/runtime/canvas_widget_semantics_tests.zig
@@ -939,8 +939,25 @@ test "failed automation focus reveal preserves ancestor scroll and prior focus" 
 
 test "automation focus reveals an offscreen field and its end caret" {
     const TestApp = struct {
+        scroll_event_count: u32 = 0,
+        last_scroll_id: canvas.ObjectId = 0,
+        last_scroll: canvas.ScrollState = .{},
+
         fn app(self: *@This()) App {
-            return .{ .context = self, .name = "gpu-widget-automation-focus-reveal", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+            return .{ .context = self, .name = "gpu-widget-automation-focus-reveal", .source = platform.WebViewSource.html("<h1>Hello</h1>"), .event_fn = event };
+        }
+
+        fn event(context: *anyopaque, runtime: *Runtime, event_value: Event) anyerror!void {
+            _ = runtime;
+            const self: *@This() = @ptrCast(@alignCast(context));
+            switch (event_value) {
+                .canvas_widget_scroll => |scroll_event| {
+                    self.scroll_event_count += 1;
+                    self.last_scroll_id = scroll_event.id;
+                    self.last_scroll = scroll_event.scroll;
+                },
+                else => {},
+            }
         }
     };
 
@@ -975,6 +992,10 @@ test "automation focus reveals an offscreen field and its end caret" {
     try std.testing.expectEqual(@as(canvas.ObjectId, 0), harness.runtime.views[0].canvas_widget_focused_id);
 
     _ = try harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 2, .action = .focus });
+    try std.testing.expectEqual(@as(u32, 1), app_state.scroll_event_count);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 1), app_state.last_scroll_id);
+    try std.testing.expect(app_state.last_scroll.offset_y > 0);
+    try std.testing.expectEqual(@as(usize, 0), harness.runtime.views[0].widget_scroll_event_count);
 
     const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
     const scroll = retained.findById(1).?;
@@ -991,6 +1012,56 @@ test "automation focus reveals an offscreen field and its end caret" {
     const caret = text_geometry.caret_bounds.?;
     try std.testing.expect(caret.x >= field_viewport.x - 0.001);
     try std.testing.expect(caret.maxX() <= field_viewport.maxX() + 0.001);
+}
+
+test "failed view focus leaves automation reveal scroll untouched" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-focus-reveal-rollback", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    const app = app_state.app();
+    try harness.start(app);
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 180, 64),
+        .visible = false,
+    });
+
+    const children = [_]canvas.Widget{.{
+        .id = 2,
+        .kind = .button,
+        .frame = geometry.RectF.init(0, 96, 96, 32),
+        .text = "Hidden view action",
+    }};
+    var nodes: [2]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .scroll_view, .children = &children },
+        geometry.RectF.init(0, 0, 180, 64),
+        &nodes,
+    );
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+    const before = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    const target_frame = before.findById(2).?.frame;
+
+    try std.testing.expectError(
+        error.UnsupportedViewFocus,
+        harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 2, .action = .focus }),
+    );
+
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    try std.testing.expectEqual(@as(f32, 0), retained.findById(1).?.widget.value);
+    try std.testing.expectEqualDeep(target_frame, retained.findById(2).?.frame);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 0), harness.runtime.views[0].canvas_widget_focused_id);
+    try std.testing.expectEqual(@as(usize, 0), harness.runtime.views[0].widget_scroll_event_count);
 }
 
 test "runtime keeps programmatic focus quiet on buttons and rings editables" {

--- a/src/runtime/canvas_widget_semantics_tests.zig
+++ b/src/runtime/canvas_widget_semantics_tests.zig
@@ -824,6 +824,119 @@ test "runtime autofocus preserves a source-declared text selection" {
     try std.testing.expectEqualDeep(selection, retained.findById(2).?.widget.text_selection.?);
 }
 
+test "runtime autofocus accepts a focusable virtual scroll-semantic container" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-autofocus-virtual-table", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    try harness.start(app_state.app());
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 240, 80),
+    });
+
+    const children = [_]canvas.Widget{.{
+        .id = 2,
+        .kind = .table,
+        .frame = geometry.RectF.init(0, 96, 0, 80),
+        .autofocus = true,
+        .layout = .{
+            .virtualized = true,
+            .virtual_item_count = 20,
+            .virtual_item_extent = 24,
+        },
+        .semantics = .{ .label = "Virtual results" },
+    }};
+    const root_children = [_]canvas.Widget{.{
+        .id = 1,
+        .kind = .scroll_view,
+        .frame = geometry.RectF.init(0, 0, 240, 80),
+        .children = &children,
+    }};
+    var nodes: [3]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 10, .kind = .card, .layout = .{ .clip_content = true }, .children = &root_children },
+        geometry.RectF.init(0, 0, 240, 80),
+        &nodes,
+    );
+    try std.testing.expect(!canvas.widgetIsFocusable(layout.nodes[2].widget));
+    try std.testing.expect(layout.focusTargetById(2) == null);
+    try std.testing.expect(layout.logicalFocusTargetAtIndex(2) != null);
+
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    try std.testing.expect(retained.findById(1).?.widget.value > 0);
+}
+
+test "failed automation focus reveal preserves ancestor scroll and prior focus" {
+    const TestApp = struct {
+        fn app(self: *@This()) App {
+            return .{ .context = self, .name = "gpu-widget-focus-fixed-clip", .source = platform.WebViewSource.html("<h1>Hello</h1>") };
+        }
+    };
+
+    const harness = try TestHarness().create(std.testing.allocator, .{});
+    defer harness.destroy(std.testing.allocator);
+    harness.null_platform.gpu_surfaces = true;
+    var app_state: TestApp = .{};
+    const app = app_state.app();
+    try harness.start(app);
+
+    _ = try harness.runtime.createView(.{
+        .window_id = 1,
+        .label = "canvas",
+        .kind = .gpu_surface,
+        .frame = geometry.RectF.init(0, 0, 180, 64),
+    });
+
+    const clipped_target = [_]canvas.Widget{.{
+        .id = 4,
+        .kind = .button,
+        .frame = geometry.RectF.init(0, 0, 0, 24),
+        .text = "Hidden action",
+    }};
+    const children = [_]canvas.Widget{
+        .{ .id = 2, .kind = .button, .frame = geometry.RectF.init(0, 0, 0, 32), .text = "Standing focus" },
+        .{ .kind = .text, .frame = geometry.RectF.init(0, 0, 0, 64), .text = "Spacer" },
+        .{
+            .id = 3,
+            .kind = .card,
+            .frame = geometry.RectF.init(0, 0, 0, 32),
+            .layout = .{ .clip_content = true, .padding = .{ .top = 40 } },
+            .children = &clipped_target,
+        },
+    };
+    var nodes: [5]canvas.WidgetLayoutNode = undefined;
+    const layout = try canvas.layoutWidgetTree(
+        .{ .id = 1, .kind = .scroll_view, .children = &children },
+        geometry.RectF.init(0, 0, 180, 64),
+        &nodes,
+    );
+    try std.testing.expect(layout.focusTargetById(4) == null);
+    _ = try harness.runtime.setCanvasWidgetLayout(1, "canvas", layout);
+    _ = try harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 2, .action = .focus });
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+
+    try std.testing.expectError(
+        error.InvalidCommand,
+        harness.runtime.dispatchCanvasWidgetAccessibilityAction(app, 1, "canvas", .{ .id = 4, .action = .focus }),
+    );
+
+    const retained = try harness.runtime.canvasWidgetLayout(1, "canvas");
+    try std.testing.expectEqual(@as(f32, 0), retained.findById(1).?.widget.value);
+    try std.testing.expectEqual(@as(canvas.ObjectId, 2), harness.runtime.views[0].canvas_widget_focused_id);
+}
+
 test "automation focus reveals an offscreen field and its end caret" {
     const TestApp = struct {
         fn app(self: *@This()) App {

--- a/src/runtime/canvas_widget_state.zig
+++ b/src/runtime/canvas_widget_state.zig
@@ -203,11 +203,20 @@ pub fn RuntimeCanvasWidgetState(comptime Runtime: type) type {
             if (render_state_changed) CanvasWidgetEventMethods(Runtime).invalidateForCanvasWidgetRenderStateDirty(self, index, render_state_dirty);
             const layout_dirty = invalidations.len > 0 or render_state_changed;
             if (autofocus_target) |autofocus_id| {
-                // The same focus write every other focus source performs
-                // (view focus + focused/visible ids + invalidation);
-                // widgets that are not focusable ignore the request.
-                if (self.views[index].widgetLayoutTree().focusTargetById(autofocus_id) != null) {
-                    try AutomationWidgetMethods(Runtime).focusAutomationCanvasWidget(self, index, autofocus_id);
+                // Autofocus is programmatic, not pointer hit testing: admit a
+                // logically focusable target even while a scroll ancestor
+                // clips it, then let the shared automation/keyboard reveal
+                // seam scroll, reconcile, and re-verify before focus lands.
+                // A disabled/hidden/fixed-clipped target still consumes the
+                // source edge; holding autofocus true never retries or steals.
+                const retained_layout = self.views[index].widgetLayoutTree();
+                if (canvas_widget_runtime.canvasWidgetLayoutNodeIndexById(retained_layout, autofocus_id)) |autofocus_index| {
+                    if (canvas_widget_runtime.canvasWidgetLogicalFocusTarget(retained_layout, autofocus_index) != null) {
+                        AutomationWidgetMethods(Runtime).focusAutomationCanvasWidget(self, index, autofocus_id) catch |err| switch (err) {
+                            error.InvalidCommand => {},
+                            else => return err,
+                        };
+                    }
                 }
             }
             self.frame_profile.end(.reconcile, reconcile_begin);

--- a/src/runtime/canvas_widget_state.zig
+++ b/src/runtime/canvas_widget_state.zig
@@ -13,6 +13,7 @@ const runtime_canvas_widget_display = @import("canvas_widget_display.zig");
 const runtime_view = @import("view.zig");
 const runtime_canvas_widget_events = @import("canvas_widget_events.zig");
 const runtime_automation_widget_dispatch = @import("automation_widget_dispatch.zig");
+const runtime_gpu_surface_events = @import("gpu_surface_events.zig");
 const widget_bridge = @import("widget_bridge.zig");
 
 const validateViewLabel = validation.validateViewLabel;
@@ -355,6 +356,11 @@ pub fn RuntimeCanvasWidgetState(comptime Runtime: type) type {
                 .drop_files => try AutomationWidgetMethods(Runtime).dispatchAutomationCanvasWidgetFileDrop(self, app, index, action.id, action.text),
                 .dismiss => try AutomationWidgetMethods(Runtime).dismissAutomationCanvasWidget(self, app, index, action.id),
             }
+            // A direct focus action can reveal an offscreen target without
+            // passing through the GPU input dispatcher. Deliver the pending
+            // scroll observation in this semantic-action transaction too,
+            // rather than leaving it parked until unrelated future input.
+            try runtime_gpu_surface_events.RuntimeGpuSurfaceEvents(Runtime).dispatchPendingCanvasWidgetScrollEvents(self, app, index);
             // Key-driven action routes above dispatch real input events
             // whose refresh batches defer the platform publish; the AX
             // client reads the tree next, so force-flush here too.

--- a/src/runtime/ui_app_tests.zig
+++ b/src/runtime/ui_app_tests.zig
@@ -3388,17 +3388,23 @@ fn autofocusUpdate(model: *AutofocusModel, msg: AutofocusMsg) void {
 /// must receive the keyboard without a click.
 fn autofocusView(ui: *AutofocusApp.Ui, model: *const AutofocusModel) AutofocusApp.Ui.Node {
     if (!model.editing) {
-        return ui.column(.{ .gap = 8, .padding = 12 }, .{
-            ui.button(.{ .on_press = AutofocusMsg.begin_edit }, "New note"),
+        return ui.column(.{ .padding = 12 }, .{
+            ui.scroll(.{ .height = 96 }, ui.column(.{ .gap = 8 }, .{
+                ui.button(.{ .on_press = AutofocusMsg.begin_edit }, "New note"),
+                ui.text(.{ .height = 120 }, "Recent notes"),
+            })),
         });
     }
-    return ui.column(.{ .gap = 8, .padding = 12 }, .{
-        ui.button(.{ .on_press = AutofocusMsg.begin_edit }, "New note"),
-        ui.textField(.{
-            .autofocus = true,
-            .text = model.draft.text(),
-            .on_input = AutofocusApp.Ui.inputMsg(.draft_edit),
-        }),
+    return ui.column(.{ .padding = 12 }, .{
+        ui.scroll(.{ .height = 96 }, ui.column(.{ .gap = 8 }, .{
+            ui.button(.{ .on_press = AutofocusMsg.begin_edit }, "New note"),
+            ui.text(.{ .height = 120 }, "Recent notes"),
+            ui.textField(.{
+                .autofocus = true,
+                .text = model.draft.text(),
+                .on_input = AutofocusApp.Ui.inputMsg(.draft_edit),
+            }),
+        })),
     });
 }
 
@@ -3453,12 +3459,20 @@ test "ui app autofocus moves the keyboard to a freshly mounted editor through th
     }
     try std.testing.expectEqual(@as(canvas.ObjectId, 0), harness.runtime.views[view_index].canvas_widget_focused_id);
 
-    // The Cmd-N-shaped command mounts the editor; the rebuild's
-    // autofocus edge moves keyboard focus to it — no click.
+    // The Cmd-N-shaped command mounts the editor BELOW the scroll
+    // viewport; the rebuild's autofocus edge reveals it and moves
+    // keyboard focus to it — no click.
     try harness.runtime.dispatchPlatformEvent(app, .{ .menu_command = .{ .name = "note.new", .window_id = 1 } });
     try std.testing.expect(app_state.model.editing);
     const field_id = findWidgetIdByKind(app_state.tree.?.root, .text_field).?;
+    const scroll_id = findWidgetIdByKind(app_state.tree.?.root, .scroll_view).?;
     try std.testing.expectEqual(field_id, harness.runtime.views[view_index].canvas_widget_focused_id);
+    var retained = try harness.runtime.canvasWidgetLayout(1, autofocus_canvas_label);
+    const scroll = retained.findById(scroll_id).?;
+    const field = retained.findById(field_id).?;
+    try std.testing.expect(scroll.widget.value > 0);
+    try std.testing.expect(field.frame.y >= scroll.frame.y);
+    try std.testing.expect(field.frame.maxY() <= scroll.frame.maxY());
 
     // Typing lands in the model through the ordinary input path.
     try harness.runtime.dispatchPlatformEvent(app, .{ .gpu_surface_input = .{
@@ -3470,10 +3484,18 @@ test "ui app autofocus moves the keyboard to a freshly mounted editor through th
     try std.testing.expectEqualStrings("Groceries", app_state.model.draft.text());
     try std.testing.expect(app_state.model.edit_count > 0);
 
-    // A later rebuild with the flag still true never re-steals focus:
-    // click the button (its press dispatches begin_edit and rebuilds).
+    // A later rebuild with the flag still true never re-steals focus.
+    // Programmatically focusing the now-offscreen button first also proves
+    // the shared automation focus verb reveals logical targets; its real
+    // click then dispatches begin_edit and rebuilds.
     const button_id = findWidgetIdByKind(app_state.tree.?.root, .button).?;
     var command_buffer: [96]u8 = undefined;
+    const focus_command = try std.fmt.bufPrint(&command_buffer, "widget-action {s} {d} focus", .{ autofocus_canvas_label, button_id });
+    try harness.runtime.dispatchAutomationCommand(app, focus_command);
+    try std.testing.expectEqual(button_id, harness.runtime.views[view_index].canvas_widget_focused_id);
+    retained = try harness.runtime.canvasWidgetLayout(1, autofocus_canvas_label);
+    try std.testing.expectEqual(@as(f32, 0), retained.findById(scroll_id).?.widget.value);
+
     const click_command = try std.fmt.bufPrint(&command_buffer, "widget-click {s} {d}", .{ autofocus_canvas_label, button_id });
     try harness.runtime.dispatchAutomationCommand(app, click_command);
     try std.testing.expectEqual(button_id, harness.runtime.views[view_index].canvas_widget_focused_id);

--- a/src/runtime/view.zig
+++ b/src/runtime/view.zig
@@ -864,6 +864,7 @@ pub const RuntimeView = struct {
     pub const applyCanvasWidgetTextareaScroll = CanvasWidgetScrollMethods.applyCanvasWidgetTextareaScroll;
     pub const applyCanvasWidgetScrollDriverOffset = CanvasWidgetScrollMethods.applyCanvasWidgetScrollDriverOffset;
     pub const applyCanvasWidgetScrollKeyboardTarget = CanvasWidgetScrollMethods.applyCanvasWidgetScrollKeyboardTarget;
+    pub const canScrollCanvasWidgetIntoView = CanvasWidgetScrollMethods.canScrollCanvasWidgetIntoView;
     pub const scrollCanvasWidgetIntoView = CanvasWidgetScrollMethods.scrollCanvasWidgetIntoView;
     pub const stepCanvasWidgetKineticScroll = CanvasWidgetScrollMethods.stepCanvasWidgetKineticScroll;
     pub const canvasWidgetScrollContentExtent = CanvasWidgetScrollMethods.canvasWidgetScrollContentExtent;

--- a/src/runtime/view_widget_scroll.zig
+++ b/src/runtime/view_widget_scroll.zig
@@ -6,6 +6,7 @@ const canvas_widget_runtime = @import("canvas_widget_runtime.zig");
 
 const unionRects = canvas_frame_helpers.unionRects;
 const CanvasWidgetScrollKeyboardTarget = canvas_widget_runtime.CanvasWidgetScrollKeyboardTarget;
+const canvasWidgetClipsContent = canvas_widget_runtime.canvasWidgetClipsContent;
 const canvasWidgetScrollableKind = canvas_widget_runtime.canvasWidgetScrollableKind;
 const canvasWidgetSingleLineTextKind = canvas_widget_runtime.canvasWidgetSingleLineTextKind;
 
@@ -27,6 +28,23 @@ fn unionOptionalRects(a: ?geometry.RectF, b: ?geometry.RectF) ?geometry.RectF {
     const first = a orelse return b;
     const second = b orelse return first;
     return unionRects(first, second);
+}
+
+fn canvasWidgetRevealAxisRequestedDelta(comptime axis: canvas.ScrollAxis, target: geometry.RectF, viewport: geometry.RectF) f32 {
+    return switch (axis) {
+        .vertical => if (target.y < viewport.y)
+            target.y - viewport.y
+        else if (target.maxY() > viewport.maxY())
+            target.maxY() - viewport.maxY()
+        else
+            0,
+        .horizontal => if (target.x < viewport.x)
+            target.x - viewport.x
+        else if (target.maxX() > viewport.maxX())
+            target.maxX() - viewport.maxX()
+        else
+            0,
+    };
 }
 
 pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
@@ -387,6 +405,12 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
         /// normal routable focus target in the same key event.
         pub fn scrollCanvasWidgetIntoView(self: *RuntimeView, id: canvas.ObjectId) anyerror!?geometry.RectF {
             const target_index = self.canvasWidgetNodeIndexById(id) orelse return null;
+            // Prove the whole reveal before mutating the first retained
+            // offset. A fixed clip outside a runtime scroll can never be
+            // repaired by scrolling an outer ancestor; partially applying
+            // that attempt used to jump the viewport (and could clear the
+            // old focus) before the caller rejected the still-hidden target.
+            if (!canvasWidgetCanScrollIntoView(self, target_index)) return null;
             var dirty: ?geometry.RectF = null;
             var current = self.widget_layout_nodes[target_index].parent_index;
             while (current) |ancestor_index| {
@@ -402,24 +426,14 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
                     if (!viewport.isEmpty()) {
                         if (canvas.widgetScrollsAxis(ancestor.widget, .vertical)) {
                             const target = self.widget_layout_nodes[target_index].frame.normalized();
-                            const delta_y: f32 = if (target.y < viewport.y)
-                                target.y - viewport.y
-                            else if (target.maxY() > viewport.maxY())
-                                target.maxY() - viewport.maxY()
-                            else
-                                0;
+                            const delta_y = canvasWidgetRevealAxisRequestedDelta(.vertical, target, viewport);
                             if (delta_y != 0) {
                                 dirty = unionOptionalRects(dirty, try self.applyCanvasWidgetScrollAxis(ancestor_index, .vertical, delta_y, .discrete, false));
                             }
                         }
                         if (canvas.widgetScrollsAxis(ancestor.widget, .horizontal)) {
                             const target = self.widget_layout_nodes[target_index].frame.normalized();
-                            const delta_x: f32 = if (target.x < viewport.x)
-                                target.x - viewport.x
-                            else if (target.maxX() > viewport.maxX())
-                                target.maxX() - viewport.maxX()
-                            else
-                                0;
+                            const delta_x = canvasWidgetRevealAxisRequestedDelta(.horizontal, target, viewport);
                             if (delta_x != 0) {
                                 dirty = unionOptionalRects(dirty, try self.applyCanvasWidgetScrollAxis(ancestor_index, .horizontal, delta_x, .discrete, false));
                             }
@@ -429,6 +443,66 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
                 current = self.widget_layout_nodes[ancestor_index].parent_index;
             }
             return dirty;
+        }
+
+        /// Dry-run `scrollCanvasWidgetIntoView` against one target frame.
+        /// Inner scrolls translate the target before each outer clip is
+        /// tested, exactly like the live walk, but no retained scroll state,
+        /// descendant frame, semantics revision, or pending scroll event is
+        /// touched until every clip has proved revealable.
+        fn canvasWidgetCanScrollIntoView(self: *const RuntimeView, target_index: usize) bool {
+            if (target_index >= self.widget_layout_node_count) return false;
+            var target = self.widget_layout_nodes[target_index].frame.normalized();
+            if (target.isEmpty()) return false;
+
+            var current = self.widget_layout_nodes[target_index].parent_index;
+            while (current) |ancestor_index| {
+                if (ancestor_index >= self.widget_layout_node_count) break;
+                const ancestor = self.widget_layout_nodes[ancestor_index];
+
+                // Window-level surfaces still clip their own descendants;
+                // they only escape clips ABOVE their surface root.
+                if (canvas.widgetEscapesAncestorClips(ancestor.widget)) {
+                    if (canvasWidgetClipsContent(ancestor.widget) and geometry.RectF.intersection(target, ancestor.frame.normalized()).isEmpty()) return false;
+                    break;
+                }
+
+                if (canvasWidgetScrollableKind(ancestor.widget.kind) and ancestor.widget.kind != .textarea) {
+                    const viewport = ancestor.frame.inset(ancestor.widget.layout.padding).normalized();
+                    if (!viewport.isEmpty()) {
+                        const delta_y = canvasWidgetRevealAxisOffsetDelta(self, ancestor_index, .vertical, target, viewport);
+                        const delta_x = canvasWidgetRevealAxisOffsetDelta(self, ancestor_index, .horizontal, target, viewport);
+                        target = target.translate(.{ .dx = -delta_x, .dy = -delta_y });
+                    }
+                }
+
+                if (canvasWidgetClipsContent(ancestor.widget) and geometry.RectF.intersection(target, ancestor.frame.normalized()).isEmpty()) return false;
+                current = ancestor.parent_index;
+            }
+            return true;
+        }
+
+        fn canvasWidgetRevealAxisOffsetDelta(
+            self: *const RuntimeView,
+            scroll_index: usize,
+            comptime axis: canvas.ScrollAxis,
+            target: geometry.RectF,
+            viewport: geometry.RectF,
+        ) f32 {
+            if (scroll_index >= self.widget_layout_node_count) return 0;
+            const scroll_node = self.widget_layout_nodes[scroll_index];
+            if (canvasWidgetModelDrivenVirtual(scroll_node.widget)) return 0;
+            if (!canvas.widgetScrollsAxis(scroll_node.widget, axis)) return 0;
+
+            const requested = canvasWidgetRevealAxisRequestedDelta(axis, target, viewport);
+            if (requested == 0) return 0;
+
+            const current_axis = self.canvasWidgetScrollState(scroll_index, scroll_node, viewport).axis(axis);
+            var next_axis = current_axis;
+            next_axis.offset += requested;
+            next_axis.velocity = 0;
+            next_axis = next_axis.clamped();
+            return next_axis.offset - current_axis.offset;
         }
 
         pub fn stepCanvasWidgetKineticScroll(self: *RuntimeView, dt_ms: f32) anyerror!?geometry.RectF {

--- a/src/runtime/view_widget_scroll.zig
+++ b/src/runtime/view_widget_scroll.zig
@@ -411,6 +411,10 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
             // that attempt used to jump the viewport (and could clear the
             // old focus) before the caller rejected the still-hidden target.
             if (!canvasWidgetCanScrollIntoView(self, target_index)) return null;
+            // The target itself is a hoisted window-level surface. Its
+            // authored scroll ancestors neither clip nor translate it, so
+            // revealing it must not move the content underneath it.
+            if (canvas.widgetEscapesAncestorClips(self.widget_layout_nodes[target_index].widget)) return null;
             var dirty: ?geometry.RectF = null;
             var current = self.widget_layout_nodes[target_index].parent_index;
             while (current) |ancestor_index| {
@@ -445,6 +449,14 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
             return dirty;
         }
 
+        /// Pure preflight for the fallible focus/reveal sequence. Callers
+        /// can validate the entire scroll path before changing platform
+        /// focus or retained scroll offsets.
+        pub fn canScrollCanvasWidgetIntoView(self: *const RuntimeView, id: canvas.ObjectId) bool {
+            const target_index = self.canvasWidgetNodeIndexById(id) orelse return false;
+            return canvasWidgetCanScrollIntoView(self, target_index);
+        }
+
         /// Dry-run `scrollCanvasWidgetIntoView` against one target frame.
         /// Inner scrolls translate the target before each outer clip is
         /// tested, exactly like the live walk, but no retained scroll state,
@@ -454,6 +466,11 @@ pub fn RuntimeViewCanvasWidgetScroll(comptime RuntimeView: type) type {
             if (target_index >= self.widget_layout_node_count) return false;
             var target = self.widget_layout_nodes[target_index].frame.normalized();
             if (target.isEmpty()) return false;
+
+            // A window-level target escapes every ancestor clip at its own
+            // tree position. There is therefore nothing to reveal through
+            // the authored ancestor chain.
+            if (canvas.widgetEscapesAncestorClips(self.widget_layout_nodes[target_index].widget)) return true;
 
             var current = self.widget_layout_nodes[target_index].parent_index;
             while (current) |ancestor_index| {

--- a/tools/native-sdk/markup_docs.zig
+++ b/tools/native-sdk/markup_docs.zig
@@ -130,7 +130,7 @@ pub const attribute_docs = [_]Doc{
     .{ .name = "expanded", .doc = "Tree rows (role=\"treeitem\"): disclosure state (true/false or a {binding}). Omit on leaves; expanded rows collapse on Left, collapsed ones expand on Right, both through on-toggle - the model owns the state." },
     .{ .name = "tree-level", .doc = "Flat sibling rows with role=\"treeitem\": one-based logical depth used by Left/Right to resolve parents and first children. Omit it when tree rows are structurally nested." },
     .{ .name = "label", .doc = "Accessible name; when set it REPLACES the element's text as the announced name - screen readers and automation snapshots see the label, never the text it shadows." },
-    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus). The TEA way to focus an editor on create." },
+    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus), revealing it through ancestor scroll regions first. For editable text, an absent selection becomes a caret collapsed at the end of the text and the editor scrolls to reveal it; an existing selection is preserved. The TEA way to focus an editor on create." },
     .{ .name = "submit-on-enter", .doc = "textarea only: true makes plain Enter dispatch on-submit while Shift+Enter inserts a newline; Cmd/Ctrl+Enter still submits. False or absent keeps the multiline default where Enter inserts and submission uses the primary chord." },
     .{ .name = "icon", .doc = "button, toggle-button, list-item, menu-item: vector icon drawn inline (buttons/toggle-buttons before the label, list/menu items as a leading slot): a built-in name (comptime-validated against canvas.icons.known_icon_names, e.g. save, plus, refresh-cw), an app-registered app:<name>, or one {binding} resolving to such a name. Icon-only buttons when the content is empty — add a label. One hit target, one enabled/disabled tint." },
     .{ .name = "icon-placement", .doc = "Icon slot side on label-bearing buttons/toggle-buttons: leading (default) draws the icon before the label, trailing after it — the next-page chevron. Icon-only buttons center the glyph regardless." },
@@ -200,7 +200,7 @@ pub const stepper_attr_docs = [_]Doc{
     .{ .name = "key", .doc = "Sibling-scoped identity key." },
     .{ .name = "global-key", .doc = "Parent-independent identity: ids survive reparenting between containers." },
     .{ .name = "label", .doc = "Accessible name; when set it REPLACES the element's text as the announced name - screen readers and automation snapshots see the label, never the text it shadows." },
-    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus). The TEA way to focus an editor on create." },
+    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus), revealing it through ancestor scroll regions first. For editable text, an absent selection becomes a caret collapsed at the end of the text and the editor scrolls to reveal it; an existing selection is preserved. The TEA way to focus an editor on create." },
 };
 
 pub const timeline_attr_docs = [_]Doc{
@@ -209,7 +209,7 @@ pub const timeline_attr_docs = [_]Doc{
     .{ .name = "key", .doc = "Sibling-scoped identity key." },
     .{ .name = "global-key", .doc = "Parent-independent identity: ids survive reparenting between containers." },
     .{ .name = "label", .doc = "Accessible name; when set it REPLACES the element's text as the announced name - screen readers and automation snapshots see the label, never the text it shadows." },
-    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus). The TEA way to focus an editor on create." },
+    .{ .name = "autofocus", .doc = "Focusable controls only: moves keyboard focus to the element when it mounts or when the value turns on (edge-triggered - holding it true never re-steals focus), revealing it through ancestor scroll regions first. For editable text, an absent selection becomes a caret collapsed at the end of the text and the editor scrolls to reveal it; an existing selection is preserved. The TEA way to focus an editor on create." },
 };
 
 pub const timeline_item_attr_docs = [_]Doc{


### PR DESCRIPTION
- Share scroll-then-verify focus reveal across keyboard, autofocus, and automation.
- Preserve selection while revealing collapsed end carets inside text editors.
- Cover scrolled focus flows and document the autofocus contract.