### PR TITLE
fix(canvas): respect link span underline flag

### DIFF
--- a/src/primitives/canvas/markdown.zig
+++ b/src/primitives/canvas/markdown.zig
@@ -1530,6 +1530,10 @@ pub fn Markdown(comptime Msg: type) type {
                 if (style.html_small > 0) span.scale = if (span.scale > 0) span.scale * 0.875 else 0.875;
                 if (style.html_heading_level) |level| span.scale = heading_scales[@min(level, heading_scales.len) - 1];
                 if (span.link.len == 0 and style.html_link.len > 0) span.link = style.html_link;
+                // Markdown keeps its conventional underlined-link register,
+                // while the underlying TextSpan renderer leaves decoration
+                // entirely under the span's explicit `underline` flag.
+                if (span.link.len > 0) span.underline = true;
                 appendSpan(spans, len, span);
             }
 

--- a/src/primitives/canvas/markdown_tests.zig
+++ b/src/primitives/canvas/markdown_tests.zig
@@ -187,6 +187,7 @@ test "markdown maps headings, paragraphs, and inline styles onto spans" {
     try testing.expectEqualStrings("gone", spans[7].text);
     try testing.expectEqualStrings("a link", spans[9].text);
     try testing.expectEqualStrings("https://example.com", spans[9].link);
+    try testing.expect(spans[9].underline);
 
     // The link span grew a hit-area child that dispatches on_link's Msg.
     const link_child = paragraph.children[0];

--- a/src/primitives/canvas/text_span_tests.zig
+++ b/src/primitives/canvas/text_span_tests.zig
@@ -435,7 +435,7 @@ fn paragraphView(ui: *SpanUi) SpanUi.Node {
         .{ .text = "Read " },
         .{ .text = "the guide", .link = "https://example.com/guide" },
         .{ .text = " and " },
-        .{ .text = "the spec", .link = "https://example.com/spec" },
+        .{ .text = "the spec", .link = "https://example.com/spec", .underline = true },
     };
     return ui.column(.{ .gap = 8 }, .{
         ui.paragraph(.{ .on_link = SpanUi.linkMsg(.open) }, &spans),
@@ -502,7 +502,7 @@ test "link children get span-derived frames and are hit-testable" {
     try testing.expectEqual(paragraph.id, paragraph_hit.id);
 }
 
-test "span paragraphs emit one text command per run plus link underlines" {
+test "span underline decoration is independent from link behavior" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     var ui = SpanUi.init(arena_state.allocator());
@@ -532,7 +532,9 @@ test "span paragraphs emit one text command per run plus link underlines" {
     }
     // 4 spans on one wide line + the plain trailer text widget.
     try testing.expectEqual(@as(usize, 5), text_commands);
-    try testing.expectEqual(@as(usize, 2), underlines);
+    // Both links keep accent ink and link interaction, but only the second
+    // span explicitly opts into an underline.
+    try testing.expectEqual(@as(usize, 1), underlines);
     try testing.expectEqual(@as(usize, 2), accent_texts);
 }
 

--- a/src/primitives/canvas/text_spans.zig
+++ b/src/primitives/canvas/text_spans.zig
@@ -78,6 +78,8 @@ pub const TextSpan = struct {
     /// backgrounds never affect measurement or layout (#86, intra-line
     /// diff emphasis).
     background: ?TextSpanColor = null,
+    /// Visual underline decoration. Independent from `link`: clickable
+    /// spans remain undecorated unless this is true.
     underline: bool = false,
     strikethrough: bool = false,
     /// Relative size multiplier against the paragraph base size; 0 means

--- a/src/primitives/canvas/widget_render.zig
+++ b/src/primitives/canvas/widget_render.zig
@@ -1611,7 +1611,7 @@ fn emitVisibleTextSpansWidget(
             if (run.text.len == 0) continue;
             const span = widget.spans[run.span_index];
             const is_link = span.link.len > 0;
-            const underline_ordinal: ?usize = if (span.underline or is_link) blk: {
+            const underline_ordinal: ?usize = if (span.underline) blk: {
                 const value = decoration_base +| decoration_ordinal;
                 decoration_ordinal += 1;
                 break :blk value;


### PR DESCRIPTION
- Render span underlines only when explicitly enabled.
- Preserve conventional underlines for Markdown-generated links.
- Cover linked spans with and without underline decoration.