### PR TITLE
fix(macos): report content rects in window frame events

### DIFF
--- a/src/platform/macos/appkit_host.m
+++ b/src/platform/macos/appkit_host.m
@@ -10080,7 +10080,16 @@ static void NativeSdkApplyProcessDisplayName(NSString *displayName) {
 - (void)emitWindowFrameForWindowId:(uint64_t)windowId open:(BOOL)open {
     NSWindow *window = self.windows[@(windowId)] ?: self.window;
     NSString *label = self.windowLabels[@(windowId)] ?: (windowId == 1 ? self.windowLabel : @"");
-    NSRect frame = window.frame;
+    // The frame event's rect is the CONTENT rect in screen coordinates,
+    // never window.frame: every consumer treats these numbers as content
+    // geometry — shell layout bounds, the resize channel
+    // (contentView.bounds), window-state persistence, and
+    // createWindowWithId:'s initWithContentRect: round-trip — and the
+    // GTK/Win32 hosts report content size on the same event. The outer
+    // frame here laid shell views past the content's bottom edge on
+    // open/restore and grew every restored window by the titlebar height
+    // once per launch.
+    NSRect frame = [window contentRectForFrameRect:window.frame];
     [self emitEvent:(native_sdk_appkit_event_t){
         .kind = NATIVE_SDK_APPKIT_EVENT_WINDOW_FRAME,
         .window_id = windowId,

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -2362,13 +2362,18 @@ native_sdk_appkit_host_t *native_sdk_appkit_create(const char *app_name, size_t 
         NSString *aboutDescriptionString = [[NSString alloc] initWithBytes:about_description length:about_description_len encoding:NSUTF8StringEncoding] ?: @"";
         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
         NativeSdkChromiumHost *host = [[NativeSdkChromiumHost alloc] initWithAppName:appNameString displayName:displayNameString version:versionString aboutDescription:aboutDescriptionString dockVisible:(dock_visible != 0) title:titleString width:width height:height];
-        if (restore_frame) {
-            [host.window setFrame:NativeSdkConstrainFrame(NSMakeRect(x, y, width, height)) display:NO];
-        }
+        // Restored coordinates are content geometry, matching the window
+        // frame event and createWindowWithId:'s initWithContentRect: path.
+        // Install the final titlebar first so AppKit can convert that content
+        // rect through the actual chrome before setFrame: consumes it.
+        NativeSdkApplyHiddenInsetTitlebar(host.window, titlebar_style, host.delegates[@1]);
         if (!resizable) {
             host.window.styleMask &= ~NSWindowStyleMaskResizable;
         }
-        NativeSdkApplyHiddenInsetTitlebar(host.window, titlebar_style, host.delegates[@1]);
+        if (restore_frame) {
+            NSRect contentRect = NativeSdkConstrainFrame(NSMakeRect(x, y, width, height));
+            [host.window setFrame:[host.window frameRectForContentRect:contentRect] display:NO];
+        }
         NativeSdkApplyOverlayWindowFlags(host, 1, window_flags);
         if (show_policy == 2) [host.policyHiddenWindows addObject:@1];
         return (__bridge_retained native_sdk_appkit_host_t *)host;

--- a/src/platform/macos/cef_host.mm
+++ b/src/platform/macos/cef_host.mm
@@ -1429,7 +1429,12 @@ static const char *NativeSdkCefBridgeScript() {
 - (void)emitWindowFrameForWindowId:(uint64_t)windowId open:(BOOL)open {
     NSWindow *window = self.windows[@(windowId)] ?: self.window;
     NSString *label = self.windowLabels[@(windowId)] ?: @"";
-    NSRect frame = window.frame;
+    // The frame event's rect is the CONTENT rect in screen coordinates,
+    // never window.frame: consumers treat these numbers as content
+    // geometry (shell layout, the resize channel, window-state
+    // persistence, and the initWithContentRect: round-trip) — see the
+    // AppKit host's emitWindowFrameForWindowId:.
+    NSRect frame = [window contentRectForFrameRect:window.frame];
     [self emitEvent:(native_sdk_appkit_event_t){
         .kind = NATIVE_SDK_APPKIT_EVENT_WINDOW_FRAME,
         .window_id = windowId,


### PR DESCRIPTION
- Emit content geometry consistently from the AppKit and CEF hosts.
- Preserve layout and restore round-trips without titlebar drift.