### PR TITLE
fix(runtime): apply TypeScript core external_links policy

### DIFF
--- a/src/app_runner/ts_core_main.zig
+++ b/src/app_runner/ts_core_main.zig
@@ -9,7 +9,8 @@
 //!   scene / canvas   app.zon's `.shell` through `shellConfigFrom`; the
 //!                    canvas is the scene's first gpu_surface view.
 //!   identity         app.zon's `.id`/`.name`/`.display_name`.
-//!   security         app.zon's `.permissions` and navigation origins.
+//!   security         app.zon's `.permissions`, navigation origins, and
+//!                    `external_links` (Cmd.openExternalUrl allowlist).
 //!   theme            app.zon's `.theme` pack; the stock tokens compose
 //!                    it with the live system appearance. `.theme_accent`
 //!                    layers the manifest's one-accent brand override
@@ -83,6 +84,7 @@ pub const app_markup = @embedFile("app.native");
 
 const app_permissions = manifestStringList(manifest, "permissions");
 const allowed_origins = manifestAllowedOrigins();
+const external_links = manifestExternalLinks();
 const app_data_dir_env = "NATIVE_SDK_APP_DATA_DIR";
 
 pub fn main(init: std.process.Init) !void {
@@ -312,7 +314,10 @@ pub fn main(init: std.process.Init) !void {
         .js_window_api = false,
         .security = .{
             .permissions = app_permissions,
-            .navigation = .{ .allowed_origins = allowed_origins },
+            .navigation = .{
+                .allowed_origins = allowed_origins,
+                .external_links = external_links,
+            },
         },
         .relational_migrations = &relational_migrations.migrations,
     }, init);
@@ -503,4 +508,27 @@ fn manifestAllowedOrigins() []const []const u8 {
         if (!@hasField(@TypeOf(manifest.security), "navigation")) return &.{};
         return manifestStringList(manifest.security.navigation, "allowed_origins");
     }
+}
+
+fn manifestExternalLinks() native_sdk.security.ExternalLinkPolicy {
+    comptime {
+        if (!@hasField(@TypeOf(manifest), "security")) return .{};
+        if (!@hasField(@TypeOf(manifest.security), "navigation")) return .{};
+        if (!@hasField(@TypeOf(manifest.security.navigation), "external_links")) return .{};
+        const links = manifest.security.navigation.external_links;
+        return .{
+            .action = manifestExternalLinkAction(links),
+            .allowed_urls = if (@hasField(@TypeOf(links), "allowed_urls"))
+                manifestStringList(links, "allowed_urls")
+            else
+                &.{},
+        };
+    }
+}
+
+fn manifestExternalLinkAction(comptime links: anytype) native_sdk.security.ExternalLinkAction {
+    if (!@hasField(@TypeOf(links), "action")) return .deny;
+    const action: []const u8 = links.action;
+    if (std.mem.eql(u8, action, "open_system_browser")) return .open_system_browser;
+    return .deny;
 }


### PR DESCRIPTION
## Summary

- TypeScript cores never copied `app.zon` `security.navigation.external_links` into `runWithOptions`, so the policy stayed at the deny-by-default empty allowlist.
- `Cmd.openExternalUrl` is then rejected as `NavigationDenied`. The host send is fire-and-forget (`catch {}`), so allowed HTTP(S) URLs never open a system browser and the app shows no error.
- Zig cores already pass this field. The TypeScript runner now reads `action` and `allowed_urls` from the manifest the same way it already reads navigation origins.

Docs already describe this gate (`https://native-sdk.dev/security`). Wildcard patterns must end in `*` and include a `/` after the host (`https://example.com/*` is valid; `https://example.com*` is not).

## Test plan

- [x] `zig build test` and `zig build validate` (root suites from `scripts/gate.sh fast`)
- [x] `zig build test-examples-frontends` and the render bench-check
- [x] `npm ci --include=dev` in `packages/core`, then `zig build test-examples-native`
- [x] `zig build test-example-kanban` and `zig build test-example-gpu-components` (compile the staged TypeScript runner against real `app.zon` manifests that set `external_links.action = "deny"`)
- [x] Compile the same TypeScript runner with `.external_links = .{ .action = "open_system_browser", .allowed_urls = .{ "https://example.com/*" } }` (temporary local `app.zon` only; not committed). This is the path `native check` does not compile.
- [x] Existing root tests already cover allow/deny once the policy is on the runtime: `allowsExternalUrl` matcher rules, and `openExternalUrl` succeeding for `https://example.com/docs` / failing for a non-matching URL on the null platform
- [x] Live desktop confirmation on this branch (temporary uncommitted `examples/chatbot` harness): `open_system_browser` + `https://example.com/*` opened the system browser to `https://example.com/docs`; `.action = "deny"` on the same button opened nothing and showed no error
- [x] `node --test packages/core/test/services.test.ts` and `packages/core/test/surface_tools.test.ts` (gate-mapped for `src/**`; not specific to this wiring)

`scripts/gate.sh fast` also mapped `examples-mobile`; that step fails on this machine (no Apple iOS SDK) and does not compile `ts_core_main.zig`.