### PR TITLE
chore(release): prepare v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,35 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.9.1
+## 0.9.2
 
 <!-- release:start -->
+
+### New Features
+
+- **Flash-free accessory startup**: Apps can opt into accessory activation from `app.zon` to launch without a Dock icon or foreground flash, with tray-affordance validation, runtime composition, packaging support, and an updated menu-bar example (#358).
+- **Logical canvas radio groups**: Nested radios now form accessible single-selection groups with roving focus and consistent keyboard, pointer, handler, and naming semantics (#361).
+- **Budget-aware photo decoding**: Dynamic encoded images are downsampled across desktop and mobile codecs to fit a configurable registered-pixel budget, with independent source bounds, deterministic replay, and platform-level regression coverage (#366).
+
+### Bug Fixes
+
+- **Correct anchored surfaces**: Floating and modal surfaces now dismiss without requiring focus, relayout after scroll restoration, resolve against the correct root, and behave consistently across window contexts (#363).
+- **Reliable autofocus and caret reveal**: Keyboard focus, autofocus, and automation now transactionally reveal offscreen targets while preserving collapsed end-caret selections in text editors (#364).
+- **Explicit link decoration**: Linked text spans now honor their underline flag while Markdown-generated links retain conventional underlines (#368).
+- **Stable macOS window geometry**: Fresh windows now distinguish restored, explicit, and default placement, while AppKit and CEF frame events consistently report content geometry without titlebar drift (#369, #370).
+
+### Improvements
+
+- **Consistent canvas controls and surfaces**: Checkbox and radio labels can contain markup consistently, while actionable states, disabled colors, variant accents, selection geometry, compact layouts, and zero-width strokes now render uniformly across the schema, runtime, accessibility tree, and documentation (#367).
+
+### Contributors
+
+- @ctate
+- @sepehr-safari
+
+<!-- release:end -->
+
+## 0.9.1
 
 ### New Features
 
@@ -30,8 +56,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 - @ctate
 - @ElSebas41
 - @johnlindquist
-
-<!-- release:end -->
 
 ## 0.9.0
 

--- a/examples/gpu-components/package.json
+++ b/examples/gpu-components/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/menu-bar/package.json
+++ b/examples/menu-bar/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "TypeScript + Native markup menu-bar lifecycle example.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/record-store/package.json
+++ b/examples/record-store/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/relational-notes/package.json
+++ b/examples/relational-notes/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/examples/voice-memo/package.json
+++ b/examples/voice-memo/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.1"
+    "@native-sdk/core": "0.9.2"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "scriptc": "0.0.31"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -35,14 +35,14 @@
     "scriptc": "0.0.31"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.9.1",
-    "@native-sdk/cli-darwin-x64": "0.9.1",
-    "@native-sdk/cli-linux-arm64-gnu": "0.9.1",
-    "@native-sdk/cli-linux-arm64-musl": "0.9.1",
-    "@native-sdk/cli-linux-x64-gnu": "0.9.1",
-    "@native-sdk/cli-linux-x64-musl": "0.9.1",
-    "@native-sdk/cli-win32-arm64": "0.9.1",
-    "@native-sdk/cli-win32-x64": "0.9.1"
+    "@native-sdk/cli-darwin-arm64": "0.9.2",
+    "@native-sdk/cli-darwin-x64": "0.9.2",
+    "@native-sdk/cli-linux-arm64-gnu": "0.9.2",
+    "@native-sdk/cli-linux-arm64-musl": "0.9.2",
+    "@native-sdk/cli-linux-x64-gnu": "0.9.2",
+    "@native-sdk/cli-linux-x64-musl": "0.9.2",
+    "@native-sdk/cli-win32-arm64": "0.9.2",
+    "@native-sdk/cli-win32-x64": "0.9.2"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.9.1";
+const version = "0.9.2";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Synchronize CLI, core, platform package, and example versions to 0.9.2.
- Add release notes and contributors for all changes since v0.9.1.