### PR TITLE
chore(release): prepare v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,30 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.9.2
+## 0.9.3
 
 <!-- release:start -->
+
+### New Features
+
+- **Model-driven TypeScript theme state**: Zero-config TypeScript apps can now derive the built-in pack, color scheme, and accent from committed model state while preserving manifest fallback, live system accessibility settings, deterministic replay, and the existing `themePack` helper (#378).
+- **Platform-correct line deletion**: Command+Backspace on macOS now deletes to the start of a field or logical textarea line across every editable canvas control, with matching TypeScript text helpers, controlled-state behavior, undo, and replay (#377).
+
+### Bug Fixes
+
+- **Precise macOS file-drop routing**: AppKit drops now retain labeled canvas and WebView targets with top-left, view-local coordinates, while unlabeled window regions fall back to content coordinates (#374).
+- **Manifest menus in generated runners**: Zero-config TypeScript and Zig-core apps now load `app.zon` commands, shortcuts, and menus consistently in live and replay runners, including ejected-runner fallbacks (#376).
+- **Large TypeScript message unions compile reliably**: Generated shims now derive comptime scan quotas from message shape and identifier size, allowing wide unions to compile across persistence, channels, environment routing, and the full external-core pipeline (#375).
+- **Correct combobox Enter precedence**: A bound `on-submit` now handles Enter before trigger activation, so query submission no longer opens the picker or dispatches the wrong command (#373).
+
+### Contributors
+
+- @ctate
+- @MohakBajaj
+
+<!-- release:end -->
+
+## 0.9.2
 
 ### New Features
 
@@ -27,8 +48,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 
 - @ctate
 - @sepehr-safari
-
-<!-- release:end -->
 
 ## 0.9.1
 

--- a/examples/gpu-components/package.json
+++ b/examples/gpu-components/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/menu-bar/package.json
+++ b/examples/menu-bar/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "TypeScript + Native markup menu-bar lifecycle example.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/record-store/package.json
+++ b/examples/record-store/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/relational-notes/package.json
+++ b/examples/relational-notes/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/examples/voice-memo/package.json
+++ b/examples/voice-memo/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.2"
+    "@native-sdk/core": "0.9.3"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "scriptc": "0.0.31"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "bin": {
@@ -35,14 +35,14 @@
     "scriptc": "0.0.31"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.9.2",
-    "@native-sdk/cli-darwin-x64": "0.9.2",
-    "@native-sdk/cli-linux-arm64-gnu": "0.9.2",
-    "@native-sdk/cli-linux-arm64-musl": "0.9.2",
-    "@native-sdk/cli-linux-x64-gnu": "0.9.2",
-    "@native-sdk/cli-linux-x64-musl": "0.9.2",
-    "@native-sdk/cli-win32-arm64": "0.9.2",
-    "@native-sdk/cli-win32-x64": "0.9.2"
+    "@native-sdk/cli-darwin-arm64": "0.9.3",
+    "@native-sdk/cli-darwin-x64": "0.9.3",
+    "@native-sdk/cli-linux-arm64-gnu": "0.9.3",
+    "@native-sdk/cli-linux-arm64-musl": "0.9.3",
+    "@native-sdk/cli-linux-x64-gnu": "0.9.3",
+    "@native-sdk/cli-linux-x64-musl": "0.9.3",
+    "@native-sdk/cli-win32-arm64": "0.9.3",
+    "@native-sdk/cli-win32-x64": "0.9.3"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.9.2";
+const version = "0.9.3";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Synchronize CLI, core, platform package, and example versions to 0.9.3.
- Add release notes and contributors for all changes since v0.9.2.