### PR TITLE
fix(build): keep iterative app rebuilds local

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -844,6 +844,10 @@ pub fn build(b: *std.Build) void {
         .{ .path = "build/app.zig", .pattern = "const contract = stabilizeGeneratedFile(b, contract_raw, \"core.contract.json\", build_trace);" },
         .{ .path = "build/app.zig", .pattern = "break :services_contract stabilizeGeneratedFile(b, raw, \"services.contract.json\", build_trace);" },
         .{ .path = "build/app.zig", .pattern = "addAppCoreTsDirInputs(b, stage_run, appPath(b, app_root, \"src\"));" },
+        .{ .path = "build/app.zig", .pattern = "addStagedCoreSdkInputs(b, dep.builder, stage_run);" },
+        .{ .path = "build/app.zig", .pattern = "for ([_][]const u8{ \"text.ts\", \"events.ts\" }) |source|" },
+        .{ .path = "build.zig", .pattern = "app_build.addStagedCoreSdkInputs(b, b, stage_run);" },
+        .{ .path = "packages/core/scripts/stage_external_core.mjs", .pattern = "for (const sdkFile of [\"text.ts\", \"events.ts\"])" },
         .{ .path = "build/app.zig", .pattern = "if (std.mem.startsWith(u8, normalized, \"services/\")) continue;" },
         .{ .path = "tools/corewire/emit_service.zig", .pattern = "native-sdk.services.abi.v3" },
         .{ .path = "tools/corewire/emit_service.zig", .pattern = "implementation-only fingerprint" },
@@ -4042,6 +4046,7 @@ fn externalCoreFixtureModule(
         stage_run.addFileArg(client);
     }
     tsCoreAddCoreDirInputs(b, stage_run, std.fs.path.dirname(spec.entry) orelse ".");
+    app_build.addStagedCoreSdkInputs(b, b, stage_run);
     stage_run.addArg("--out");
     const stage_dir = stage_run.addOutputDirectoryArg("stage");
 

--- a/build.zig
+++ b/build.zig
@@ -848,6 +848,8 @@ pub fn build(b: *std.Build) void {
         .{ .path = "tools/corewire/emit_service.zig", .pattern = "native-sdk.services.abi.v3" },
         .{ .path = "tools/corewire/emit_service.zig", .pattern = "implementation-only fingerprint" },
         .{ .path = "build/app.zig", .pattern = "link_mod.addObject(markupDataObject(b, target, app_optimize, stage.markup_c));" },
+        .{ .path = "build/app.zig", .pattern = "addPlatformLinkSearchPaths(b, selected_platform, web_engine, cef_dir, link_mod);" },
+        .{ .path = "build/app.zig", .pattern = "mod.addFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, \"System/Library/Frameworks\" }) });" },
         .{ .path = "build/app.zig", .pattern = "b.fmt(\"{s}-app-code\", .{app_options.name})" },
         .{ .path = "src/app_runner/ts_core_main.zig", .pattern = "extern const native_sdk_app_markup: u8;" },
         .{ .path = "packages/core/scripts/embed_markup_c.mjs", .pattern = "const unsigned char native_sdk_app_markup[]" },
@@ -862,7 +864,9 @@ pub fn build(b: *std.Build) void {
         .{ .path = "build.zig", .pattern = "packages/core/node_modules/.bin/scriptc.cmd" },
         .{ .path = "build.zig", .pattern = "compile.addArgs(&.{ \"--compiler\", repositoryScriptcBin(b) });" },
         .{ .path = "src/tooling/verbs.zig", .pattern = "Zig's full summary reports each named build step's duration" },
-        .{ .path = "src/tooling/verbs.zig", .pattern = "appendRebuildInput(allocator, io, &inputs, \"app.zon\")" },
+        .{ .path = "src/tooling/verbs.zig", .pattern = "fn rebuildPathIgnored" },
+        .{ .path = "src/tooling/verbs.zig", .pattern = "var walker = try root.walkSelectively(allocator);" },
+        .{ .path = "src/tooling/verbs.zig", .pattern = "if (!rebuildPathIgnored(path)) try walker.enter(io, entry);" },
         .{ .path = "tools/native-sdk/main.zig", .pattern = "--explain-rebuild" },
     });
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-scriptc-cross-target-plumbing", "Verify core and service archives share the target-aware ScriptC lane, and every direct Windows archive consumer links its runtime import libraries", &.{

--- a/build.zig
+++ b/build.zig
@@ -847,6 +847,10 @@ pub fn build(b: *std.Build) void {
         .{ .path = "build/app.zig", .pattern = "node_modules\", \"scriptc\", \"dist\", \"bootstrap.js\"" },
         .{ .path = "build/app.zig", .pattern = "setEnvironmentVariable(\"SCRIPTC_TIMING\", \"1\")" },
         .{ .path = "build/app.zig", .pattern = "node_modules\", \".bin\", if (builtin.os.tag == .windows) \"scriptc.cmd\" else \"scriptc\"" },
+        .{ .path = "build/app.zig", .pattern = "addFileInput(dep.path(\"packages/core/scripts/compiler_command.mjs\"))" },
+        .{ .path = "packages/core/scripts/run_external_core_compiler.mjs", .pattern = "compilerArgv(args.compiler)" },
+        .{ .path = "packages/core/scripts/run_external_service_compiler.mjs", .pattern = "compilerArgv(args.compiler)" },
+        .{ .path = "packages/core/scripts/compiler_command.mjs", .pattern = "npmTarget !== null" },
         .{ .path = "src/tooling/verbs.zig", .pattern = "Zig's full summary reports each named build step's duration" },
         .{ .path = "tools/native-sdk/main.zig", .pattern = "--explain-rebuild" },
     });
@@ -3777,6 +3781,7 @@ fn externalServiceFixture(
 
     const compile = b.addSystemCommand(&.{node});
     compile.addFileArg(b.path("packages/core/scripts/run_external_service_compiler.mjs"));
+    compile.addFileInput(b.path("packages/core/scripts/compiler_command.mjs"));
     compile.addArg("--stage");
     compile.addDirectoryArg(stage_dir);
     compile.addArg("--manifest");
@@ -4029,6 +4034,7 @@ fn externalCoreFixtureModule(
     // pin, archive normalized, the co-emitted sidecar captured.
     const compile = b.addSystemCommand(&.{node});
     compile.addFileArg(b.path("packages/core/scripts/run_external_core_compiler.mjs"));
+    compile.addFileInput(b.path("packages/core/scripts/compiler_command.mjs"));
     compile.addArg("--stage");
     compile.addDirectoryArg(stage_dir);
     compile.addArgs(&.{ "--name", spec.name });

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,13 @@
 const std = @import("std");
 const web_engine_tool = @import("src/tooling/web_engine.zig");
 
+fn repositoryScriptcBin(b: *std.Build) []const u8 {
+    return b.pathFromRoot(if (b.graph.host.result.os.tag == .windows)
+        "packages/core/node_modules/.bin/scriptc.cmd"
+    else
+        "packages/core/node_modules/.bin/scriptc");
+}
+
 const PlatformOption = enum {
     auto,
     null,
@@ -851,7 +858,11 @@ pub fn build(b: *std.Build) void {
         .{ .path = "packages/core/scripts/run_external_core_compiler.mjs", .pattern = "compilerArgv(args.compiler)" },
         .{ .path = "packages/core/scripts/run_external_service_compiler.mjs", .pattern = "compilerArgv(args.compiler)" },
         .{ .path = "packages/core/scripts/compiler_command.mjs", .pattern = "npmTarget !== null" },
+        .{ .path = "build.zig", .pattern = "fn repositoryScriptcBin" },
+        .{ .path = "build.zig", .pattern = "packages/core/node_modules/.bin/scriptc.cmd" },
+        .{ .path = "build.zig", .pattern = "compile.addArgs(&.{ \"--compiler\", repositoryScriptcBin(b) });" },
         .{ .path = "src/tooling/verbs.zig", .pattern = "Zig's full summary reports each named build step's duration" },
+        .{ .path = "src/tooling/verbs.zig", .pattern = "appendRebuildInput(allocator, io, &inputs, \"app.zon\")" },
         .{ .path = "tools/native-sdk/main.zig", .pattern = "--explain-rebuild" },
     });
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-scriptc-cross-target-plumbing", "Verify core and service archives share the target-aware ScriptC lane, and every direct Windows archive consumer links its runtime import libraries", &.{
@@ -3257,7 +3268,7 @@ fn tsCoreE2eArtifact(
     if (b.graph.environ_map.get("NATIVE_SDK_CORE_COMPILER") == null) {
         b.build_root.handle.access(
             b.graph.io,
-            "packages/core/node_modules/.bin/scriptc",
+            repositoryScriptcBin(b),
             .{},
         ) catch return null;
     }
@@ -3810,7 +3821,7 @@ fn externalServiceFixture(
     if (b.graph.environ_map.get("NATIVE_SDK_CORE_COMPILER")) |override| {
         compile.addArgs(&.{ "--compiler", override });
     } else {
-        compile.addArgs(&.{ "--compiler", b.pathFromRoot("packages/core/node_modules/.bin/scriptc") });
+        compile.addArgs(&.{ "--compiler", repositoryScriptcBin(b) });
     }
 
     return .{
@@ -4061,7 +4072,7 @@ fn externalCoreFixtureModule(
         // driver still refuses a release other than the SDK's pin.
         compile.addArgs(&.{ "--compiler", override });
     } else {
-        compile.addArgs(&.{ "--compiler", b.pathFromRoot("packages/core/node_modules/.bin/scriptc") });
+        compile.addArgs(&.{ "--compiler", repositoryScriptcBin(b) });
     }
 
     // The mirror, generated from the archive's OWN co-emitted contract,

--- a/build.zig
+++ b/build.zig
@@ -832,6 +832,24 @@ pub fn build(b: *std.Build) void {
         .{ .path = "build.zig", .pattern = "if (spec.emit_services) check.addFileInput(b.path(\"packages/core/package.json\"));" },
         .{ .path = "build/app.zig", .pattern = "if (has_services) check.addFileInput(dep.path(\"packages/core/package.json\"));" },
     });
+    addFileContainsCheckStep(b, file_contains_checker, test_step, "test-ts-build-invalidation-boundaries", "Verify generated TypeScript contracts stabilize by content and service implementation inputs cannot dirty the core compiler lane", &.{
+        .{ .path = "build/app.zig", .pattern = "pub fn stabilizeGeneratedFile" },
+        .{ .path = "build/app.zig", .pattern = "const contract = stabilizeGeneratedFile(b, contract_raw, \"core.contract.json\", build_trace);" },
+        .{ .path = "build/app.zig", .pattern = "break :services_contract stabilizeGeneratedFile(b, raw, \"services.contract.json\", build_trace);" },
+        .{ .path = "build/app.zig", .pattern = "addAppCoreTsDirInputs(b, stage_run, appPath(b, app_root, \"src\"));" },
+        .{ .path = "build/app.zig", .pattern = "if (std.mem.startsWith(u8, normalized, \"services/\")) continue;" },
+        .{ .path = "tools/corewire/emit_service.zig", .pattern = "native-sdk.services.abi.v3" },
+        .{ .path = "tools/corewire/emit_service.zig", .pattern = "implementation-only fingerprint" },
+        .{ .path = "build/app.zig", .pattern = "link_mod.addObject(markupDataObject(b, target, app_optimize, stage.markup_c));" },
+        .{ .path = "build/app.zig", .pattern = "b.fmt(\"{s}-app-code\", .{app_options.name})" },
+        .{ .path = "src/app_runner/ts_core_main.zig", .pattern = "extern const native_sdk_app_markup: u8;" },
+        .{ .path = "packages/core/scripts/embed_markup_c.mjs", .pattern = "const unsigned char native_sdk_app_markup[]" },
+        .{ .path = "build/app.zig", .pattern = "node_modules\", \"scriptc\", \"dist\", \"bootstrap.js\"" },
+        .{ .path = "build/app.zig", .pattern = "setEnvironmentVariable(\"SCRIPTC_TIMING\", \"1\")" },
+        .{ .path = "build/app.zig", .pattern = "node_modules\", \".bin\", if (builtin.os.tag == .windows) \"scriptc.cmd\" else \"scriptc\"" },
+        .{ .path = "src/tooling/verbs.zig", .pattern = "Zig's full summary reports each named build step's duration" },
+        .{ .path = "tools/native-sdk/main.zig", .pattern = "--explain-rebuild" },
+    });
     addFileContainsCheckStep(b, file_contains_checker, test_step, "test-scriptc-cross-target-plumbing", "Verify core and service archives share the target-aware ScriptC lane, and every direct Windows archive consumer links its runtime import libraries", &.{
         .{ .path = "build/app.zig", .pattern = ".linux => !cross or target.result.cpu.arch == .x86_64 or target.result.cpu.arch == .aarch64" },
         .{ .path = "build/app.zig", .pattern = ".windows => !cross or target.result.abi == .gnu" },
@@ -3235,7 +3253,7 @@ fn tsCoreE2eArtifact(
     if (b.graph.environ_map.get("NATIVE_SDK_CORE_COMPILER") == null) {
         b.build_root.handle.access(
             b.graph.io,
-            "packages/core/node_modules/scriptc/dist/main.js",
+            "packages/core/node_modules/.bin/scriptc",
             .{},
         ) catch return null;
     }
@@ -3787,8 +3805,7 @@ fn externalServiceFixture(
     if (b.graph.environ_map.get("NATIVE_SDK_CORE_COMPILER")) |override| {
         compile.addArgs(&.{ "--compiler", override });
     } else {
-        compile.addArg("--compiler-js");
-        compile.addFileArg(b.path("packages/core/node_modules/scriptc/dist/main.js"));
+        compile.addArgs(&.{ "--compiler", b.pathFromRoot("packages/core/node_modules/.bin/scriptc") });
     }
 
     return .{
@@ -3935,12 +3952,14 @@ fn externalCoreFixtureModule(
     check.addFileArg(b.path("packages/core/src/cli.ts"));
     check.addFileArg(b.path(spec.entry));
     check.addArg("--contract");
-    const contract = check.addOutputFileArg("core.contract.json");
+    const contract_raw = check.addOutputFileArg("core.contract.json");
+    const contract = app_build.stabilizeGeneratedFile(b, contract_raw, "core.contract.json", false);
     check.addArg("--contract-entry");
     check.addArg(spec.entry);
     const services_contract: ?std.Build.LazyPath = if (spec.emit_services) services: {
         check.addArg("--services-contract");
-        break :services check.addOutputFileArg("services.contract.json");
+        const raw = check.addOutputFileArg("services.contract.json");
+        break :services app_build.stabilizeGeneratedFile(b, raw, "services.contract.json", false);
     } else null;
     for (spec.service_packages) |package_entry| check.addArgs(&.{ "--service-package", package_entry });
     const services_client: ?std.Build.LazyPath = if (services_contract) |service_contract| client: {
@@ -3948,7 +3967,8 @@ fn externalCoreFixtureModule(
         service_project.addArg("--services-sidecar");
         service_project.addFileArg(service_contract);
         service_project.addArg("--service-client");
-        break :client service_project.addOutputFileArg("services.gen.ts");
+        const client_raw = service_project.addOutputFileArg("services.gen.ts");
+        break :client app_build.stabilizeGeneratedFile(b, client_raw, "services.gen.ts", false);
     } else null;
     if (spec.persist_capability) check.addArgs(&.{ "--capability", "persist" });
     if (spec.store_capability) check.addArgs(&.{ "--capability", "store" });
@@ -4001,6 +4021,7 @@ fn externalCoreFixtureModule(
         stage_run.addArg("--services-client");
         stage_run.addFileArg(client);
     }
+    tsCoreAddCoreDirInputs(b, stage_run, std.fs.path.dirname(spec.entry) orelse ".");
     stage_run.addArg("--out");
     const stage_dir = stage_run.addOutputDirectoryArg("stage");
 
@@ -4034,8 +4055,7 @@ fn externalCoreFixtureModule(
         // driver still refuses a release other than the SDK's pin.
         compile.addArgs(&.{ "--compiler", override });
     } else {
-        compile.addArg("--compiler-js");
-        compile.addFileArg(b.path("packages/core/node_modules/scriptc/dist/main.js"));
+        compile.addArgs(&.{ "--compiler", b.pathFromRoot("packages/core/node_modules/.bin/scriptc") });
     }
 
     // The mirror, generated from the archive's OWN co-emitted contract,
@@ -4080,6 +4100,24 @@ fn tsCoreAddDirInputs(b: *std.Build, transpile: *std.Build.Step.Run, dir_path: [
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.basename, ".ts")) continue;
         transpile.addFileInput(b.path(b.fmt("{s}/{s}", .{ dir_path, entry.path })));
+    }
+}
+
+/// The source set stage_external_core.mjs copies: every ordinary `.ts` file,
+/// excluding the independent services compiler class and declaration files.
+fn tsCoreAddCoreDirInputs(b: *std.Build, stage: *std.Build.Step.Run, dir_path: []const u8) void {
+    var dir = b.build_root.handle.openDir(b.graph.io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(b.graph.io);
+    var walker = dir.walk(b.allocator) catch return;
+    defer walker.deinit();
+    while (walker.next(b.graph.io) catch null) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.basename, ".ts") or std.mem.endsWith(u8, entry.basename, ".d.ts")) continue;
+        const normalized = b.dupe(entry.path);
+        for (normalized) |*char| if (char.* == '\\') {
+            char.* = '/';
+        };
+        if (std.mem.startsWith(u8, normalized, "services/")) continue;
+        stage.addFileInput(b.path(b.fmt("{s}/{s}", .{ dir_path, entry.path })));
     }
 }
 

--- a/build/app.zig
+++ b/build/app.zig
@@ -1055,6 +1055,7 @@ fn tsCoreStage(
         service_compile.setName("native scriptc service compile");
         if (build_trace) service_compile.setEnvironmentVariable("SCRIPTC_TIMING", "1");
         service_compile.addFileArg(dep.path("packages/core/scripts/run_external_service_compiler.mjs"));
+        service_compile.addFileInput(dep.path("packages/core/scripts/compiler_command.mjs"));
         service_compile.addArg("--stage");
         service_compile.addDirectoryArg(service_stage_dir);
         service_compile.addArg("--manifest");
@@ -1128,6 +1129,7 @@ fn tsCoreStage(
     compile.setName("native scriptc core compile");
     if (build_trace) compile.setEnvironmentVariable("SCRIPTC_TIMING", "1");
     compile.addFileArg(dep.path("packages/core/scripts/run_external_core_compiler.mjs"));
+    compile.addFileInput(dep.path("packages/core/scripts/compiler_command.mjs"));
     compile.addArg("--stage");
     compile.addDirectoryArg(stage_dir);
     compile.addArgs(&.{ "--name", symbol_name });

--- a/build/app.zig
+++ b/build/app.zig
@@ -1112,13 +1112,14 @@ fn tsCoreStage(
         stage_run.addFileArg(client);
     }
     // `addDirectoryArg` orders the stager after a generated directory but
-    // does not hash a source directory's recursively discovered contents.
-    // The old graph accidentally got core-source invalidation from changing
-    // producer cache paths. Now that generated ABI files are stabilized by
-    // content, state the author's actual core compile inputs explicitly.
-    // Services are excluded because stage_external_core.mjs excludes them;
-    // their implementation class has its own compile lane.
+    // does not hash a source directory's discovered contents. The old graph
+    // accidentally got core-source invalidation from changing producer cache
+    // paths. Now that generated ABI files are stabilized by content, state
+    // every source the stager copies explicitly: authored core files plus the
+    // two SDK implementation modules. Services are excluded because they have
+    // their own compile lane.
     addAppCoreTsDirInputs(b, stage_run, appPath(b, app_root, "src"));
+    addStagedCoreSdkInputs(b, dep.builder, stage_run);
     stage_run.addArg("--out");
     const stage_dir = stage_run.addOutputDirectoryArg("stage");
 
@@ -1317,6 +1318,18 @@ fn addAppCoreTsDirInputs(b: *std.Build, stage: *std.Build.Step.Run, src_path: []
         };
         if (std.mem.startsWith(u8, normalized, "services/")) continue;
         stage.addFileInput(b.path(b.fmt("{s}/{s}", .{ src_path, entry.path })));
+    }
+}
+
+/// Declare the SDK implementation modules copied by
+/// stage_external_core.mjs. A directory LazyPath supplies ordering only for
+/// this source tree; these file inputs make implementation-only SDK edits
+/// invalidate the staged tree and compiled core archive even when the public
+/// contract remains byte-identical. Public for the repository fixture graph,
+/// which exercises the same compiler boundary as app builds.
+pub fn addStagedCoreSdkInputs(b: *std.Build, sdk_builder: *std.Build, stage: *std.Build.Step.Run) void {
+    for ([_][]const u8{ "text.ts", "events.ts" }) |source| {
+        stage.addFileInput(sdk_builder.path(b.fmt("packages/core/sdk/{s}", .{source})));
     }
 }
 

--- a/build/app.zig
+++ b/build/app.zig
@@ -1760,6 +1760,12 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
         const link_mod = b.createModule(.{ .target = target, .optimize = app_optimize });
         link_mod.addObject(app_code);
         link_mod.addObject(markupDataObject(b, target, app_optimize, stage.markup_c));
+        // Object dependencies propagate framework/system-library NAMES, but
+        // Zig does not propagate the search paths or rpaths recorded on the
+        // module that produced an object. Restate those path-only facts on
+        // the final link module so the cached app-code split remains link-
+        // equivalent to compiling the app module directly.
+        addPlatformLinkSearchPaths(b, selected_platform, web_engine, cef_dir, link_mod);
         break :root link_mod;
     } else app_mod;
     const exe = b.addExecutable(.{
@@ -2419,6 +2425,7 @@ fn externalModule(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.R
 // 26.0 SDKs. Release builds never hit it (no UBSan), which is why only
 // Debug-built examples (standardOptimizeOption default) crashed.
 fn linkPlatform(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.ResolvedTarget, app_mod: *std.Build.Module, exe: *std.Build.Step.Compile, platform: PlatformOption, web_engine: WebEngineOption, web_layer: bool, cef_dir: []const u8, cef_auto_install: bool) void {
+    addPlatformLinkSearchPaths(b, platform, web_engine, cef_dir, app_mod);
     if (platform == .macos) {
         switch (web_engine) {
             .system => {
@@ -2443,13 +2450,8 @@ fn linkPlatform(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Res
                 const flags: []const []const u8 = if (b.sysroot) |sysroot| &.{ "-fobjc-arc", "-fno-sanitize=builtin", "-ObjC++", "-std=c++17", "-stdlib=libc++", "-mmacosx-version-min=11.0", "-isysroot", sysroot, sdk_include, include_arg, define_arg } else &.{ "-fobjc-arc", "-fno-sanitize=builtin", "-ObjC++", "-std=c++17", "-stdlib=libc++", "-mmacosx-version-min=11.0", include_arg, define_arg };
                 app_mod.addCSourceFile(.{ .file = dep.path("src/platform/macos/cef_host.mm"), .flags = flags });
                 app_mod.addObjectFile(b.path(b.fmt("{s}/libcef_dll_wrapper/libcef_dll_wrapper.a", .{cef_dir})));
-                app_mod.addFrameworkPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
                 app_mod.linkFramework("Chromium Embedded Framework", .{});
-                app_mod.addRPath(.{ .cwd_relative = "@executable_path/Frameworks" });
             },
-        }
-        if (b.sysroot) |sysroot| {
-            app_mod.addFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, "System/Library/Frameworks" }) });
         }
         app_mod.linkFramework("AppKit", .{});
         // The audio playback service (the AppKit host's single AVPlayer).
@@ -2511,9 +2513,7 @@ fn linkPlatform(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Res
                 const define_arg = b.fmt("-DNATIVE_SDK_CEF_DIR=\"{s}\"", .{cef_dir});
                 app_mod.addCSourceFile(.{ .file = dep.path("src/platform/linux/cef_host.cpp"), .flags = &.{ "-std=c++17", include_arg, define_arg } });
                 app_mod.addObjectFile(b.path(b.fmt("{s}/libcef_dll_wrapper/libcef_dll_wrapper.a", .{cef_dir})));
-                app_mod.addLibraryPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
                 app_mod.linkSystemLibrary("cef", .{});
-                app_mod.addRPath(.{ .cwd_relative = "$ORIGIN" });
             },
         }
         app_mod.linkSystemLibrary("c", .{});
@@ -2572,7 +2572,6 @@ fn linkPlatform(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Res
                 app_mod.addCSourceFile(.{ .file = dep.path("src/platform/windows/cef_host.cpp"), .flags = &.{ "-std=c++17", include_arg, define_arg } });
                 app_mod.addCSourceFile(.{ .file = dep.path("src/platform/windows/gpu_surface_renderer.cpp"), .flags = &.{"-std=c++17"} });
                 app_mod.addObjectFile(b.path(b.fmt("{s}/libcef_dll_wrapper/libcef_dll_wrapper.lib", .{cef_dir})));
-                app_mod.addLibraryPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
             },
         }
         app_mod.linkSystemLibrary("c", .{});
@@ -2602,6 +2601,27 @@ fn linkPlatform(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Res
         app_mod.linkSystemLibrary("mfplat", .{});
         app_mod.linkSystemLibrary("winhttp", .{});
         if (web_engine == .chromium) app_mod.linkSystemLibrary("libcef", .{});
+    }
+}
+
+/// Link-search metadata is not inherited through a compiled object in Zig's
+/// build graph. Keep every path-only platform setting in this one helper so a
+/// TypeScript app's cached app-code object and its final link receive the same
+/// framework/library lookup and runtime-search policy.
+fn addPlatformLinkSearchPaths(b: *std.Build, platform: PlatformOption, web_engine: WebEngineOption, cef_dir: []const u8, mod: *std.Build.Module) void {
+    if (platform == .macos) {
+        if (b.sysroot) |sysroot| {
+            mod.addFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, "System/Library/Frameworks" }) });
+        }
+        if (web_engine == .chromium) {
+            mod.addFrameworkPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
+            mod.addRPath(.{ .cwd_relative = "@executable_path/Frameworks" });
+        }
+    } else if (platform == .linux and web_engine == .chromium) {
+        mod.addLibraryPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
+        mod.addRPath(.{ .cwd_relative = "$ORIGIN" });
+    } else if (platform == .windows and web_engine == .chromium) {
+        mod.addLibraryPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
     }
 }
 

--- a/build/app.zig
+++ b/build/app.zig
@@ -6,6 +6,94 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+/// Canonicalize a generated file by its CONTENT before another build step
+/// consumes it. `std.Build.Step.Run` normally places outputs under a cache
+/// directory keyed by every declared input. That is correct for the producer,
+/// but it means an unrelated input can change the output PATH even when the
+/// file's bytes are identical; downstream Run steps hash that path and miss
+/// their own caches. TypeScript's combined frontend is exactly that shape:
+/// service implementation edits re-run the checker while often leaving the
+/// core ABI contract byte-identical.
+///
+/// This narrow adapter gives equal bytes one immutable cache path. Consumers
+/// still invalidate whenever the bytes change, while producer-only churn
+/// stops here. It is public so the repository's fixture graph can exercise
+/// the same boundary as app builds.
+pub fn stabilizeGeneratedFile(b: *std.Build, source: std.Build.LazyPath, basename: []const u8, trace: bool) std.Build.LazyPath {
+    return StableGeneratedFile.create(b, source, basename, trace).lazyPath();
+}
+
+const StableGeneratedFile = struct {
+    step: std.Build.Step,
+    source: std.Build.LazyPath,
+    basename: []const u8,
+    trace: bool,
+    generated: std.Build.GeneratedFile,
+
+    fn create(b: *std.Build, source: std.Build.LazyPath, basename: []const u8, trace: bool) *StableGeneratedFile {
+        const stable = b.allocator.create(StableGeneratedFile) catch @panic("OOM");
+        stable.* = .{
+            .step = std.Build.Step.init(.{
+                .id = .custom,
+                .name = b.fmt("stabilize generated {s}", .{basename}),
+                .owner = b,
+                .makeFn = make,
+            }),
+            .source = source.dupe(b),
+            .basename = b.dupePath(basename),
+            .trace = trace,
+            .generated = undefined,
+        };
+        stable.generated = .{ .step = &stable.step };
+        source.addStepDependencies(&stable.step);
+        return stable;
+    }
+
+    fn lazyPath(self: *StableGeneratedFile) std.Build.LazyPath {
+        return .{ .generated = .{ .file = &self.generated } };
+    }
+
+    fn make(step: *std.Build.Step, options: std.Build.Step.MakeOptions) !void {
+        _ = options;
+        const self: *StableGeneratedFile = @fieldParentPtr("step", step);
+        const b = step.owner;
+        const io = b.graph.io;
+        const arena = b.allocator;
+        const source_path = self.source.getPath3(b, step);
+        const bytes = source_path.root_dir.handle.readFileAlloc(io, source_path.sub_path, arena, .limited(64 * 1024 * 1024)) catch |err|
+            return step.fail("cannot stabilize generated {s}: {t}", .{ self.basename, err });
+
+        var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+        const hex = std.fmt.bytesToHex(digest, .lower);
+        const output_dir = b.pathJoin(&.{ "o", "native-stable", &hex });
+        const output_path = b.pathJoin(&.{ output_dir, self.basename });
+        self.generated.path = try b.cache_root.join(arena, &.{output_path});
+
+        var reused = false;
+        if (b.cache_root.handle.readFileAlloc(io, output_path, arena, .limited(64 * 1024 * 1024))) |existing| {
+            reused = std.mem.eql(u8, existing, bytes);
+        } else |_| {}
+        if (!reused) {
+            b.cache_root.handle.createDirPath(io, output_dir) catch |err|
+                return step.fail("cannot create the stable generated-output directory for {s}: {t}", .{ self.basename, err });
+            var atomic = b.cache_root.handle.createFileAtomic(io, output_path, .{ .replace = true }) catch |err|
+                return step.fail("cannot stage stable generated {s}: {t}", .{ self.basename, err });
+            defer atomic.deinit(io);
+            atomic.file.writeStreamingAll(io, bytes) catch |err|
+                return step.fail("cannot write stable generated {s}: {t}", .{ self.basename, err });
+            atomic.replace(io) catch |err|
+                return step.fail("cannot publish stable generated {s}: {t}", .{ self.basename, err });
+        }
+        step.result_cached = reused;
+        if (self.trace) std.debug.print("native build trace: {s} content {s} {s}\n", .{
+            self.basename,
+            &hex,
+            if (reused) "reused" else "changed",
+        });
+    }
+};
+
 /// The shared web-layer inference contract: this build graph is one thin
 /// adapter over it (the CLI's manifest tooling and the app runner are the
 /// others), feeding it the inputs only this boundary sees — the
@@ -239,15 +327,14 @@ const core_compiler_teaching =
     " that is the default.\nDelete the setting (or spell it \"external\").\n";
 
 /// The staged TypeScript-core wiring: one generated directory holding the
-/// core module (the generated mirror with its staged shim runtime), the
-/// app's markup, and the SDK's generated-wiring entry (ts_core_main.zig
-/// as main.zig) — plus the compiled-core archive the app module links
-/// behind the mirror. Built once per app build and shared by the exe
-/// and test modules.
+/// core module (the generated mirror with its staged shim runtime) and the
+/// SDK's generated-wiring entry (ts_core_main.zig as main.zig) — plus the
+/// compiled-core archive and isolated markup data object the app module
+/// links. Built once per app build and shared by the exe and test modules.
 const TsCoreStage = struct {
     main_root: std.Build.LazyPath,
     /// The staged mobile wiring (ts_core_mobile.zig beside the same
-    /// mirror/markup/registry files): the embed static library's `app`
+    /// mirror/registry files): the embed static library's `app`
     /// module roots here on iOS/Android targets.
     mobile_root: std.Build.LazyPath,
     /// The compiled-core archive: the app module links it (with libc,
@@ -262,6 +349,9 @@ const TsCoreStage = struct {
     /// carrier is selected. The app module links it beside the core's
     /// archive.
     service_archive: ?std.Build.LazyPath = null,
+    /// C source containing the primary markup bytes under stable external
+    /// symbols. Compiled as a tiny data object by the final app artifact.
+    markup_c: std.Build.LazyPath,
     migrations: std.Build.LazyPath,
 };
 
@@ -586,20 +676,20 @@ fn tsParseQuotedManifestValue(manifest_json: []const u8, comptime key: []const u
     return suffix;
 }
 
-/// The external core compiler's entry module (scriptc's dist/main.js),
+/// The external compiler's published `scriptc` binary entrypoint,
 /// resolved by node's ancestor node_modules walk from the SDK's
 /// packages/core — the same origin the frontend toolchain resolves from
 /// (tsAliasedCompilerVersion's walk, kept in lockstep). Repo checkouts
 /// install it there with `npm ci`; the npm-installed CLI carries the
 /// compiler as a regular dependency, nested under the package on global
 /// prefixes and hoisted to the project root on local ones.
-fn tsExternalCompilerJs(b: *std.Build, dep: *std.Build.Dependency) ?[]const u8 {
+fn tsExternalCompilerBin(b: *std.Build, dep: *std.Build.Dependency) ?[]const u8 {
     const io = b.graph.io;
     const sdk_root = tsSdkRoot(b.allocator, io, dep);
     var dir: []const u8 = b.pathJoin(&.{ sdk_root, "packages", "core" });
     while (true) {
         if (!std.mem.eql(u8, std.fs.path.basename(dir), "node_modules")) {
-            const candidate = b.pathJoin(&.{ dir, "node_modules", "scriptc", "dist", "main.js" });
+            const candidate = b.pathJoin(&.{ dir, "node_modules", ".bin", if (builtin.os.tag == .windows) "scriptc.cmd" else "scriptc" });
             found: {
                 std.Io.Dir.cwd().access(io, candidate, .{}) catch break :found;
                 return candidate;
@@ -609,8 +699,8 @@ fn tsExternalCompilerJs(b: *std.Build, dep: *std.Build.Dependency) ?[]const u8 {
     }
 }
 
-fn requireTsExternalCompilerJs(b: *std.Build, dep: *std.Build.Dependency) []const u8 {
-    return tsExternalCompilerJs(b, dep) orelse {
+fn requireTsExternalCompilerBin(b: *std.Build, dep: *std.Build.Dependency) []const u8 {
+    return tsExternalCompilerBin(b, dep) orelse {
         const sdk_root = tsSdkRoot(dep.builder.allocator, dep.builder.graph.io, dep);
         std.debug.print(
             \\
@@ -626,6 +716,27 @@ fn requireTsExternalCompilerJs(b: *std.Build, dep: *std.Build.Dependency) []cons
         , .{sdk_root});
         std.process.exit(1);
     };
+}
+
+/// PR 166 adds both the published compile-cache bootstrap and the optional
+/// library-profile optimization field. The installed bootstrap is therefore
+/// the capability marker: keep older exact pins byte-for-byte compatible;
+/// once that release is installed, Debug/native-dev gets `dev` and
+/// release/package artifacts get `release` automatically.
+fn scriptcProfileOptimization(b: *std.Build, dep: *std.Build.Dependency, optimize: std.builtin.OptimizeMode) ?[]const u8 {
+    const sdk_root = tsSdkRoot(b.allocator, b.graph.io, dep);
+    var dir: []const u8 = b.pathJoin(&.{ sdk_root, "packages", "core" });
+    while (true) {
+        if (!std.mem.eql(u8, std.fs.path.basename(dir), "node_modules")) {
+            const marker = b.pathJoin(&.{ dir, "node_modules", "scriptc", "dist", "bootstrap.js" });
+            std.Io.Dir.cwd().access(b.graph.io, marker, .{}) catch {
+                dir = std.fs.path.dirname(dir) orelse return null;
+                continue;
+            };
+            return if (optimize == .Debug) "dev" else "release";
+        }
+        dir = std.fs.path.dirname(dir) orelse return null;
+    }
 }
 
 /// The SDK dependency's real root, resolved the way both the toolchain
@@ -737,7 +848,7 @@ fn tsCorePreflight(b: *std.Build, dep: *std.Build.Dependency, app_root: []const 
 /// contract sidecar, and corewire generates the mirror module from THAT
 /// document — so the boot identity fence always pairs the mirror with
 /// its own compile. The staged module directory carries core.zig (the
-/// mirror) + its staged runtime + app.native + main.zig, so the
+/// mirror) + its staged runtime + main.zig, so the
 /// generated wiring imports one fixed shape.
 fn tsCoreStage(
     b: *std.Build,
@@ -754,6 +865,8 @@ fn tsCoreStage(
     service_packages: []const ServicePackageConfig,
     service_carrier_choice: ServiceCarrierOption,
     service_pool_workers: ?u8,
+    build_trace: bool,
+    scriptc_optimization: ?[]const u8,
 ) TsCoreStage {
     const node = tsCorePreflight(b, dep, app_root);
     const window_views = collectTsWindowViews(b, app_root);
@@ -819,17 +932,20 @@ fn tsCoreStage(
     // of the reachable imports: over-approximation only re-runs the
     // check, never misses a stale input).
     const check = b.addSystemCommand(&.{node});
+    check.setName("native ts frontend (core + service contracts)");
     check.addFileArg(dep.path("build/ts_run.mjs"));
     check.addFileArg(dep.path("packages/core/src/cli.ts"));
     check.addFileArg(b.path(appPath(b, app_root, "src/core.ts")));
     check.addArg("--contract");
-    const contract = check.addOutputFileArg("core.contract.json");
+    const contract_raw = check.addOutputFileArg("core.contract.json");
+    const contract = stabilizeGeneratedFile(b, contract_raw, "core.contract.json", build_trace);
     // The document's entry spelling is app-relative (the sidecar/facade
     // contract carries no machine paths).
     check.addArgs(&.{ "--contract-entry", "src/core.ts" });
     const services_contract: ?std.Build.LazyPath = if (has_services) services_contract: {
         check.addArg("--services-contract");
-        break :services_contract check.addOutputFileArg("services.contract.json");
+        const raw = check.addOutputFileArg("services.contract.json");
+        break :services_contract stabilizeGeneratedFile(b, raw, "services.contract.json", build_trace);
     } else null;
     if (persist_capability) check.addArgs(&.{ "--capability", "persist" });
     for (service_packages) |package_entry| {
@@ -869,12 +985,14 @@ fn tsCoreStage(
     // so the profile's entry spelling and the facade file can never skew.
     const corewire_exe = corewireExe(b, dep);
     const project = b.addRunArtifact(corewire_exe);
+    project.setName("native corewire (core facade + profile)");
     project.addArg("--sidecar");
     project.addFileArg(contract);
     project.addArg("--facade");
     const facade = project.addOutputFileArg("core_facade.ts");
     project.addArg("--profile");
     const profile = project.addOutputFileArg("core_profile.json");
+    if (scriptc_optimization) |value| project.addArgs(&.{ "--optimization", value });
 
     // The fourth corewire projection is intentionally driven only by the
     // service sidecar: the generated TypeScript dispatch loop and Zig
@@ -885,14 +1003,17 @@ fn tsCoreStage(
     var service_client: ?std.Build.LazyPath = null;
     if (services_contract) |service_contract| {
         const service_project = b.addRunArtifact(corewire_exe);
+        service_project.setName("native corewire (service host + ABI projections)");
         service_project.addArg("--services-sidecar");
         service_project.addFileArg(service_contract);
         service_project.addArg("--service-host-main");
         const service_host_main = service_project.addOutputFileArg("service_host_main.ts");
         service_project.addArg("--service-registry");
-        service_registry = service_project.addOutputFileArg("services.zig");
+        const service_registry_raw = service_project.addOutputFileArg("services.zig");
+        service_registry = stabilizeGeneratedFile(b, service_registry_raw, "services.zig", build_trace);
         service_project.addArg("--service-client");
-        service_client = service_project.addOutputFileArg("services.gen.ts");
+        const service_client_raw = service_project.addOutputFileArg("services.gen.ts");
+        service_client = stabilizeGeneratedFile(b, service_client_raw, "services.gen.ts", build_trace);
         const service_inproc_main: ?std.Build.LazyPath = if (service_carrier == .in_process) inproc: {
             service_project.addArg("--service-inproc-main");
             break :inproc service_project.addOutputFileArg("service_inproc_main.ts");
@@ -907,6 +1028,7 @@ fn tsCoreStage(
         // throw into the tagged Error shape the pinned compiler can catch from an
         // imported op; no deterministic profile fences participate here.
         const service_stage_run = b.addSystemCommand(&.{node});
+        service_stage_run.setName("native stage TypeScript services");
         service_stage_run.addFileArg(dep.path("packages/core/scripts/stage_external_services.mjs"));
         service_stage_run.addArg("--src");
         service_stage_run.addDirectoryArg(b.path(appPath(b, app_root, "src")));
@@ -920,6 +1042,7 @@ fn tsCoreStage(
             service_stage_run.addArg("--inproc-profile");
             service_stage_run.addFileArg(inproc_profile);
         }
+        if (scriptc_optimization) |value| service_project.addArgs(&.{ "--optimization", value });
         service_stage_run.addArg("--contract");
         service_stage_run.addFileArg(service_contract);
         service_stage_run.addArg("--out");
@@ -929,6 +1052,8 @@ fn tsCoreStage(
         service_stage_run.has_side_effects = true;
 
         const service_compile = b.addSystemCommand(&.{node});
+        service_compile.setName("native scriptc service compile");
+        if (build_trace) service_compile.setEnvironmentVariable("SCRIPTC_TIMING", "1");
         service_compile.addFileArg(dep.path("packages/core/scripts/run_external_service_compiler.mjs"));
         service_compile.addArg("--stage");
         service_compile.addDirectoryArg(service_stage_dir);
@@ -961,15 +1086,15 @@ fn tsCoreStage(
         if (b.graph.environ_map.get("NATIVE_SDK_CORE_COMPILER")) |override| {
             service_compile.addArgs(&.{ "--compiler", override });
         } else {
-            const compiler_js = requireTsExternalCompilerJs(b, dep);
-            service_compile.addArg("--compiler-js");
-            service_compile.addFileArg(.{ .cwd_relative = compiler_js });
+            const compiler_bin = requireTsExternalCompilerBin(b, dep);
+            service_compile.addArgs(&.{ "--compiler", compiler_bin });
         }
     }
 
     // The compile stage: author sources + staged SDK + static surface +
     // generated entry/profile, one scratch tree.
     const stage_run = b.addSystemCommand(&.{node});
+    stage_run.setName("native stage TypeScript core");
     stage_run.addFileArg(dep.path("packages/core/scripts/stage_external_core.mjs"));
     stage_run.addArg("--src");
     stage_run.addDirectoryArg(b.path(appPath(b, app_root, "src")));
@@ -985,6 +1110,14 @@ fn tsCoreStage(
         stage_run.addArg("--services-client");
         stage_run.addFileArg(client);
     }
+    // `addDirectoryArg` orders the stager after a generated directory but
+    // does not hash a source directory's recursively discovered contents.
+    // The old graph accidentally got core-source invalidation from changing
+    // producer cache paths. Now that generated ABI files are stabilized by
+    // content, state the author's actual core compile inputs explicitly.
+    // Services are excluded because stage_external_core.mjs excludes them;
+    // their implementation class has its own compile lane.
+    addAppCoreTsDirInputs(b, stage_run, appPath(b, app_root, "src"));
     stage_run.addArg("--out");
     const stage_dir = stage_run.addOutputDirectoryArg("stage");
 
@@ -992,6 +1125,8 @@ fn tsCoreStage(
     // exact pin, archive normalized, the co-emitted sidecar captured.
     const symbol_name = externalCoreSymbolName(b, app_name);
     const compile = b.addSystemCommand(&.{node});
+    compile.setName("native scriptc core compile");
+    if (build_trace) compile.setEnvironmentVariable("SCRIPTC_TIMING", "1");
     compile.addFileArg(dep.path("packages/core/scripts/run_external_core_compiler.mjs"));
     compile.addArg("--stage");
     compile.addDirectoryArg(stage_dir);
@@ -1020,13 +1155,13 @@ fn tsCoreStage(
         // driver still refuses a release other than the SDK's pin.
         compile.addArgs(&.{ "--compiler", override });
     } else {
-        const compiler_js = requireTsExternalCompilerJs(b, dep);
-        compile.addArg("--compiler-js");
-        compile.addFileArg(.{ .cwd_relative = compiler_js });
+        const compiler_bin = requireTsExternalCompilerBin(b, dep);
+        compile.addArgs(&.{ "--compiler", compiler_bin });
     }
 
     // The mirror, generated from the archive's OWN co-emitted contract.
     const mirror = b.addRunArtifact(corewire_exe);
+    mirror.setName("native corewire (compiled-core mirror)");
     mirror.addArg("--sidecar");
     mirror.addFileArg(compiled_sidecar);
     mirror.addArg("--out");
@@ -1051,7 +1186,14 @@ fn tsCoreStage(
         \\
     , .{ service_carrier, service_pool_workers }));
     _ = staged.addCopyFile(migrations_zig, "migrations.zig");
-    _ = staged.addCopyFile(b.path(appPath(b, app_root, "src/app.native")), "app.native");
+    // Primary markup bytes live in their own tiny C translation unit. They
+    // no longer participate in Zig source analysis, so a markup edit reuses
+    // the compiled app/SDK graph and performs only C data compile + relink.
+    const markup_embed = b.addSystemCommand(&.{node});
+    markup_embed.setName("native embed primary markup data");
+    markup_embed.addFileArg(dep.path("packages/core/scripts/embed_markup_c.mjs"));
+    markup_embed.addFileArg(b.path(appPath(b, app_root, "src/app.native")));
+    const markup_c = markup_embed.addOutputFileArg("app_markup.c");
     for (window_views.sources) |source| {
         _ = staged.addCopyFile(b.path(appPath(b, app_root, source.source_path)), source.staged_path);
     }
@@ -1067,6 +1209,7 @@ fn tsCoreStage(
         .archive = archive,
         .service_exe = service_exe,
         .service_archive = service_archive,
+        .markup_c = markup_c,
         .migrations = migrations_zig,
     };
 }
@@ -1153,6 +1296,25 @@ fn addAppTsDirInputs(b: *std.Build, transpile: *std.Build.Step.Run, src_path: []
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.basename, ".ts")) continue;
         transpile.addFileInput(b.path(b.fmt("{s}/{s}", .{ src_path, entry.path })));
+    }
+}
+
+/// Declare exactly the author TypeScript files copied into the core compiler's
+/// scratch tree. `src/services/` is a separate compiler class and `.d.ts`
+/// files are declarations for editor/provider use, not scriptc source inputs.
+fn addAppCoreTsDirInputs(b: *std.Build, stage: *std.Build.Step.Run, src_path: []const u8) void {
+    var dir = b.build_root.handle.openDir(b.graph.io, src_path, .{ .iterate = true }) catch return;
+    defer dir.close(b.graph.io);
+    var walker = dir.walk(b.allocator) catch return;
+    defer walker.deinit();
+    while (walker.next(b.graph.io) catch null) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.basename, ".ts") or std.mem.endsWith(u8, entry.basename, ".d.ts")) continue;
+        const normalized = b.dupe(entry.path);
+        for (normalized) |*char| if (char.* == '\\') {
+            char.* = '/';
+        };
+        if (std.mem.startsWith(u8, normalized, "services/")) continue;
+        stage.addFileInput(b.path(b.fmt("{s}/{s}", .{ src_path, entry.path })));
     }
 }
 
@@ -1274,6 +1436,7 @@ pub const MobileTsCore = struct {
     archive: std.Build.LazyPath,
     /// The in-process service archive, when src/services exists.
     service_archive: ?std.Build.LazyPath,
+    markup_c: std.Build.LazyPath,
     /// The app.zon module the mobile wiring reads scene chrome, identity,
     /// and theme from (`app_manifest_zon`).
     manifest_mod: *std.Build.Module,
@@ -1352,6 +1515,7 @@ fn addMobileLibWithTarget(b: *std.Build, dep: *std.Build.Dependency, target: std
         // host link already passes).
         exports_mod.link_libc = true;
         exports_mod.addObjectFile(ts.archive);
+        exports_mod.addObjectFile(markupDataObject(b, target, optimize, ts.markup_c).getEmittedBin());
         if (ts.service_archive) |service_archive| exports_mod.addObjectFile(service_archive);
     }
     if (options.store_capability or options.relational_capability) {
@@ -1432,6 +1596,8 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
     const optimize_request = b.option(std.builtin.OptimizeMode, "optimize", "Prioritize performance, safety, or binary size");
     const optimize = exampleOptimizeMode(b, optimize_request, .Debug);
     const app_optimize = exampleOptimizeMode(b, optimize_request, .ReleaseFast);
+    const build_trace = b.option(bool, "build-trace", "Trace generated TypeScript ABI artifacts and cache reuse") orelse false;
+    const scriptc_optimization = scriptcProfileOptimization(b, dep, app_optimize);
 
     // The core role is detected from the tree (never a flag or config):
     // builds with a custom `main` entry declared their core explicitly and
@@ -1491,6 +1657,8 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
             app_config.service_packages,
             service_carrier_choice,
             service_pool_workers,
+            build_trace,
+            scriptc_optimization,
         )
     else
         null;
@@ -1524,6 +1692,7 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
                 .main_root = stage.mobile_root,
                 .archive = stage.archive,
                 .service_archive = stage.service_archive,
+                .markup_c = stage.markup_c,
                 .manifest_mod = b.createModule(.{ .root_source_file = b.path(appPath(b, app_options.app_root, "app.zon")) }),
             } else null,
         });
@@ -1575,9 +1744,25 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
     const options_mod = options.createModule();
 
     const app_mod = appModule(b, dep, target, app_optimize, app_options, options_mod, ts_stage, relational_migrations, app_config);
+    // TypeScript app code and platform hosts are expensive Zig/Clang semantic
+    // work but do not depend on primary markup bytes. Compile them once into
+    // an object, then make the executable a link-only artifact over that
+    // cached object plus the tiny generated markup-data object. A markup edit
+    // therefore avoids re-analyzing the SDK and app runner entirely.
+    const exe_root = if (ts_stage) |stage| root: {
+        const app_code = b.addObject(.{
+            .name = b.fmt("{s}-app-code", .{app_options.name}),
+            .root_module = app_mod,
+            .use_llvm = useLlvmWorkaround(target),
+        });
+        const link_mod = b.createModule(.{ .target = target, .optimize = app_optimize });
+        link_mod.addObject(app_code);
+        link_mod.addObject(markupDataObject(b, target, app_optimize, stage.markup_c));
+        break :root link_mod;
+    } else app_mod;
     const exe = b.addExecutable(.{
         .name = app_options.name,
-        .root_module = app_mod,
+        .root_module = exe_root,
         // The app executable crosses the platform C seam on every host
         // call (the GTK host's `native_sdk_gtk_create_view` is a
         // 22-parameter mix of pointers, sizes, ints, and doubles), and
@@ -1629,7 +1814,14 @@ pub fn addAppArtifacts(b: *std.Build, dep: *std.Build.Dependency, app_options: A
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run.step);
 
-    const test_app_mod = if (app_optimize == optimize) app_mod else appModule(b, dep, target, optimize, app_options, options_mod, ts_stage, relational_migrations, app_config);
+    // TypeScript tests need their own module even when optimize modes match:
+    // the production app module feeds the cached app-code object and must not
+    // absorb the separately linked markup data object.
+    const test_app_mod = if (ts_stage != null or app_optimize != optimize)
+        appModule(b, dep, target, optimize, app_options, options_mod, ts_stage, relational_migrations, app_config)
+    else
+        app_mod;
+    if (ts_stage) |stage| test_app_mod.addObject(markupDataObject(b, target, optimize, stage.markup_c));
     const tests = b.addTest(.{ .root_module = test_app_mod, .use_llvm = useLlvmWorkaround(target) });
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
@@ -1820,7 +2012,7 @@ fn appModule(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Resolv
     const app_mod = if (ts_stage) |stage|
         // TypeScript core: the app module roots at the staged generated
         // wiring (ts_core_main.zig beside the mirror core.zig, its shim
-        // runtime, and the app's markup).
+        // runtime; primary markup bytes link as a separate data object).
         b.createModule(.{
             .root_source_file = stage.main_root,
             .target = target,
@@ -1857,6 +2049,15 @@ fn appModule(b: *std.Build, dep: *std.Build.Dependency, target: std.Build.Resolv
     }
     addMacosInfoPlist(b, app_mod, target, app_config);
     return app_mod;
+}
+
+/// Compile primary markup bytes independently from the Zig app graph. The
+/// final artifact sees this as an object-file input, so a markup edit dirties
+/// only this tiny C compile and the final link.
+fn markupDataObject(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, source: std.Build.LazyPath) *std.Build.Step.Compile {
+    const mod = b.createModule(.{ .target = target, .optimize = optimize });
+    mod.addCSourceFile(.{ .file = source, .flags = &.{} });
+    return b.addObject(.{ .name = "native-app-markup-data", .root_module = mod });
 }
 
 /// Bare Mach-O executables launched by the dev loop do not have an app

--- a/packages/core/scripts/compiler_command.mjs
+++ b/packages/core/scripts/compiler_command.mjs
@@ -1,0 +1,48 @@
+// Resolve a compiler command into the argv prefix used by the core and
+// service drivers. On Windows npm exposes package bins as .cmd shims, which
+// Node's spawnSync cannot execute directly. For the installed scriptc bin,
+// unwrap the shim through the package's own `bin` declaration and execute the
+// declared JavaScript entry with Node. This preserves published-bin changes
+// (for example dist/main.js -> dist/bootstrap.js) without a shell boundary.
+
+import fs from "node:fs";
+import path from "node:path";
+
+function npmBinJavaScript(command) {
+  const binName = path.basename(command).replace(/\.(?:cmd|bat)$/i, "");
+  const nodeModules = path.dirname(path.dirname(command));
+  const packageJson = path.join(nodeModules, binName, "package.json");
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(packageJson, "utf8"));
+  } catch {
+    return null;
+  }
+  const declared = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binName];
+  if (typeof declared !== "string" || declared.length === 0 || path.isAbsolute(declared)) return null;
+  const packageRoot = path.dirname(packageJson);
+  const target = path.resolve(packageRoot, declared);
+  const relative = path.relative(packageRoot, target);
+  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
+  try {
+    if (!fs.statSync(target).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return target;
+}
+
+export function compilerArgv(command, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const node = options.node ?? process.execPath;
+  const env = options.env ?? process.env;
+  const argv = fs.existsSync(command) ? [command] : command.split(/\s+/);
+  if (platform !== "win32" || argv.length !== 1 || !/\.(?:cmd|bat)$/i.test(argv[0])) return argv;
+
+  const npmTarget = npmBinJavaScript(argv[0]);
+  if (npmTarget !== null) return [node, npmTarget];
+
+  // Development overrides may name an arbitrary batch file rather than an
+  // npm bin. cmd.exe is the Windows executable format's required launcher.
+  return [env.ComSpec ?? env.COMSPEC ?? "cmd.exe", "/d", "/s", "/c", argv[0]];
+}

--- a/packages/core/scripts/embed_markup_c.mjs
+++ b/packages/core/scripts/embed_markup_c.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Turn Native markup into one tiny C translation unit. Keeping the authored
+// bytes outside Zig's module graph means a markup edit recompiles this data
+// object and relinks the app without re-analyzing the SDK/app Zig graph.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [, , input, output] = process.argv;
+if (!input || !output) {
+  console.error("usage: embed_markup_c.mjs <src/app.native> <out.c>");
+  process.exit(2);
+}
+
+const bytes = fs.readFileSync(input);
+let source = "#include <stddef.h>\n";
+source += "const unsigned char native_sdk_app_markup[] = {";
+for (let i = 0; i < bytes.length; i++) {
+  if (i % 24 === 0) source += "\n  ";
+  source += `${bytes[i]},`;
+}
+source += "\n};\n";
+source += `const size_t native_sdk_app_markup_len = ${bytes.length};\n`;
+fs.mkdirSync(path.dirname(output), { recursive: true });
+fs.writeFileSync(output, source);

--- a/packages/core/scripts/run_external_core_compiler.mjs
+++ b/packages/core/scripts/run_external_core_compiler.mjs
@@ -20,6 +20,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { compilerArgv } from "./compiler_command.mjs";
 
 function parseArgs(argv) {
   const args = {};
@@ -56,10 +57,10 @@ for (const key of ["stage", "manifest", "frontend-sidecar", "out-archive", "out-
   if (key in args) args[key] = path.resolve(args[key]);
 }
 // --compiler is a COMMAND: a bare executable path (possibly containing
-// spaces) or an interpreter plus script ("node .../main.js"). A path
-// that exists is taken whole; anything else splits on whitespace.
+// spaces) or an interpreter plus script ("node .../main.js"). The shared
+// resolver also unwraps npm's Windows .cmd shim to its declared JS bin.
 const argv0 = args.compiler
-  ? (fs.existsSync(args.compiler) ? [args.compiler] : args.compiler.split(/\s+/))
+  ? compilerArgv(args.compiler)
   : [process.execPath, args["compiler-js"]];
 
 // App and fixture build graphs state the host and target explicitly. A

--- a/packages/core/scripts/run_external_service_compiler.mjs
+++ b/packages/core/scripts/run_external_service_compiler.mjs
@@ -17,6 +17,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { compilerArgv } from "./compiler_command.mjs";
 
 function parseArgs(argv) {
   const args = {};
@@ -143,7 +144,7 @@ for (const key of ["stage", "manifest", "contract", "out-exe", "out-archive", "c
   if (args[key]) args[key] = path.resolve(args[key]);
 }
 const argv0 = args.compiler
-  ? (fs.existsSync(args.compiler) ? [args.compiler] : args.compiler.split(/\s+/))
+  ? compilerArgv(args.compiler)
   : [process.execPath, args["compiler-js"]];
 
 // Cross compiles hand the compiler its zig-cc lane: the target triple as

--- a/packages/core/test/compiler_command.test.ts
+++ b/packages/core/test/compiler_command.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { compilerArgv } from "../scripts/compiler_command.mjs";
+
+test("Windows npm scriptc shims execute the package's published bin through Node", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "native-scriptc-command-"));
+  try {
+    const nodeModules = path.join(root, "node_modules");
+    const shim = path.join(nodeModules, ".bin", "scriptc.cmd");
+    const packageRoot = path.join(nodeModules, "scriptc");
+    const publishedBin = path.join(packageRoot, "dist", "bootstrap.js");
+    fs.mkdirSync(path.dirname(shim), { recursive: true });
+    fs.mkdirSync(path.dirname(publishedBin), { recursive: true });
+    fs.writeFileSync(shim, "@echo off\r\n");
+    fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ bin: { scriptc: "dist/bootstrap.js" } }));
+    fs.writeFileSync(publishedBin, "// published compiler bin\n");
+
+    assert.deepEqual(
+      compilerArgv(shim, { platform: "win32", node: "C:\\Node\\node.exe", env: {} }),
+      ["C:\\Node\\node.exe", publishedBin],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows batch-file compiler overrides use cmd.exe while other commands stay direct", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "native-scriptc-command-"));
+  try {
+    const override = path.join(root, "custom compiler.cmd");
+    fs.writeFileSync(override, "@echo off\r\n");
+    assert.deepEqual(
+      compilerArgv(override, { platform: "win32", env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" } }),
+      ["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", override],
+    );
+    assert.deepEqual(compilerArgv(override, { platform: "linux" }), [override]);
+    assert.deepEqual(compilerArgv("node ./compiler.js", { platform: "win32" }), ["node", "./compiler.js"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/core/test/services.test.ts
+++ b/packages/core/test/services.test.ts
@@ -90,6 +90,31 @@ test("service source hashes cover transitive shared modules", () => {
   assert.notEqual(beforeHash, afterHash);
 });
 
+test("comment-only service edits preserve core ABI and generated client artifacts", () => {
+  const check = (comment: string) => checkFiles({
+    "core.ts": serviceCore,
+    "shared.ts": `export function helper(bytes: Uint8Array): Uint8Array { return bytes; }`,
+    "services/feeds.ts": `import { helper } from "../shared.ts"; ${comment}\nexport function parse(bytes: Uint8Array): Uint8Array { return helper(bytes); }`,
+  }, { contractEntry: "src/core.ts", servicesContract: true });
+  const before = check("// implementation note one");
+  const after = check("// implementation note two");
+  assert.equal(before.ok, true, JSON.stringify(before.diagnostics));
+  assert.equal(after.ok, true, JSON.stringify(after.diagnostics));
+  assert.equal(before.contract, after.contract, "service implementation comments do not change the core ABI contract");
+  assert.equal(before.servicesClient, after.servicesClient, "service implementation comments do not change the typed client");
+  assert.notEqual(
+    JSON.parse(before.servicesContract!).operations[0].source_hash,
+    JSON.parse(after.servicesContract!).operations[0].source_hash,
+    "the service implementation lane still receives a fresh source identity",
+  );
+  const signatureChange = checkFiles({
+    "core.ts": serviceCore,
+    "services/feeds.ts": `export function parse(): Uint8Array { return new Uint8Array(0); }`,
+  }, { contractEntry: "src/core.ts", servicesContract: true });
+  assert.equal(signatureChange.ok, true, JSON.stringify(signatureChange.diagnostics));
+  assert.notEqual(before.servicesClient, signatureChange.servicesClient, "a service signature change rewrites the typed client and therefore the core compile input");
+});
+
 test("the same ambient module stays refused when it is moved into the core class", () => {
   const result = checkFiles({
     "core.ts": `

--- a/src/app_runner/ts_core_main.zig
+++ b/src/app_runner/ts_core_main.zig
@@ -1,7 +1,8 @@
 //! The generated wiring for a TypeScript app core — staged (never written
 //! into the app) by the framework build when the tree carries src/core.ts:
-//! the build transpiles the core beside this file as core.zig, copies the
-//! app's src/app.native beside it too, and roots the app module here. The
+//! the build transpiles the core beside this file as core.zig, links the
+//! app's src/app.native as an isolated data object, and roots the app module
+//! here. The
 //! app tree stays three files of truth — core.ts (logic), app.native
 //! (view), app.zon (manifest) — and every value below derives from them at
 //! comptime:
@@ -79,7 +80,14 @@ const App = Adapter.App;
 
 const shell_scene = native_sdk.app_manifest.shellConfigFrom(manifest);
 const canvas_label = native_sdk.app_manifest.firstGpuSurfaceLabel(shell_scene);
-pub const app_markup = @embedFile("app.native");
+extern const native_sdk_app_markup: u8;
+extern const native_sdk_app_markup_len: usize;
+
+/// Primary markup is linked as a data object so changing it does not dirty
+/// this Zig module's already-compiled SDK/app graph.
+pub fn appMarkup() []const u8 {
+    return @as([*]const u8, @ptrCast(&native_sdk_app_markup))[0..native_sdk_app_markup_len];
+}
 
 const app_permissions = manifestStringList(manifest, "permissions");
 const allowed_origins = manifestAllowedOrigins();
@@ -90,7 +98,7 @@ pub fn main(init: std.process.Init) !void {
         .name = manifest.name,
         .scene = shell_scene,
         .canvas_label = canvas_label,
-        .markup = .{ .source = app_markup, .watch_path = "src/app.native", .io = init.io },
+        .markup = .{ .source = appMarkup(), .watch_path = "src/app.native", .io = init.io },
         // app.zon's theme pack; unthemed manifests get the house register.
         // The stock tokens compose the pack with the LIVE system
         // appearance, so TS apps follow the OS light/dark flip with no

--- a/src/app_runner/ts_core_mobile.zig
+++ b/src/app_runner/ts_core_mobile.zig
@@ -46,7 +46,11 @@ const Adapter = native_sdk.TsUiApp(core);
 pub const Model = core.Model;
 pub const Msg = core.Msg;
 
-pub const app_markup = @embedFile("app.native");
+extern const native_sdk_app_markup: u8;
+extern const native_sdk_app_markup_len: usize;
+pub fn appMarkup() []const u8 {
+    return @as([*]const u8, @ptrCast(&native_sdk_app_markup))[0..native_sdk_app_markup_len];
+}
 
 comptime {
     // The build graph resolves the carrier before staging this file; a
@@ -97,7 +101,7 @@ pub fn mobileOptions() Adapter.Options {
         .name = manifest.name,
         .scene = mobile_scene,
         .canvas_label = native_sdk.embed.mobile_gpu_surface_label,
-        .markup = .{ .source = app_markup },
+        .markup = .{ .source = appMarkup() },
         // app.zon's theme pack and one-accent override, same as desktop.
         .theme = comptime manifestThemePack(),
         .theme_accent = comptime manifestThemeAccent(),

--- a/src/tooling/verbs.zig
+++ b/src/tooling/verbs.zig
@@ -242,9 +242,26 @@ const RebuildInput = struct {
     hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8,
 };
 
+fn appendRebuildInput(allocator: std.mem.Allocator, io: std.Io, inputs: *std.ArrayList(RebuildInput), path: []const u8) !void {
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024));
+    defer allocator.free(bytes);
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    try inputs.append(allocator, .{ .path = owned_path, .hash = std.fmt.bytesToHex(digest, .lower) });
+}
+
 fn rebuildInputs(allocator: std.mem.Allocator, io: std.Io) ![]RebuildInput {
     var inputs: std.ArrayList(RebuildInput) = .empty;
-    errdefer inputs.deinit(allocator);
+    errdefer {
+        for (inputs.items) |input| allocator.free(input.path);
+        inputs.deinit(allocator);
+    }
+    // app.zon is authored build truth just as much as src/: capabilities,
+    // windows, services, web-layer selection, and packaging metadata all
+    // alter the generated graph or final artifact.
+    try appendRebuildInput(allocator, io, &inputs, "app.zon");
     var src = std.Io.Dir.cwd().openDir(io, "src", .{ .iterate = true }) catch return inputs.toOwnedSlice(allocator);
     defer src.close(io);
     var walker = try src.walk(allocator);
@@ -253,11 +270,8 @@ fn rebuildInputs(allocator: std.mem.Allocator, io: std.Io) ![]RebuildInput {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.basename, ".ts") and !std.mem.endsWith(u8, entry.basename, ".native") and !std.mem.endsWith(u8, entry.basename, ".sql")) continue;
         const path = try std.fmt.allocPrint(allocator, "src/{s}", .{entry.path});
-        const bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024));
-        defer allocator.free(bytes);
-        var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
-        std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
-        try inputs.append(allocator, .{ .path = path, .hash = std.fmt.bytesToHex(digest, .lower) });
+        defer allocator.free(path);
+        try appendRebuildInput(allocator, io, &inputs, path);
     }
     std.mem.sort(RebuildInput, inputs.items, {}, struct {
         fn less(_: void, a: RebuildInput, b: RebuildInput) bool {
@@ -292,7 +306,9 @@ fn explainRebuild(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
         if (old_hash != null and std.mem.eql(u8, old_hash.?, &input.hash)) continue;
         changed += 1;
         std.debug.print("native rebuild: {s} {s} -> {s}\n", .{ input.path, old_hash orelse "<new>", &input.hash });
-        if (std.mem.eql(u8, input.path, "src/app.native")) {
+        if (std.mem.eql(u8, input.path, "app.zon")) {
+            std.debug.print("  invalidates manifest-derived configuration -> affected contracts, app-code/platform link, and final artifact\n", .{});
+        } else if (std.mem.eql(u8, input.path, "src/app.native")) {
             std.debug.print("  invalidates markup data object -> final app link; app-code/core scriptc remain content-gated\n", .{});
         } else if (std.mem.endsWith(u8, input.path, ".native")) {
             std.debug.print("  invalidates staged markup source set -> app-code object -> final link; core scriptc remains content-gated\n", .{});
@@ -440,7 +456,7 @@ test "optimize flags are detected among forwarded args" {
     try std.testing.expect(!hasOptimizeFlag(&.{}));
 }
 
-test "rebuild explanations persist source hashes and distinguish service from markup edges" {
+test "rebuild explanations persist manifest and source hashes" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
     const root = ".zig-cache/test-rebuild-explain";
@@ -448,6 +464,7 @@ test "rebuild explanations persist source hashes and distinguish service from ma
     cwd.deleteTree(io, root) catch {};
     defer cwd.deleteTree(io, root) catch {};
     try cwd.createDirPath(io, root ++ "/src/services");
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/app.zon", .data = ".{ .name = \"rebuild-test\" }\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/core.ts", .data = "export const core = 1;\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/app.native", .data = "<column/>\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/services/work.ts", .data = "export function work(): number { return 1; }\n" });
@@ -457,6 +474,7 @@ test "rebuild explanations persist source hashes and distinguish service from ma
     defer std.process.setCurrentPath(io, original) catch {};
     const first = try explainRebuild(allocator, io);
     defer allocator.free(first);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tapp.zon\n") != null);
     try persistRebuildSnapshot(io, first);
     const second = try explainRebuild(allocator, io);
     defer allocator.free(second);
@@ -465,4 +483,8 @@ test "rebuild explanations persist source hashes and distinguish service from ma
     const changed = try explainRebuild(allocator, io);
     defer allocator.free(changed);
     try std.testing.expect(!std.mem.eql(u8, first, changed));
+    try cwd.writeFile(io, .{ .sub_path = "app.zon", .data = ".{ .name = \"rebuild-test\", .capabilities = .{\"store\"} }\n" });
+    const manifest_changed = try explainRebuild(allocator, io);
+    defer allocator.free(manifest_changed);
+    try std.testing.expect(!std.mem.eql(u8, changed, manifest_changed));
 }

--- a/src/tooling/verbs.zig
+++ b/src/tooling/verbs.zig
@@ -38,6 +38,8 @@ pub const Options = struct {
     url_override: ?[]const u8 = null,
     command_override: ?[]const []const u8 = null,
     timeout_ms: ?u32 = null,
+    /// Explain authored-input changes and the content-gated downstream graph.
+    explain_rebuild: bool = false,
 };
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io, verb: Verb, options: Options) !void {
@@ -50,6 +52,11 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, verb: Verb, options: Option
         return error.MissingManifest;
     }
     const metadata = try manifest_tool.readMetadata(allocator, io, "app.zon");
+    const rebuild_snapshot = if (options.explain_rebuild)
+        try explainRebuild(allocator, io)
+    else
+        null;
+    defer if (rebuild_snapshot) |snapshot| allocator.free(snapshot);
 
     // Tree detection happens here too (the build graph re-derives it), so
     // a both-cores tree fails with one clean teaching message before any
@@ -122,6 +129,12 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, verb: Verb, options: Option
     switch (verb) {
         .dev => {
             if (!wants_frontend_dev) try argv.append(allocator, "run");
+            // Zig's full summary reports each named build step's duration,
+            // cache status, and peak RSS. Native's generated graph names the
+            // frontend, corewire, staging, scriptc, and final Zig phases, so
+            // slow iterative builds are attributable without reproducing
+            // them under an external profiler.
+            try argv.appendSlice(allocator, &.{ "--summary", "all" });
             if (!hasOptimizeFlag(options.forwarded_args)) {
                 // The dev loop is a Debug loop: the markup hot-reload
                 // watcher and the teaching diagnostics are compiled in only
@@ -133,6 +146,8 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, verb: Verb, options: Option
             }
         },
         .build => {
+            try argv.appendSlice(allocator, &.{ "--summary", "all" });
+            if (options.explain_rebuild) try argv.append(allocator, "-Dbuild-trace=true");
             if (!hasOptimizeFlag(options.forwarded_args)) {
                 // Both build shapes register -Doptimize (addApp and the
                 // expanded template each b.option it by hand).
@@ -157,6 +172,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, verb: Verb, options: Option
     }
 
     try runZig(io, verb, argv.items);
+    if (rebuild_snapshot) |snapshot| try persistRebuildSnapshot(io, snapshot);
 
     if (wants_frontend_dev) {
         // WebView apps with a dev server config: the binary is built, now
@@ -217,6 +233,111 @@ fn hasOptimizeFlag(args: []const []const u8) bool {
         if (std.mem.startsWith(u8, arg, "--release")) return true;
     }
     return false;
+}
+
+const rebuild_snapshot_path = ".native/cache/rebuild-inputs.tsv";
+
+const RebuildInput = struct {
+    path: []const u8,
+    hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8,
+};
+
+fn rebuildInputs(allocator: std.mem.Allocator, io: std.Io) ![]RebuildInput {
+    var inputs: std.ArrayList(RebuildInput) = .empty;
+    errdefer inputs.deinit(allocator);
+    var src = std.Io.Dir.cwd().openDir(io, "src", .{ .iterate = true }) catch return inputs.toOwnedSlice(allocator);
+    defer src.close(io);
+    var walker = try src.walk(allocator);
+    defer walker.deinit();
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".ts") and !std.mem.endsWith(u8, entry.basename, ".native") and !std.mem.endsWith(u8, entry.basename, ".sql")) continue;
+        const path = try std.fmt.allocPrint(allocator, "src/{s}", .{entry.path});
+        const bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024));
+        defer allocator.free(bytes);
+        var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+        try inputs.append(allocator, .{ .path = path, .hash = std.fmt.bytesToHex(digest, .lower) });
+    }
+    std.mem.sort(RebuildInput, inputs.items, {}, struct {
+        fn less(_: void, a: RebuildInput, b: RebuildInput) bool {
+            return std.mem.order(u8, a.path, b.path) == .lt;
+        }
+    }.less);
+    return inputs.toOwnedSlice(allocator);
+}
+
+fn explainRebuild(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
+    const inputs = try rebuildInputs(allocator, io);
+    defer {
+        for (inputs) |input| allocator.free(input.path);
+        allocator.free(inputs);
+    }
+    const prior = std.Io.Dir.cwd().readFileAlloc(io, rebuild_snapshot_path, allocator, .limited(16 * 1024 * 1024)) catch null;
+    defer if (prior) |bytes| allocator.free(bytes);
+
+    var snapshot = std.Io.Writer.Allocating.init(allocator);
+    errdefer snapshot.deinit();
+    var changed: usize = 0;
+    for (inputs) |input| {
+        try snapshot.writer.print("{s}\t{s}\n", .{ &input.hash, input.path });
+        const old_hash: ?[]const u8 = if (prior) |bytes| old: {
+            var lines = std.mem.splitScalar(u8, bytes, '\n');
+            while (lines.next()) |line| {
+                const tab = std.mem.indexOfScalar(u8, line, '\t') orelse continue;
+                if (std.mem.eql(u8, line[tab + 1 ..], input.path)) break :old line[0..tab];
+            }
+            break :old null;
+        } else null;
+        if (old_hash != null and std.mem.eql(u8, old_hash.?, &input.hash)) continue;
+        changed += 1;
+        std.debug.print("native rebuild: {s} {s} -> {s}\n", .{ input.path, old_hash orelse "<new>", &input.hash });
+        if (std.mem.eql(u8, input.path, "src/app.native")) {
+            std.debug.print("  invalidates markup data object -> final app link; app-code/core scriptc remain content-gated\n", .{});
+        } else if (std.mem.endsWith(u8, input.path, ".native")) {
+            std.debug.print("  invalidates staged markup source set -> app-code object -> final link; core scriptc remains content-gated\n", .{});
+        } else if (std.mem.startsWith(u8, input.path, "src/services/")) {
+            std.debug.print("  invalidates TS frontend -> service contract/source hash -> service host compile; API client/registry/core scriptc change only if API shape changes\n", .{});
+        } else if (std.mem.endsWith(u8, input.path, ".ts")) {
+            std.debug.print("  invalidates TS frontend -> core contract/facade/stage -> core scriptc -> app-code object -> final link\n", .{});
+        } else {
+            std.debug.print("  invalidates SQLite schema/migration generation -> app-code object -> final link\n", .{});
+        }
+    }
+    if (prior) |bytes| {
+        var lines = std.mem.splitScalar(u8, bytes, '\n');
+        while (lines.next()) |line| {
+            const tab = std.mem.indexOfScalar(u8, line, '\t') orelse continue;
+            const old_hash = line[0..tab];
+            const old_path = line[tab + 1 ..];
+            const present = for (inputs) |input| {
+                if (std.mem.eql(u8, input.path, old_path)) break true;
+            } else false;
+            if (present) continue;
+            changed += 1;
+            std.debug.print("native rebuild: {s} {s} -> <deleted>\n", .{ old_path, old_hash });
+            if (std.mem.startsWith(u8, old_path, "src/services/")) {
+                std.debug.print("  invalidates TS frontend -> service API/source set -> service host; core scriptc changes if the removed module changed API shape\n", .{});
+            } else if (std.mem.eql(u8, old_path, "src/app.native")) {
+                std.debug.print("  invalidates primary markup data object -> final app link\n", .{});
+            } else if (std.mem.endsWith(u8, old_path, ".native")) {
+                std.debug.print("  invalidates markup source set -> app-code object -> final link\n", .{});
+            } else {
+                std.debug.print("  invalidates TS/schema source set and its downstream generated artifacts\n", .{});
+            }
+        }
+    }
+    if (prior == null) std.debug.print("native rebuild: no prior successful snapshot; current inputs are the baseline\n", .{});
+    if (prior != null and changed == 0) std.debug.print("native rebuild: no authored input hashes changed\n", .{});
+    return snapshot.toOwnedSlice();
+}
+
+fn persistRebuildSnapshot(io: std.Io, snapshot: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(io, ".native/cache");
+    var atomic = try std.Io.Dir.cwd().createFileAtomic(io, rebuild_snapshot_path, .{ .make_path = true, .replace = true });
+    defer atomic.deinit(io);
+    try atomic.file.writeStreamingAll(io, snapshot);
+    try atomic.replace(io);
 }
 
 fn runZig(io: std.Io, verb: Verb, argv: []const []const u8) !void {
@@ -317,4 +438,31 @@ test "optimize flags are detected among forwarded args" {
     try std.testing.expect(hasOptimizeFlag(&.{ "-Dautomation=true", "--release=safe" }));
     try std.testing.expect(!hasOptimizeFlag(&.{"-Dautomation=true"}));
     try std.testing.expect(!hasOptimizeFlag(&.{}));
+}
+
+test "rebuild explanations persist source hashes and distinguish service from markup edges" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const root = ".zig-cache/test-rebuild-explain";
+    var cwd = std.Io.Dir.cwd();
+    cwd.deleteTree(io, root) catch {};
+    defer cwd.deleteTree(io, root) catch {};
+    try cwd.createDirPath(io, root ++ "/src/services");
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/src/core.ts", .data = "export const core = 1;\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/src/app.native", .data = "<column/>\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/src/services/work.ts", .data = "export function work(): number { return 1; }\n" });
+    const original = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original);
+    try std.process.setCurrentPath(io, root);
+    defer std.process.setCurrentPath(io, original) catch {};
+    const first = try explainRebuild(allocator, io);
+    defer allocator.free(first);
+    try persistRebuildSnapshot(io, first);
+    const second = try explainRebuild(allocator, io);
+    defer allocator.free(second);
+    try std.testing.expectEqualStrings(first, second);
+    try cwd.writeFile(io, .{ .sub_path = "src/services/work.ts", .data = "// comment\nexport function work(): number { return 1; }\n" });
+    const changed = try explainRebuild(allocator, io);
+    defer allocator.free(changed);
+    try std.testing.expect(!std.mem.eql(u8, first, changed));
 }

--- a/src/tooling/verbs.zig
+++ b/src/tooling/verbs.zig
@@ -245,11 +245,31 @@ const RebuildInput = struct {
 fn appendRebuildInput(allocator: std.mem.Allocator, io: std.Io, inputs: *std.ArrayList(RebuildInput), path: []const u8) !void {
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
-    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024));
-    defer allocator.free(bytes);
-    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    var read_buffer: [64 * 1024]u8 = undefined;
+    var reader = file.reader(io, &read_buffer);
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var chunk: [64 * 1024]u8 = undefined;
+    while (true) {
+        const len = try reader.interface.readSliceShort(&chunk);
+        hasher.update(chunk[0..len]);
+        if (len < chunk.len) break;
+    }
+    const digest = hasher.finalResult();
     try inputs.append(allocator, .{ .path = owned_path, .hash = std.fmt.bytesToHex(digest, .lower) });
+}
+
+fn rebuildPathIgnored(path: []const u8) bool {
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (std.mem.eql(u8, component, ".git") or
+            std.mem.eql(u8, component, ".native") or
+            std.mem.eql(u8, component, ".zig-cache") or
+            std.mem.eql(u8, component, "zig-out") or
+            std.mem.eql(u8, component, "node_modules")) return true;
+    }
+    return false;
 }
 
 fn rebuildInputs(allocator: std.mem.Allocator, io: std.Io) ![]RebuildInput {
@@ -258,19 +278,28 @@ fn rebuildInputs(allocator: std.mem.Allocator, io: std.Io) ![]RebuildInput {
         for (inputs.items) |input| allocator.free(input.path);
         inputs.deinit(allocator);
     }
-    // app.zon is authored build truth just as much as src/: capabilities,
-    // windows, services, web-layer selection, and packaging metadata all
-    // alter the generated graph or final artifact.
-    try appendRebuildInput(allocator, io, &inputs, "app.zon");
-    var src = std.Io.Dir.cwd().openDir(io, "src", .{ .iterate = true }) catch return inputs.toOwnedSlice(allocator);
-    defer src.close(io);
-    var walker = try src.walk(allocator);
+    // Ejected builds can consume any authored file, and even the standard
+    // graph has non-extension inputs: Zig sources, migration lock JSON,
+    // vendored service packages, assets, and frontend configuration. Hash the
+    // app tree instead of maintaining an inevitably incomplete suffix list;
+    // exclude only directories owned by VCS, dependency installs, and build
+    // outputs (including this snapshot itself under .native/).
+    var root = try std.Io.Dir.cwd().openDir(io, ".", .{ .iterate = true });
+    defer root.close(io);
+    var walker = try root.walkSelectively(allocator);
     defer walker.deinit();
     while (try walker.next(io)) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.basename, ".ts") and !std.mem.endsWith(u8, entry.basename, ".native") and !std.mem.endsWith(u8, entry.basename, ".sql")) continue;
-        const path = try std.fmt.allocPrint(allocator, "src/{s}", .{entry.path});
+        const path = try allocator.dupe(u8, entry.path);
         defer allocator.free(path);
+        for (path) |*char| if (char.* == '\\') {
+            char.* = '/';
+        };
+        if (entry.kind == .directory) {
+            if (!rebuildPathIgnored(path)) try walker.enter(io, entry);
+            continue;
+        }
+        if (entry.kind != .file) continue;
+        if (rebuildPathIgnored(path)) continue;
         try appendRebuildInput(allocator, io, &inputs, path);
     }
     std.mem.sort(RebuildInput, inputs.items, {}, struct {
@@ -308,6 +337,8 @@ fn explainRebuild(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
         std.debug.print("native rebuild: {s} {s} -> {s}\n", .{ input.path, old_hash orelse "<new>", &input.hash });
         if (std.mem.eql(u8, input.path, "app.zon")) {
             std.debug.print("  invalidates manifest-derived configuration -> affected contracts, app-code/platform link, and final artifact\n", .{});
+        } else if (std.mem.eql(u8, input.path, "build.zig") or std.mem.eql(u8, input.path, "build.zig.zon")) {
+            std.debug.print("  invalidates the owned build graph -> graph-selected compilation and final artifact\n", .{});
         } else if (std.mem.eql(u8, input.path, "src/app.native")) {
             std.debug.print("  invalidates markup data object -> final app link; app-code/core scriptc remain content-gated\n", .{});
         } else if (std.mem.endsWith(u8, input.path, ".native")) {
@@ -316,8 +347,16 @@ fn explainRebuild(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
             std.debug.print("  invalidates TS frontend -> service contract/source hash -> service host compile; API client/registry/core scriptc change only if API shape changes\n", .{});
         } else if (std.mem.endsWith(u8, input.path, ".ts")) {
             std.debug.print("  invalidates TS frontend -> core contract/facade/stage -> core scriptc -> app-code object -> final link\n", .{});
-        } else {
+        } else if (std.mem.endsWith(u8, input.path, ".zig")) {
+            std.debug.print("  invalidates Zig build/app code -> affected compile and final link\n", .{});
+        } else if (std.mem.endsWith(u8, input.path, ".sql") or std.mem.endsWith(u8, input.path, "/migrations.lock.json")) {
             std.debug.print("  invalidates SQLite schema/migration generation -> app-code object -> final link\n", .{});
+        } else if (std.mem.startsWith(u8, input.path, "frontend/")) {
+            std.debug.print("  invalidates frontend build inputs -> bundled web assets and final package\n", .{});
+        } else if (std.mem.startsWith(u8, input.path, "assets/")) {
+            std.debug.print("  invalidates authored assets -> affected runtime/package artifact\n", .{});
+        } else {
+            std.debug.print("  changes an authored app input -> the build graph determines affected downstream steps\n", .{});
         }
     }
     if (prior) |bytes| {
@@ -338,8 +377,10 @@ fn explainRebuild(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
                 std.debug.print("  invalidates primary markup data object -> final app link\n", .{});
             } else if (std.mem.endsWith(u8, old_path, ".native")) {
                 std.debug.print("  invalidates markup source set -> app-code object -> final link\n", .{});
+            } else if (std.mem.endsWith(u8, old_path, ".zig")) {
+                std.debug.print("  invalidates Zig build/app code -> affected compile and final link\n", .{});
             } else {
-                std.debug.print("  invalidates TS/schema source set and its downstream generated artifacts\n", .{});
+                std.debug.print("  removes an authored app input -> the build graph determines affected downstream steps\n", .{});
             }
         }
     }
@@ -464,10 +505,20 @@ test "rebuild explanations persist manifest and source hashes" {
     cwd.deleteTree(io, root) catch {};
     defer cwd.deleteTree(io, root) catch {};
     try cwd.createDirPath(io, root ++ "/src/services");
+    try cwd.createDirPath(io, root ++ "/src/schema");
+    try cwd.createDirPath(io, root ++ "/assets");
+    try cwd.createDirPath(io, root ++ "/.native/cache");
+    try cwd.createDirPath(io, root ++ "/node_modules/package");
     try cwd.writeFile(io, .{ .sub_path = root ++ "/app.zon", .data = ".{ .name = \"rebuild-test\" }\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/build.zig", .data = "pub fn build() void {}\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/core.ts", .data = "export const core = 1;\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/src/main.zig", .data = "pub fn main() void {}\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/app.native", .data = "<column/>\n" });
     try cwd.writeFile(io, .{ .sub_path = root ++ "/src/services/work.ts", .data = "export function work(): number { return 1; }\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/src/schema/migrations.lock.json", .data = "{}\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/assets/icon.bin", .data = "authored asset\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/.native/cache/generated", .data = "generated\n" });
+    try cwd.writeFile(io, .{ .sub_path = root ++ "/node_modules/package/index.js", .data = "dependency\n" });
     const original = try std.process.currentPathAlloc(io, allocator);
     defer allocator.free(original);
     try std.process.setCurrentPath(io, root);
@@ -475,6 +526,12 @@ test "rebuild explanations persist manifest and source hashes" {
     const first = try explainRebuild(allocator, io);
     defer allocator.free(first);
     try std.testing.expect(std.mem.indexOf(u8, first, "\tapp.zon\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tbuild.zig\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tsrc/main.zig\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tsrc/schema/migrations.lock.json\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tassets/icon.bin\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\t.native/") == null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\tnode_modules/") == null);
     try persistRebuildSnapshot(io, first);
     const second = try explainRebuild(allocator, io);
     defer allocator.free(second);

--- a/tools/corewire/emit_profile.zig
+++ b/tools/corewire/emit_profile.zig
@@ -153,7 +153,7 @@ const determinism_remediations = [_]Rider{
     .{ .code = "SC4017", .text = "restart the app process: a trapped core is poisoned and never resumes in place, and the recorded session replays deterministically." },
 };
 
-pub fn emitProfile(arena: std.mem.Allocator, sidecar: Sidecar, entry: []const u8, diags: *sidecar_mod.Diagnostics) Error![]const u8 {
+pub fn emitProfile(arena: std.mem.Allocator, sidecar: Sidecar, entry: []const u8, optimization: ?[]const u8, diags: *sidecar_mod.Diagnostics) Error![]const u8 {
     // The profile is ENFORCEMENT data: a compile that succeeds under its
     // determinism fences attests deterministic, and the compilation mode
     // is structurally async-free — so a contract attesting false for
@@ -168,7 +168,7 @@ pub fn emitProfile(arena: std.mem.Allocator, sidecar: Sidecar, entry: []const u8
         diags.flag("async_free", "the contract attests async_free: false, but this profile's compilation mode is structurally async-free — a core reaching async surface refuses under it, so this contract cannot have come from the profile it asks for; remove the async surface and regenerate the contract", .{});
     }
     if (diags.hasErrors()) return error.Refused;
-    var emitter = ProfileEmitter{ .arena = arena, .sidecar = sidecar, .out = .empty };
+    var emitter = ProfileEmitter{ .arena = arena, .sidecar = sidecar, .optimization = optimization, .out = .empty };
     try emitter.run(entry);
     return emitter.out.items;
 }
@@ -176,6 +176,7 @@ pub fn emitProfile(arena: std.mem.Allocator, sidecar: Sidecar, entry: []const u8
 const ProfileEmitter = struct {
     arena: std.mem.Allocator,
     sidecar: Sidecar,
+    optimization: ?[]const u8,
     out: std.ArrayListUnmanaged(u8),
 
     fn print(self: *ProfileEmitter, comptime fmt: []const u8, args: anytype) Error!void {
@@ -195,6 +196,11 @@ const ProfileEmitter = struct {
             \\  "name": "native-sdk-core",
             \\  "entry": {s},
             \\  "emission": "llvm",
+        , .{try self.jsonString(entry)});
+        if (self.optimization) |optimization| try self.print(
+            \\  "optimization": {s},
+        , .{try self.jsonString(optimization)});
+        try self.print(
             \\  "abi": {{
             \\    "prefix": {s},
             \\    "init_symbol": {s},
@@ -205,7 +211,6 @@ const ProfileEmitter = struct {
             \\  "exports": [
             \\
         , .{
-            try self.jsonString(entry),
             try self.jsonString(prefix),
             try self.symbol(prefix, "init"),
             try self.symbol(prefix, "set_panic_sink"),
@@ -361,7 +366,7 @@ const testing = std.testing;
 fn profileFromJson(arena: std.mem.Allocator, json: []const u8, entry: []const u8) ![]const u8 {
     var diags = sidecar_mod.Diagnostics{ .arena = arena };
     const parsed = try sidecar_mod.read(arena, json, &diags);
-    return emitProfile(arena, parsed, entry, &diags);
+    return emitProfile(arena, parsed, entry, "release", &diags);
 }
 
 test "profile emission is deterministic and carries the library-mode surface" {
@@ -373,6 +378,11 @@ test "profile emission is deterministic and carries the library-mode surface" {
     try testing.expectEqualStrings(first, second);
     try testing.expect(std.mem.indexOf(u8, first, "\"profile_format\": 1") != null);
     try testing.expect(std.mem.indexOf(u8, first, "\"entry\": \"core_facade.ts\"") != null);
+    try testing.expect(std.mem.indexOf(u8, first, "\"optimization\": \"release\"") != null);
+    var dev_diags = sidecar_mod.Diagnostics{ .arena = arena };
+    const parsed_for_dev = try sidecar_mod.read(arena, sidecar_mod.minimal_valid_json, &dev_diags);
+    const dev = try emitProfile(arena, parsed_for_dev, default_entry, "dev", &dev_diags);
+    try testing.expect(std.mem.indexOf(u8, dev, "\"optimization\": \"dev\"") != null);
     // Mode symbols ride the abi block under the contract's prefix.
     try testing.expect(std.mem.indexOf(u8, first, "\"init_symbol\": \"nsc_core_init\"") != null);
     try testing.expect(std.mem.indexOf(u8, first, "\"sink_register_symbol\": \"nsc_core_set_panic_sink\"") != null);
@@ -459,7 +469,7 @@ test "a non-UTF-8 entry spelling refuses instead of corrupting the JSON" {
     const arena = arena_state.allocator();
     var diags = sidecar_mod.Diagnostics{ .arena = arena };
     const parsed = try sidecar_mod.read(arena, sidecar_mod.minimal_valid_json, &diags);
-    try testing.expectError(error.Refused, emitProfile(arena, parsed, "core_\xfffacade.ts", &diags));
+    try testing.expectError(error.Refused, emitProfile(arena, parsed, "core_\xfffacade.ts", "release", &diags));
 }
 
 test "a contract attesting false for an enforced posture refuses" {
@@ -473,7 +483,7 @@ test "a contract attesting false for an enforced posture refuses" {
         const source = try std.mem.replaceOwned(u8, arena, sidecar_mod.minimal_valid_json, case.needle, case.replacement);
         var diags = sidecar_mod.Diagnostics{ .arena = arena };
         const parsed = try sidecar_mod.read(arena, source, &diags);
-        try testing.expectError(error.Refused, emitProfile(arena, parsed, default_entry, &diags));
+        try testing.expectError(error.Refused, emitProfile(arena, parsed, default_entry, "release", &diags));
         var found = false;
         for (diags.list.items) |item| {
             if (item.severity == .@"error" and std.mem.indexOf(u8, item.message, case.fragment) != null) found = true;
@@ -489,7 +499,7 @@ test "the emitted profile parses as JSON with the expected top-level keys" {
     const generated = try profileFromJson(arena, sidecar_mod.minimal_valid_json, default_entry);
     const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena, generated, .{});
     const top = parsed.object;
-    for ([_][]const u8{ "profile_format", "name", "entry", "emission", "abi", "exports", "sidecar", "determinism" }) |key| {
+    for ([_][]const u8{ "profile_format", "name", "entry", "emission", "optimization", "abi", "exports", "sidecar", "determinism" }) |key| {
         try testing.expect(top.contains(key));
     }
     const determinism = top.get("determinism").?.object;

--- a/tools/corewire/emit_service.zig
+++ b/tools/corewire/emit_service.zig
@@ -29,29 +29,24 @@ fn fingerprintType(hasher: *std.crypto.hash.sha2.Sha256, ref: service.TypeRef) v
     if (ref.name) |name| fingerprintField(hasher, name);
 }
 
-/// Identity of every fact that can change generated dispatch semantics. The
-/// same digest is embedded in the service executable and the Zig registry so
-/// a stale or hand-supplied sibling is refused before numeric indices are used.
+/// Identity of the service ABI facts both carriers put on the wire. The same
+/// digest is embedded in the service executable and the Zig registry so a
+/// stale or hand-supplied sibling is refused before numeric indices are used.
+///
+/// Deliberately excluded: compiler/package identities, implementation module
+/// paths and exports, and `source_hash`. Those facts rebuild the service
+/// executable, but they do not change operation indices or encoded values and
+/// therefore must not rewrite the app runner or recompile the app core.
 fn contractFingerprint(contract: service.Contract) [fingerprint_len]u8 {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    hasher.update("native-sdk.services.contract.v3\x00");
+    hasher.update("native-sdk.services.abi.v3\x00");
     var scalar: [8]u8 = undefined;
     std.mem.writeInt(i64, &scalar, contract.format, .little);
     hasher.update(&scalar);
     std.mem.writeInt(i64, &scalar, contract.protocol_version, .little);
     hasher.update(&scalar);
-    hasher.update(&.{@intFromBool(contract.deterministic)});
-    fingerprintField(&hasher, contract.compiler_version);
-    std.mem.writeInt(u64, &scalar, @intCast(contract.packages.len), .little);
-    hasher.update(&scalar);
-    for (contract.packages) |package_entry| {
-        fingerprintField(&hasher, package_entry.name);
-        fingerprintField(&hasher, package_entry.version);
-        fingerprintField(&hasher, package_entry.content_hash);
-    }
     for (contract.types.records) |record| {
         fingerprintField(&hasher, record.name);
-        fingerprintField(&hasher, record.origin);
         for (record.fields) |field| {
             fingerprintField(&hasher, field.name);
             fingerprintType(&hasher, field.type);
@@ -59,12 +54,10 @@ fn contractFingerprint(contract: service.Contract) [fingerprint_len]u8 {
     }
     for (contract.types.enums) |enum_type| {
         fingerprintField(&hasher, enum_type.name);
-        fingerprintField(&hasher, enum_type.origin);
         for (enum_type.members) |member| fingerprintField(&hasher, member);
     }
     for (contract.types.unions) |union_type| {
         fingerprintField(&hasher, union_type.name);
-        fingerprintField(&hasher, union_type.origin);
         for (union_type.arms) |arm| {
             fingerprintField(&hasher, arm.name);
             for (arm.fields) |field| {
@@ -77,9 +70,6 @@ fn contractFingerprint(contract: service.Contract) [fingerprint_len]u8 {
     hasher.update(&scalar);
     for (contract.operations) |op| {
         fingerprintField(&hasher, op.name);
-        fingerprintField(&hasher, op.client);
-        fingerprintField(&hasher, op.module);
-        fingerprintField(&hasher, op.@"export");
         fingerprintType(&hasher, op.request);
         fingerprintType(&hasher, op.result);
         std.mem.writeInt(i64, &scalar, op.deadline_ms orelse 0, .little);
@@ -91,7 +81,6 @@ fn contractFingerprint(contract: service.Contract) [fingerprint_len]u8 {
             std.mem.writeInt(i64, &scalar, stream.in_flight, .little);
             hasher.update(&scalar);
         } else hasher.update(&.{0});
-        fingerprintField(&hasher, op.source_hash);
     }
     return hasher.finalResult();
 }
@@ -601,15 +590,20 @@ pub fn emitInprocMain(arena: std.mem.Allocator, contract: service.Contract) ![]c
 /// and linked by one build graph, and the facade's fingerprint export is
 /// the pairing check. No determinism fences — services run with ambient
 /// authority by contract.
-pub fn emitInprocProfile(arena: std.mem.Allocator) ![]const u8 {
+pub fn emitInprocProfile(arena: std.mem.Allocator, optimization: ?[]const u8) ![]const u8 {
     var out = std.Io.Writer.Allocating.init(arena);
     const w = &out.writer;
-    try w.print(
-        \\{{
+    try w.writeAll(
+        \\{
         \\  "profile_format": 1,
         \\  "name": "native-sdk-services",
         \\  "entry": "service_inproc_main.ts",
         \\  "emission": "llvm",
+    );
+    if (optimization) |value| try w.print(
+        \\  "optimization": "{s}",
+    , .{value});
+    try w.print(
         \\  "abi": {{
         \\    "prefix": "{s}",
         \\    "init_symbol": "{s}init",
@@ -887,12 +881,13 @@ test "service projection derives host dispatch and registry from one contract" {
     try std.testing.expect(std.mem.indexOf(u8, inproc, "writeHello") == null);
     try std.testing.expect(std.mem.indexOf(u8, inproc, "requestId") == null);
 
-    const profile = try emitInprocProfile(std.testing.allocator);
+    const profile = try emitInprocProfile(std.testing.allocator, "release");
     defer std.testing.allocator.free(profile);
     try std.testing.expect(std.mem.indexOf(u8, profile, "\"prefix\": \"nsc_svc_\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "\"localize_runtime\": true") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "\"instance_per_thread\": true") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "\"entry\": \"service_inproc_main.ts\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "\"optimization\": \"release\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "\"symbol\": \"nsc_svc_dispatch\"") != null);
 
     const registry = try emitRegistry(std.testing.allocator, contract);
@@ -910,6 +905,33 @@ test "service projection derives host dispatch and registry from one contract" {
     try std.testing.expect(std.mem.indexOf(u8, client, "ServiceRoute<Msg, readonly (Uint8Array | null)[]>") != null);
 
     const original_fingerprint = contractFingerprint(contract);
+    // An implementation-only fingerprint input change must leave the ABI
+    // digest alone: source/package/compiler facts rebuild only the service.
+    const implementation_only_fingerprint = contractFingerprint(.{
+        .format = contract.format,
+        .protocol_version = contract.protocol_version,
+        .compiler_version = "9.9.9",
+        .deterministic = contract.deterministic,
+        .packages = &.{.{ .name = "different-package", .version = "4.5.6", .content_hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }},
+        .types = contract.types,
+        .operations = &.{
+            .{
+                .name = operations[0].name,
+                .client = "renamedInternalClient",
+                .module = "src/services/moved.ts",
+                .@"export" = "moved",
+                .request = operations[0].request,
+                .result = operations[0].result,
+                .deadline_ms = operations[0].deadline_ms,
+                .cancellable = operations[0].cancellable,
+                .stream = operations[0].stream,
+                .source_hash = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            },
+            operations[1],
+            operations[2],
+        },
+    });
+    try std.testing.expectEqualSlices(u8, &original_fingerprint, &implementation_only_fingerprint);
     const reordered_operations = [_]service.Operation{ operations[1], operations[0] };
     const reordered_fingerprint = contractFingerprint(.{
         .format = contract.format,

--- a/tools/corewire/main.zig
+++ b/tools/corewire/main.zig
@@ -59,6 +59,7 @@ pub fn main(init: std.process.Init) !void {
     var profile_path: ?[]const u8 = null;
     var effective_sidecar_path: ?[]const u8 = null;
     var check_only = false;
+    var optimization: ?[]const u8 = null;
     var f64_slots: std.ArrayListUnmanaged([]const u8) = .empty;
     var index: usize = 1;
     while (index < args.len) : (index += 1) {
@@ -83,6 +84,9 @@ pub fn main(init: std.process.Init) !void {
             try f64_slots.append(arena, args[index]);
         } else if (std.mem.eql(u8, arg, "--check")) {
             check_only = true;
+        } else if (std.mem.eql(u8, arg, "--optimization") and index + 1 < args.len) {
+            index += 1;
+            optimization = args[index];
         } else {
             try stderr.print("corewire: unknown argument \"{s}\"\n\n{s}", .{ arg, usage });
             try stderr.flush();
@@ -256,7 +260,12 @@ pub fn main(init: std.process.Init) !void {
             try stderr.flush();
             std.process.exit(2);
         }
-        break :blk emit_profile_mod.emitProfile(arena, parsed, entry, &diags) catch |err| switch (err) {
+        if (optimization != null and !std.mem.eql(u8, optimization.?, "dev") and !std.mem.eql(u8, optimization.?, "release")) {
+            try stderr.print("corewire: --optimization must be dev or release\n", .{});
+            try stderr.flush();
+            std.process.exit(2);
+        }
+        break :blk emit_profile_mod.emitProfile(arena, parsed, entry, optimization, &diags) catch |err| switch (err) {
             error.Refused => {
                 try diags.write(input, stderr);
                 try stderr.flush();
@@ -373,6 +382,7 @@ fn serviceProjection(init: std.process.Init, args: []const []const u8, stderr: *
     var inproc_main_out: ?[]const u8 = null;
     var inproc_profile_out: ?[]const u8 = null;
     var saw_service_flag = false;
+    var optimization: ?[]const u8 = null;
     var index: usize = 1;
     while (index < args.len) : (index += 1) {
         const arg = args[index];
@@ -400,6 +410,10 @@ fn serviceProjection(init: std.process.Init, args: []const []const u8, stderr: *
             saw_service_flag = true;
             index += 1;
             inproc_profile_out = args[index];
+        } else if (saw_service_flag and std.mem.eql(u8, arg, "--optimization") and index + 1 < args.len) {
+            saw_service_flag = true;
+            index += 1;
+            optimization = args[index];
         } else if (saw_service_flag) {
             try stderr.print("corewire: unknown service projection argument \"{s}\"\n", .{arg});
             try stderr.flush();
@@ -407,6 +421,11 @@ fn serviceProjection(init: std.process.Init, args: []const []const u8, stderr: *
         }
     }
     if (!saw_service_flag) return false;
+    if (optimization != null and !std.mem.eql(u8, optimization.?, "dev") and !std.mem.eql(u8, optimization.?, "release")) {
+        try stderr.print("corewire: --optimization must be dev or release\n", .{});
+        try stderr.flush();
+        std.process.exit(2);
+    }
     const sidecar_path = input orelse {
         try stderr.print("usage: corewire --services-sidecar <services.contract.json> [--service-host-main <service_host_main.ts>] [--service-registry <services.zig>] [--service-client <services.gen.ts>] [--service-inproc-main <service_inproc_main.ts>] [--service-inproc-profile <service_profile.json>]\n", .{});
         try stderr.flush();
@@ -469,7 +488,7 @@ fn serviceProjection(init: std.process.Init, args: []const []const u8, stderr: *
         };
     }
     if (inproc_profile_out) |path| {
-        const generated = try emit_service_mod.emitInprocProfile(arena);
+        const generated = try emit_service_mod.emitInprocProfile(arena, optimization);
         std.Io.Dir.cwd().writeFile(init.io, .{ .sub_path = path, .data = generated }) catch |err| {
             try stderr.print("corewire: cannot write {s}: {t}\n", .{ path, err });
             try stderr.flush();

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -75,8 +75,8 @@ pub fn main(init: std.process.Init) !void {
     } else if (std.mem.eql(u8, command, "build") or std.mem.eql(u8, command, "test")) {
         const verb: tooling.verbs.Verb = if (std.mem.eql(u8, command, "build")) .build else .@"test";
         checkVerbFlags(command, args[2..], .{
-            .usage = if (verb == .build) "build [dir] [--yes] [-D... zig build flags]" else "test [dir] [--yes] [-D... zig build flags]",
-            .bool_flags = &.{"--yes"},
+            .usage = if (verb == .build) "build [dir] [--yes] [--explain-rebuild] [-D... zig build flags]" else "test [dir] [--yes] [-D... zig build flags]",
+            .bool_flags = if (verb == .build) &.{ "--yes", "--explain-rebuild" } else &.{"--yes"},
             .forwards_build_flags = true,
         });
         const verb_args = parseVerbArgs(allocator, args[2..], &.{}) catch fail("usage: native build|test [dir] [--yes] [-D... zig build flags]");
@@ -85,6 +85,7 @@ pub fn main(init: std.process.Init) !void {
             .base_env = init.environ_map,
             .assume_yes = verb_args.assume_yes,
             .forwarded_args = verb_args.forwarded,
+            .explain_rebuild = flagBool(args, "--explain-rebuild"),
         }) catch |err| return failVerb(err);
     } else if (std.mem.eql(u8, command, "check")) {
         checkVerbFlags("check", args[2..], .{
@@ -454,7 +455,8 @@ fn usage() void {
         \\  dev [dir] --target ios [--device name]         build for the iOS simulator, install + launch, stream the log (experimental)
         \\  dev [dir] --target android [--device name]     build a debug APK, install + launch on an emulator via adb, stream the log (experimental)
         \\  dev [dir] --core [--script msgs.ndjson] [--watch]   run the TypeScript core's logic loop under node (update/effects transcript; not a renderer)
-        \\  build [dir] [--yes] [-D... zig build flags]    build a ReleaseFast binary into zig-out/bin/
+        \\  build [dir] [--yes] [--explain-rebuild] [-D... zig build flags]
+        \\                                                  build ReleaseFast; explain changed inputs and dirty steps
         \\  test [dir] [--yes] [-D... zig build flags]     run the app's test suite
         \\  check [dir] [--strict]                         validate the core (src/core.ts through the subset checker), src/*.native markup, and app.zon
         \\  db new-migration <name> | status | reset --yes manage the relational schema and development database
@@ -598,6 +600,7 @@ fn parseVerbArgs(allocator: std.mem.Allocator, args: []const []const u8, value_f
         if (std.mem.eql(u8, arg, "--strict")) continue;
         if (std.mem.eql(u8, arg, "--core")) continue;
         if (std.mem.eql(u8, arg, "--watch")) continue;
+        if (std.mem.eql(u8, arg, "--explain-rebuild")) continue;
         if (std.mem.startsWith(u8, arg, "-D") or std.mem.startsWith(u8, arg, "--release")) {
             try forwarded.append(allocator, arg);
             continue;


### PR DESCRIPTION
- Stabilize generated core and service ABI artifacts by content so implementation-only service edits never rebuild the app core.
- Split primary markup and app code into independently cached objects, reducing warm markup rebuilds to data compilation plus linking.
- Add rebuild explanations, phase timing/RSS summaries, and forward-compatible scriptc dev profiles through its published binary.