### PR TITLE
chore(core): upgrade scriptc to 0.0.33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # TypeScript cores compile through the external core compiler at
       # build/test time; the compiler and the frontend's toolchain both
       # arrive with this one install (without it the ts-core suites skip
@@ -44,7 +44,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # The exact-pinned external core compiler and the frontend's
       # toolchain, one install (packages/core/package.json is the one
       # place the pin lives).
@@ -65,7 +65,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # gpu-components is a TypeScript-core app, so its smoke build needs
       # the frontend compiler and exact-pinned TypeScript toolchain.
       - run: npm ci --prefix packages/core
@@ -184,7 +184,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # The TypeScript core suites compile through the external core
       # compiler at build/test time; without the install they skip
       # silently, so CI must provide it.
@@ -224,7 +224,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # The TypeScript examples compile through the external core
       # compiler at build time; the compiler and the frontend toolchain
       # arrive with this install.
@@ -358,7 +358,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # The scaffold default is the TypeScript core; its frontend and
       # compiler run at build time from this checkout's packages/core.
       - run: npm ci --prefix packages/core
@@ -463,7 +463,7 @@ jobs:
           version: 0.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       # The default scaffold is a TypeScript core: its build runs the
       # @native-sdk/core frontend and the external core compiler from
       # this checkout's own install.

--- a/build/app.zig
+++ b/build/app.zig
@@ -754,11 +754,11 @@ const TsToolingConsumer = enum { app_core, sqlite_schema };
 fn tsToolingPreflight(b: *std.Build, dep: *std.Build.Dependency, consumer: TsToolingConsumer) []const u8 {
     const node = b.findProgram(&.{"node"}, &.{}) catch switch (consumer) {
         .app_core => @panic("\nbuilding a TypeScript app core needs node on PATH (the @native-sdk/core frontend checks the" ++
-            " core at build time; the binary you ship carries no JS runtime).\nInstall Node.js 22.15+ (on the 23" ++
-            " line: 23.5+) — https://nodejs.org or `brew install node` — and re-run.\n"),
+            " core at build time; the binary you ship carries no JS runtime).\nInstall Node.js 24+" ++
+            " — https://nodejs.org or `brew install node` — and re-run.\n"),
         .sqlite_schema => @panic("\nbuilding relational SQLite migrations needs node on PATH (the schema checker and" ++
             " migration generator run at build time; the binary you ship carries no JS runtime).\nInstall Node.js" ++
-            " 22.15+ (on the 23 line: 23.5+) — https://nodejs.org or `brew install node` — and re-run.\n"),
+            " 24+ — https://nodejs.org or `brew install node` — and re-run.\n"),
     };
     switch (tsToolchainResolution(b, dep)) {
         .resolved => {},

--- a/build/ts_run.mjs
+++ b/build/ts_run.mjs
@@ -12,21 +12,16 @@
 // node's ancestor node_modules walk). Node's own type stripping is never
 // relied on: it refuses node_modules-resident .ts by design
 // (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING), and outside node_modules
-// it only became DEFAULT in node 22.18 — so a checkout target on
-// 22.15-22.17 would die with ERR_UNKNOWN_FILE_EXTENSION if the hook let it
-// "fall through". Hooking everything makes the 22.15 floor true for both
-// layouts. Then the runner imports the requested module with argv
+// it only became DEFAULT in node 22.18. Hooking everything keeps both layouts
+// identical. scriptc 0.0.33 requires Node 24 for its published compile-cache
+// bootstrap, so this shared runner enforces the same floor before importing
+// any frontend module. Then it imports the requested module with argv
 // respliced so the target sees its usual shape (its own path at argv[1],
 // its arguments from argv[2]).
 //
-// On node builds without module.registerHooks (pre-22.15, or 23.0-23.4 —
-// the hook landed in 22.15 and 23.5, so ">=22.15" alone is not the
-// capability line) NO .ts target can run — node_modules-resident
-// stripping is refused by design and default stripping outside
-// node_modules only landed in 22.18, which is above this tier anyway —
-// so the runner fails fast with one teaching line (upgrade to Node.js
-// 22.15+, on the 23 line 23.5+) before importing it, instead of
-// surfacing node's raw extension/stripping error.
+// A Node 24 build without module.registerHooks is incomplete for this tier,
+// so the runner gives the same Node 24 teaching instead of surfacing a raw
+// extension/stripping error.
 
 import module, { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
@@ -39,19 +34,21 @@ if (!target) {
   process.exit(2);
 }
 const targetPath = resolve(target);
+const nodeMajor = Number(process.versions.node.split('.')[0]);
+if (!Number.isInteger(nodeMajor) || nodeMajor < 24) {
+  console.error(`TypeScript apps need Node.js 24+; you're running ${process.version} - upgrade node and re-run.`);
+  process.exit(1);
+}
 // Drop the runner from argv so the target module parses its own argv
 // exactly as when node runs it directly.
 process.argv.splice(1, 1);
 
 if (typeof module.registerHooks !== 'function') {
-  // No load hooks on this node (pre-22.15, or a 23.0-23.4 build). Every
-  // .ts target needs the hook — node_modules-resident stripping is
-  // refused by design, and native default stripping outside node_modules
-  // is 22.18+ — so any .ts target would fail deep inside node with a raw
-  // extension/stripping error. Teach the fix instead.
+  // Every .ts target needs the hook. A supported Node build without it is
+  // incomplete for this tier, so teach the supported installation instead.
   if (targetPath.endsWith('.ts')) {
     console.error(
-      `TypeScript apps need Node.js 22.15+ (on the 23 line: 23.5+); you're running ${process.version} - upgrade node and re-run.`,
+      `TypeScript apps need Node.js 24+ with module.registerHooks; you're running ${process.version} - upgrade or reinstall node and re-run.`,
     );
     process.exit(1);
   }

--- a/docs/src/app/docs/quick-start/page.mdx
+++ b/docs/src/app/docs/quick-start/page.mdx
@@ -7,7 +7,7 @@ Native SDK is the complete toolkit for building beautiful native desktop applica
 ## Prerequisites
 
 - macOS 11 or newer, Linux, or Windows
-- Node.js 22.15+ (on the 23 line: 23.5+) for the default TypeScript scaffold — the TypeScript frontend (the checker) and the core dev loop run under it at build and dev time, and the external core compiler that builds the checked core to native code ships as an exact-pinned dependency of the CLI; the binary you ship carries no JS runtime. A Zig-core app (`--template zig-core`) needs Node only when it declares relational SQLite, whose schema checker and migration generator run at build time.
+- Node.js 24+ for the default TypeScript scaffold — the TypeScript frontend (the checker), scriptc compiler, and core dev loop run under it at build and dev time; scriptc 0.0.33 uses Node 24's compile cache to accelerate repeated invocations. The binary you ship carries no JS runtime. A Zig-core app (`--template zig-core`) needs Node only when it declares relational SQLite, whose schema checker and migration generator run at build time.
 
 ## Get the CLI
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -8,25 +8,28 @@
       "name": "@native-sdk/core",
       "version": "0.9.3",
       "dependencies": {
-        "scriptc": "0.0.31"
+        "scriptc": "0.0.33"
       },
       "devDependencies": {
         "@typescript/old": "npm:typescript@6.0.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@scriptc/compiler": {
-      "version": "0.0.31",
-      "integrity": "sha512-mx0GZXQdYR19jwahXQeo8dgZffi38v2F43n2zvofRsNozjPkh4cJ8qM7ir5xgc1otEfXKHIVMTBh0x/uKq6gbQ==",
+      "version": "0.0.33",
+      "integrity": "sha512-Hkxo+Z0WwY/c/X9jR/EXVqQv4uHxRuVoE7THIdfYOgTbnshqVvW2z8k5womnSu33j4pAV8MCo4vDImgOpoAeUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scriptc/runtime": "0.0.31",
+        "@scriptc/runtime": "0.0.33",
         "typescript": "7.0.2",
         "typescript5": "npm:typescript@5.9.3"
       }
     },
     "node_modules/@scriptc/runtime": {
-      "version": "0.0.31",
-      "integrity": "sha512-NS37+H6blyQGmv24BN11vXmqOZ9igudWOqlkcL1MWvslOemy4vLWqxAe77Ca/51DJCfAu1xui2a3MPq8rQLfcQ==",
+      "version": "0.0.33",
+      "integrity": "sha512-dvmfPdS/Jz4l7rmvnHk76yC469il+zk317RTnTDzP3iW4PHjOhd+W8ZCDgQZEp1VSsNSBy2EQnh2+8Eyv+uVKA==",
       "license": "Apache-2.0"
     },
     "node_modules/@typescript/old": {
@@ -344,17 +347,17 @@
       }
     },
     "node_modules/scriptc": {
-      "version": "0.0.31",
-      "integrity": "sha512-V7cR6080/mqm1PlHeIIlGDHID4aL/Poq+w4U/03935nK0stIJkHaKGtmKZEk5GrOXrejqVEtMNCGjZvYk/ClUQ==",
+      "version": "0.0.33",
+      "integrity": "sha512-GzNvPRl41xzPA+E9hifmhACoIWPHxx2gU0BT++2T1CatrkQLvt5QKrjPw+OZzRLQBtOD/xGr3Tt4lT5gV/ganA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scriptc/compiler": "0.0.31"
+        "@scriptc/compiler": "0.0.33"
       },
       "bin": {
-        "scriptc": "dist/main.js"
+        "scriptc": "dist/bootstrap.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/typescript": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,9 @@
   },
   "homepage": "https://native-sdk.dev",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "types": "./sdk/core.ts",
   "files": [
     "sdk",
@@ -36,6 +39,6 @@
     "@typescript/old": "npm:typescript@6.0.3"
   },
   "dependencies": {
-    "scriptc": "0.0.31"
+    "scriptc": "0.0.33"
   }
 }

--- a/packages/core/pnpm-lock.yaml
+++ b/packages/core/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       scriptc:
-        specifier: 0.0.31
-        version: 0.0.31
+        specifier: 0.0.33
+        version: 0.0.33
     devDependencies:
       '@typescript/old':
         specifier: npm:typescript@6.0.3
@@ -18,11 +18,11 @@ importers:
 
 packages:
 
-  '@scriptc/compiler@0.0.31':
-    resolution: {integrity: sha512-mx0GZXQdYR19jwahXQeo8dgZffi38v2F43n2zvofRsNozjPkh4cJ8qM7ir5xgc1otEfXKHIVMTBh0x/uKq6gbQ==}
+  '@scriptc/compiler@0.0.33':
+    resolution: {integrity: sha512-Hkxo+Z0WwY/c/X9jR/EXVqQv4uHxRuVoE7THIdfYOgTbnshqVvW2z8k5womnSu33j4pAV8MCo4vDImgOpoAeUw==}
 
-  '@scriptc/runtime@0.0.31':
-    resolution: {integrity: sha512-NS37+H6blyQGmv24BN11vXmqOZ9igudWOqlkcL1MWvslOemy4vLWqxAe77Ca/51DJCfAu1xui2a3MPq8rQLfcQ==}
+  '@scriptc/runtime@0.0.33':
+    resolution: {integrity: sha512-dvmfPdS/Jz4l7rmvnHk76yC469il+zk317RTnTDzP3iW4PHjOhd+W8ZCDgQZEp1VSsNSBy2EQnh2+8Eyv+uVKA==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -144,9 +144,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  scriptc@0.0.31:
-    resolution: {integrity: sha512-V7cR6080/mqm1PlHeIIlGDHID4aL/Poq+w4U/03935nK0stIJkHaKGtmKZEk5GrOXrejqVEtMNCGjZvYk/ClUQ==}
-    engines: {node: '>=20'}
+  scriptc@0.0.33:
+    resolution: {integrity: sha512-GzNvPRl41xzPA+E9hifmhACoIWPHxx2gU0BT++2T1CatrkQLvt5QKrjPw+OZzRLQBtOD/xGr3Tt4lT5gV/ganA==}
+    engines: {node: '>=24'}
     hasBin: true
 
   typescript@5.9.3:
@@ -166,13 +166,13 @@ packages:
 
 snapshots:
 
-  '@scriptc/compiler@0.0.31':
+  '@scriptc/compiler@0.0.33':
     dependencies:
-      '@scriptc/runtime': 0.0.31
+      '@scriptc/runtime': 0.0.33
       typescript: 7.0.2
       typescript5: typescript@5.9.3
 
-  '@scriptc/runtime@0.0.31': {}
+  '@scriptc/runtime@0.0.33': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -234,9 +234,9 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  scriptc@0.0.31:
+  scriptc@0.0.33:
     dependencies:
-      '@scriptc/compiler': 0.0.31
+      '@scriptc/compiler': 0.0.33
 
   typescript@5.9.3: {}
 

--- a/packages/core/scripts/compiler_command.mjs
+++ b/packages/core/scripts/compiler_command.mjs
@@ -6,6 +6,7 @@
 // (for example dist/main.js -> dist/bootstrap.js) without a shell boundary.
 
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 function npmBinJavaScript(command) {
@@ -45,4 +46,26 @@ export function compilerArgv(command, options = {}) {
   // Development overrides may name an arbitrary batch file rather than an
   // npm bin. cmd.exe is the Windows executable format's required launcher.
   return [env.ComSpec ?? env.COMSPEC ?? "cmd.exe", "/d", "/s", "/c", argv[0]];
+}
+
+/// Resolve scriptc through its published package `bin` declaration. This is
+/// intentionally not `scriptc/dist/main.js`: 0.0.33's bin points at the Node
+/// 24 compile-cache bootstrap, and future package entrypoint changes should
+/// reach every Native check/build invocation automatically.
+export function publishedScriptcArgv(origin, options = {}) {
+  const node = options.node ?? process.execPath;
+  const packageJson = createRequire(origin).resolve("scriptc/package.json");
+  const manifest = JSON.parse(fs.readFileSync(packageJson, "utf8"));
+  const declared = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.scriptc;
+  if (typeof declared !== "string" || declared.length === 0 || path.isAbsolute(declared)) {
+    throw new Error("scriptc package has no safe published binary entrypoint");
+  }
+  const packageRoot = path.dirname(packageJson);
+  const target = path.resolve(packageRoot, declared);
+  const relative = path.relative(packageRoot, target);
+  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error("scriptc package's published binary entrypoint escapes its package");
+  }
+  if (!fs.statSync(target).isFile()) throw new Error("scriptc package's published binary entrypoint is missing");
+  return [node, target];
 }

--- a/packages/core/scripts/compiler_typecheck.mjs
+++ b/packages/core/scripts/compiler_typecheck.mjs
@@ -14,8 +14,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { publishedScriptcArgv } from "./compiler_command.mjs";
 
 const entry = process.argv[2];
 if (!entry) {
@@ -28,9 +28,9 @@ for (let i = 3; i < process.argv.length; i++) {
 }
 const here = path.dirname(fileURLToPath(import.meta.url));
 const coreRoot = path.resolve(here, "..");
-let compilerJs;
+let compilerArgv;
 try {
-  compilerJs = createRequire(path.join(coreRoot, "package.json")).resolve("scriptc/dist/main.js");
+  compilerArgv = publishedScriptcArgv(path.join(coreRoot, "package.json"));
 } catch {
   console.error("the external core compiler is not installed — run `npm ci --include=dev` in the SDK's packages/core");
   process.exit(2);
@@ -124,7 +124,7 @@ try {
     const npmArgs = isService && vendoredPackages.length > 0
       ? ["--npm-static", vendoredPackages.map((pkg) => pkg.name).join(",")]
       : [];
-    const probe = spawnSync(process.execPath, [compilerJs, "coverage", candidate, ...npmArgs, ...maps], { encoding: "utf8" });
+    const probe = spawnSync(compilerArgv[0], [...compilerArgv.slice(1), "coverage", candidate, ...npmArgs, ...maps], { encoding: "utf8" });
     const out = `${probe.stdout ?? ""}${probe.stderr ?? ""}`;
     // Coverage deliberately reports per-package fallback as a note even
     // when the rest of the source graph is analyzable. Native SDK's policy

--- a/packages/core/scripts/npm_static_spike.mjs
+++ b/packages/core/scripts/npm_static_spike.mjs
@@ -7,13 +7,13 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { publishedScriptcArgv } from "./compiler_command.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const coreRoot = path.resolve(here, "..");
 const repoRoot = path.resolve(coreRoot, "..", "..");
-const compilerJs = createRequire(path.join(coreRoot, "package.json")).resolve("scriptc/dist/main.js");
+const compilerArgv = publishedScriptcArgv(path.join(coreRoot, "package.json"));
 const compilerVersion = JSON.parse(fs.readFileSync(path.join(coreRoot, "package.json"), "utf8")).dependencies.scriptc;
 
 const candidates = [
@@ -38,7 +38,7 @@ for (const candidate of candidates) {
     fs.symlinkSync(pnpmNodeModules(candidate), path.join(scratch, "node_modules"), "dir");
     const entry = path.join(scratch, "probe.ts");
     fs.writeFileSync(entry, candidate.source);
-    const probe = spawnSync(process.execPath, [compilerJs, "coverage", entry, "--npm-static", candidate.name], { encoding: "utf8" });
+    const probe = spawnSync(compilerArgv[0], [...compilerArgv.slice(1), "coverage", entry, "--npm-static", candidate.name], { encoding: "utf8" });
     const output = `${probe.stdout ?? ""}${probe.stderr ?? ""}`;
     if (process.env.NATIVE_NPM_STATIC_SPIKE_VERBOSE === "1") {
       process.stderr.write(`\n===== ${candidate.name}@${candidate.version} =====\n${output}\n`);

--- a/packages/core/test/compiler_command.test.ts
+++ b/packages/core/test/compiler_command.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { compilerArgv } from "../scripts/compiler_command.mjs";
+import { fileURLToPath } from "node:url";
+import { compilerArgv, publishedScriptcArgv } from "../scripts/compiler_command.mjs";
 
 test("Windows npm scriptc shims execute the package's published bin through Node", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "native-scriptc-command-"));
@@ -41,4 +42,11 @@ test("Windows batch-file compiler overrides use cmd.exe while other commands sta
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("published scriptc command follows the package bin bootstrap", () => {
+  const coreRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+  const argv = publishedScriptcArgv(path.join(coreRoot, "package.json"), { node: "node24" });
+  assert.equal(argv[0], "node24");
+  assert.match(argv[1], /scriptc[/\\]dist[/\\]bootstrap\.js$/);
 });

--- a/packages/core/test/ts_run.test.ts
+++ b/packages/core/test/ts_run.test.ts
@@ -1,12 +1,12 @@
 // The layout-neutral runner (build/ts_run.mjs) under both node capability
-// tiers. Where module.registerHooks exists (22.15+; on the 23 line 23.5+)
+// tiers. Node 24 is the common floor because scriptc 0.0.33's published
+// bootstrap uses Node 24's compile cache; module.registerHooks then strips
 // the runner strips EVERY .ts target with the transpiler's own toolchain
 // — node's native stripping is never relied on (it refuses node_modules
-// by design and is only DEFAULT outside node_modules from 22.18, above
-// this tier's floor). On a hooks-less node ANY .ts target must fail fast
+// by design). On a hooks-less Node 24 build ANY .ts target must fail fast
 // with the one-line branch-aware teaching instead of node's raw
 // extension/stripping error — checkout-resident targets included, because
-// 22.15-22.17 has no default stripping for them either.
+// the shared runner requires its load hook.
 //
 // The hooks-less tier is simulated by deleting module.registerHooks in a
 // --import preload before the runner loads — the spawned node then presents
@@ -25,11 +25,9 @@ const pkg = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const runner = path.join(path.dirname(path.dirname(pkg)), "build", "ts_run.mjs");
 
 // Pins the teaching verbatim: the string the runner prints on a node
-// without registerHooks. Layout-neutral on purpose — with the hook
-// required for every .ts target, checkouts hit this teaching exactly like
-// npm installs do — and branch-aware: the hook landed in 22.15 and 23.5,
-// so a bare ">=22.15" would wrongly admit 23.0-23.4.
-const teaching = "TypeScript apps need Node.js 22.15+ (on the 23 line: 23.5+)";
+// without registerHooks. Layout-neutral on purpose: checkouts hit this
+// teaching exactly like npm installs do.
+const teaching = "TypeScript apps need Node.js 24+";
 
 // A module whose types only stripping (the runner's hook) can remove.
 const typedModule = 'const answer: number = 42;\nconsole.log("RAN", answer);\n';
@@ -57,7 +55,7 @@ function runRunner(target: string, { withoutHooks = false } = {}) {
   return spawnSync(process.execPath, args, { encoding: "utf8" });
 }
 
-test("without registerHooks, a node_modules-resident target is taught 22.15+ before import", () => {
+test("without registerHooks, a node_modules-resident target is taught Node 24 before import", () => {
   withFixture(path.join(os.tmpdir(), "tsrun-npm-"), path.join("node_modules", "app", "core.ts"), (target) => {
     const result = runRunner(target, { withoutHooks: true });
     assert.notEqual(result.status, 0);
@@ -67,13 +65,9 @@ test("without registerHooks, a node_modules-resident target is taught 22.15+ bef
   });
 });
 
-test("without registerHooks, a repo-checkout target is taught 22.15+ too (default stripping is 22.18+, not 22.15)", () => {
-  // The old premise — "checkouts keep running natively" — was false:
-  // node's default type stripping only landed in 22.18, so a
-  // hooks-absent node (< 22.15) cannot run a checkout .ts target either
-  // — letting the import proceed would die with
-  // ERR_UNKNOWN_FILE_EXTENSION. Hooks-absent therefore teaches for ANY
-  // .ts target, keeping the 22.15 floor honest for both layouts.
+test("without registerHooks, a repo-checkout target is taught Node 24 too", () => {
+  // Hooks-absent teaches for every .ts target, keeping the Node 24 floor
+  // honest for both layouts.
   withFixture(path.join(os.tmpdir(), "tsrun-checkout-"), path.join("app", "core.ts"), (target) => {
     const result = runRunner(target, { withoutHooks: true });
     assert.notEqual(result.status, 0);
@@ -97,8 +91,7 @@ test("with registerHooks, a node_modules-resident target is stripped and runs", 
 
 test("with registerHooks, a repo-checkout target is stripped by the hook and runs", () => {
   // Checkout-resident modules go through the SAME hook (one code path):
-  // on 22.15-22.17 there is nothing to fall through to, and on 22.18+ the
-  // hook short-circuits before native stripping would apply.
+  // the hook short-circuits before native stripping would apply.
   withFixture(path.join(pkg, ".tsrun-fixture-"), path.join("app", "core.ts"), (target) => {
     const result = runRunner(target);
     assert.equal(result.status, 0, result.stderr);

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.3",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "bin": {
     "native": "bin/native.js"
   },
@@ -32,7 +35,7 @@
   ],
   "dependencies": {
     "@typescript/old": "npm:typescript@6.0.3",
-    "scriptc": "0.0.31"
+    "scriptc": "0.0.33"
   },
   "optionalDependencies": {
     "@native-sdk/cli-darwin-arm64": "0.9.3",

--- a/skill-data/ts-services/references/service-surface.md
+++ b/skill-data/ts-services/references/service-surface.md
@@ -6,7 +6,7 @@
      Verify without writing:
        node packages/core/scripts/gen_service_surface.mjs --check -->
 
-# Service compile surface — scriptc 0.0.31
+# Service compile surface — scriptc 0.0.33
 
 What TypeScript under `src/services/` can use, as stated by the pinned
 compiler itself (surface manifest schema 1, 527 entries:

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -503,7 +503,7 @@ fn tsSlimReadme(allocator: std.mem.Allocator, names: TemplateNames) ![]const u8 
         \\
         \\## Requirements
         \\
-        \\Node.js 22.15+ (on the 23 line: 23.5+) on PATH (the TypeScript frontend
+        \\Node.js 24+ on PATH (the TypeScript frontend
         \\and the core compiler run at build time; your shipped binary carries
         \\none of it).
         \\

--- a/src/tooling/templates.zig
+++ b/src/tooling/templates.zig
@@ -1158,7 +1158,7 @@ fn nativeCiYaml(allocator: std.mem.Allocator, names: TemplateNames, framework_pa
     const node_setup =
         \\      - uses: actions/setup-node@v4
         \\        with:
-        \\          node-version: 22
+        \\          node-version: 24
         \\
     ;
     const compiler_install =
@@ -4531,6 +4531,10 @@ test "writeDefaultApp --full ts-core emits a CI workflow with the node tier" {
     // frontend + compiler install inside the fetched SDK's packages/core,
     // in BOTH jobs (each builds the app, so each compiles the core).
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "actions/setup-node@v4") != null);
+    const node_24 = "node-version: 24";
+    const first_node = std.mem.indexOf(u8, ci_yaml_text, node_24).?;
+    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text[first_node + node_24.len ..], node_24) != null);
+    try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text, "node-version: 22") == null);
     const npm_ci = "npm ci --prefix \"$NATIVE_SDK_PATH/packages/core\"";
     const first = std.mem.indexOf(u8, ci_yaml_text, npm_ci).?;
     try std.testing.expect(std.mem.indexOf(u8, ci_yaml_text[first + npm_ci.len ..], npm_ci) != null);

--- a/src/tooling/ts_core.zig
+++ b/src/tooling/ts_core.zig
@@ -74,7 +74,7 @@ fn nodeMissing() Error {
     std.debug.print(
         \\TypeScript app cores need node on PATH (the @native-sdk/core frontend and the
         \\core dev-harness run under it; the binary you ship carries no JS runtime).
-        \\Install Node.js 22.15+ (on the 23 line: 23.5+) - https://nodejs.org or
+        \\Install Node.js 24+ - https://nodejs.org or
         \\`brew install node` - and re-run.
         \\
     , .{});

--- a/tests/compiled-core/build_core.sh
+++ b/tests/compiled-core/build_core.sh
@@ -33,8 +33,8 @@ repo="$(cd "$(dirname "$0")/../.." && pwd)"
 
 if [ -n "${NATIVE_SDK_CORE_COMPILER:-}" ]; then
   compiler="$NATIVE_SDK_CORE_COMPILER"
-elif [ -f "$repo/packages/core/node_modules/scriptc/dist/main.js" ]; then
-  compiler="node $repo/packages/core/node_modules/scriptc/dist/main.js"
+elif [ -x "$repo/packages/core/node_modules/.bin/scriptc" ]; then
+  compiler="$repo/packages/core/node_modules/.bin/scriptc"
 else
   echo "the external core compiler is not installed — run \`npm ci --prefix $repo/packages/core\` (or point NATIVE_SDK_CORE_COMPILER at the pinned release's command)" >&2
   exit 2

--- a/tests/compiled-core/fence_check.sh
+++ b/tests/compiled-core/fence_check.sh
@@ -19,8 +19,8 @@ repo="$(cd "$(dirname "$0")/../.." && pwd)"
 
 if [ -n "${NATIVE_SDK_CORE_COMPILER:-}" ]; then
   compiler="$NATIVE_SDK_CORE_COMPILER"
-elif [ -f "$repo/packages/core/node_modules/scriptc/dist/main.js" ]; then
-  compiler="node $repo/packages/core/node_modules/scriptc/dist/main.js"
+elif [ -x "$repo/packages/core/node_modules/.bin/scriptc" ]; then
+  compiler="$repo/packages/core/node_modules/.bin/scriptc"
 else
   echo "fence-check: skipped — run \`npm ci --prefix $repo/packages/core\` (or set NATIVE_SDK_CORE_COMPILER) to run the determinism-fence negative control"
   exit 0

--- a/tests/ts-services/npm-static-spike.json
+++ b/tests/ts-services/npm-static-spike.json
@@ -1,6 +1,6 @@
 {
-  "date": "2026-08-14",
-  "compiler": "scriptc 0.0.31",
+  "date": "2026-08-17",
+  "compiler": "scriptc 0.0.33",
   "policy": "explicit --npm-static; no auto or dynamic fallback",
   "method": "packages/core/scripts/npm_static_spike.mjs against exact package bytes in the locked docs workspace",
   "summary": "3 of 5 deliberately small candidates cleared 100% static coverage; nanoid and micromark were refused, so package support is selective",

--- a/tools/corewire/emit_profile.zig
+++ b/tools/corewire/emit_profile.zig
@@ -197,9 +197,12 @@ const ProfileEmitter = struct {
             \\  "entry": {s},
             \\  "emission": "llvm",
         , .{try self.jsonString(entry)});
-        if (self.optimization) |optimization| try self.print(
-            \\  "optimization": {s},
-        , .{try self.jsonString(optimization)});
+        if (self.optimization) |optimization| {
+            try self.print(
+                \\  "optimization": {s},
+            , .{try self.jsonString(optimization)});
+            try self.raw("\n");
+        }
         try self.print(
             \\  "abi": {{
             \\    "prefix": {s},

--- a/tools/corewire/emit_service.zig
+++ b/tools/corewire/emit_service.zig
@@ -600,9 +600,12 @@ pub fn emitInprocProfile(arena: std.mem.Allocator, optimization: ?[]const u8) ![
         \\  "entry": "service_inproc_main.ts",
         \\  "emission": "llvm",
     );
-    if (optimization) |value| try w.print(
-        \\  "optimization": "{s}",
-    , .{value});
+    if (optimization) |value| {
+        try w.print(
+            \\  "optimization": "{s}",
+        , .{value});
+        try w.writeByte('\n');
+    }
     try w.print(
         \\  "abi": {{
         \\    "prefix": "{s}",


### PR DESCRIPTION
- Pin scriptc 0.0.33 across Native packages and refresh compiler surface and calibration artifacts.
- Require Node 24 and route check/build tooling through scriptc's published compile-cache bootstrap.
- Enable and verify dev/release library profiles with synchronized docs, tests, and package mirrors.