### PR TITLE
feat(schema): redirect non-schema paths to native-sdk.dev

### DIFF
--- a/apps/schema/README.md
+++ b/apps/schema/README.md
@@ -5,6 +5,10 @@ Static JSON Schemas published at `schema.native-sdk.dev`.
 - `/app/v1.json` is the stable-major schema URL scaffolded into `app.json`.
 - `/app.json` is the short-lived current-version alias.
 
+Only those schema URLs are served from this deployment. Every other path
+redirects (302) to `https://native-sdk.dev`, so the domain stays a single-
+purpose home for the manifest rather than hosting arbitrary content.
+
 Create the Vercel project as `native-schema`, set its root directory to
 `apps/schema`, leave the framework preset as Other with no build command, and
 attach `schema.native-sdk.dev`. `vercel.json` sets the output directory to

--- a/apps/schema/vercel.json
+++ b/apps/schema/vercel.json
@@ -2,8 +2,14 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "outputDirectory": "public",
   "rewrites": [
-    { "source": "/app.json", "destination": "/app/v1.json" },
-    { "source": "/(.*)", "destination": "https://native-sdk.dev" }
+    { "source": "/app.json", "destination": "/app/v1.json" }
+  ],
+  "redirects": [
+    {
+      "source": "/((?!app(?:\\.json|/v1\\.json)$).*)",
+      "destination": "https://native-sdk.dev",
+      "statusCode": 302
+    }
   ],
   "headers": [
     {

--- a/apps/schema/vercel.json
+++ b/apps/schema/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "outputDirectory": "public",
   "rewrites": [
-    { "source": "/app.json", "destination": "/app/v1.json" }
+    { "source": "/app.json", "destination": "/app/v1.json" },
+    { "source": "/(.*)", "destination": "https://native-sdk.dev" }
   ],
   "headers": [
     {

--- a/docs/scripts/check-app-schema.mjs
+++ b/docs/scripts/check-app-schema.mjs
@@ -27,13 +27,22 @@ assert.equal(schema.$defs.dmg.properties.icon_size.maximum, 256);
 assert.deepEqual(fs.readFileSync(legacyPath), publishedBytes, "legacy docs schema differs from canonical v1");
 assert.deepEqual(fs.readFileSync(packagePath), publishedBytes, "published and npm-packaged app schemas differ");
 assert.equal(deployment.outputDirectory, "public");
-// /app.json aliases the canonical schema; every other path 302-redirects
-// away from the single-purpose schema domain (files like /app/v1.json are
-// served directly and take precedence over this rewrites list).
-assert.deepEqual(deployment.rewrites, [
-  { source: "/app.json", destination: "/app/v1.json" },
-  { source: "/(.*)", destination: "https://native-sdk.dev" },
+// /app.json aliases the canonical schema; the redirect's negative lookahead
+// keeps both schema URLs local while every other path returns an actual 302.
+assert.deepEqual(deployment.rewrites, [{ source: "/app.json", destination: "/app/v1.json" }]);
+assert.deepEqual(deployment.redirects, [
+  {
+    source: "/((?!app(?:\\.json|/v1\\.json)$).*)",
+    destination: "https://native-sdk.dev",
+    statusCode: 302,
+  },
 ]);
+const redirectPattern = new RegExp(`^${deployment.redirects[0].source}$`);
+assert.equal(redirectPattern.test("/app.json"), false);
+assert.equal(redirectPattern.test("/app/v1.json"), false);
+assert.equal(redirectPattern.test("/"), true);
+assert.equal(redirectPattern.test("/docs"), true);
+assert.equal(redirectPattern.test("/app/v2.json"), true);
 assert.ok(deployment.headers.some((entry) => entry.source === "/app/v1.json"));
 assert.ok(deployment.headers.some((entry) => entry.source === "/app.json"));
 

--- a/docs/scripts/check-app-schema.mjs
+++ b/docs/scripts/check-app-schema.mjs
@@ -27,7 +27,13 @@ assert.equal(schema.$defs.dmg.properties.icon_size.maximum, 256);
 assert.deepEqual(fs.readFileSync(legacyPath), publishedBytes, "legacy docs schema differs from canonical v1");
 assert.deepEqual(fs.readFileSync(packagePath), publishedBytes, "published and npm-packaged app schemas differ");
 assert.equal(deployment.outputDirectory, "public");
-assert.deepEqual(deployment.rewrites, [{ source: "/app.json", destination: "/app/v1.json" }]);
+// /app.json aliases the canonical schema; every other path 302-redirects
+// away from the single-purpose schema domain (files like /app/v1.json are
+// served directly and take precedence over this rewrites list).
+assert.deepEqual(deployment.rewrites, [
+  { source: "/app.json", destination: "/app/v1.json" },
+  { source: "/(.*)", destination: "https://native-sdk.dev" },
+]);
 assert.ok(deployment.headers.some((entry) => entry.source === "/app/v1.json"));
 assert.ok(deployment.headers.some((entry) => entry.source === "/app.json"));
 


### PR DESCRIPTION
- schema.native-sdk.dev now serves only /app/v1.json and its /app.json alias
- Every other path catches and redirects (302) to https://native-sdk.dev
- Update pinned docs check and schema README to match the new routing