### PR TITLE
Prepare v0.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,30 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.9.4
+## 0.9.5
 
 <!-- release:start -->
+
+### New Features
+
+- **JSON manifests by default**: New TypeScript, Zig, web, full, and ejected apps now scaffold with `app.json`, backed by full parsing, discovery, build conversion, validation, vendoring, a published versioned schema, and seamless `app.zon` fallback for existing projects (#385).
+- **Registered-image source cropping**: Canvas image options and Native markup can now select atomic source rectangles from registered images for texture-atlas rendering, with schema, compiler, validation, documentation, and sampling-bleed coverage (#390).
+
+### Bug Fixes
+
+- **Reliable installed TypeScript toolchains**: Core and service builds now resolve ScriptC across nested, hoisted, and global sibling npm layouts, generate the complete SQLite SDK module family, and validate library imports against their actual directories (#389).
+
+### Improvements
+
+- **Focused schema hosting**: `schema.native-sdk.dev` now serves only the versioned app schema and its current-version alias, redirecting every non-schema route to the main Native SDK site (#388).
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.9.4
 
 ### New Features
 
@@ -18,8 +39,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.9.3
 

--- a/examples/gpu-components/package.json
+++ b/examples/gpu-components/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/menu-bar/package.json
+++ b/examples/menu-bar/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "TypeScript + Native markup menu-bar lifecycle example.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/record-store/package.json
+++ b/examples/record-store/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/relational-notes/package.json
+++ b/examples/relational-notes/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/examples/voice-memo/package.json
+++ b/examples/voice-memo/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.4"
+    "@native-sdk/core": "0.9.5"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "dependencies": {
         "scriptc": "0.0.33"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "engines": {
@@ -39,14 +39,14 @@
     "scriptc": "0.0.33"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.9.4",
-    "@native-sdk/cli-darwin-x64": "0.9.4",
-    "@native-sdk/cli-linux-arm64-gnu": "0.9.4",
-    "@native-sdk/cli-linux-arm64-musl": "0.9.4",
-    "@native-sdk/cli-linux-x64-gnu": "0.9.4",
-    "@native-sdk/cli-linux-x64-musl": "0.9.4",
-    "@native-sdk/cli-win32-arm64": "0.9.4",
-    "@native-sdk/cli-win32-x64": "0.9.4"
+    "@native-sdk/cli-darwin-arm64": "0.9.5",
+    "@native-sdk/cli-darwin-x64": "0.9.5",
+    "@native-sdk/cli-linux-arm64-gnu": "0.9.5",
+    "@native-sdk/cli-linux-arm64-musl": "0.9.5",
+    "@native-sdk/cli-linux-x64-gnu": "0.9.5",
+    "@native-sdk/cli-linux-x64-musl": "0.9.5",
+    "@native-sdk/cli-win32-arm64": "0.9.5",
+    "@native-sdk/cli-win32-x64": "0.9.5"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.9.4";
+const version = "0.9.5";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
- Make app.json the default manifest with a published versioned schema.
- Add registered-image source cropping and harden installed TypeScript toolchain resolution.
- Synchronize v0.9.5 package metadata and release notes.