### PR TITLE
fix(core): state integer proofs in sdk/text.ts range constructors

### DIFF
--- a/packages/core/sdk/text.ts
+++ b/packages/core/sdk/text.ts
@@ -74,8 +74,9 @@ export interface TextEditState {
 }
 
 function rangeNormalized(r: TextRange, textLen: number): TextRange {
-  const start = Math.min(r.start, textLen);
-  const end = Math.min(r.end, textLen);
+  const wholeLen = textLen >= 0 && textLen <= 9007199254740991 ? Math.trunc(textLen) : 0;
+  const start = r.start > wholeLen ? wholeLen : r.start;
+  const end = r.end > wholeLen ? wholeLen : r.end;
   return start <= end ? { start: start, end: end } : { start: end, end: start };
 }
 
@@ -238,13 +239,11 @@ function snapTextCaretSelection(text: Uint8Array, selection: TextSelection): Tex
 
 function snapTextRange(text: Uint8Array, range: TextRange): TextRange {
   const normalized = rangeNormalized(range, text.length);
-  return rangeNormalized(
-    {
-      start: snapTextOffset(text, normalized.start),
-      end: snapTextOffset(text, normalized.end),
-    },
-    text.length,
-  );
+  const rawStart = snapTextOffset(text, normalized.start);
+  const rawEnd = snapTextOffset(text, normalized.end);
+  const start = rawStart >= 0 && rawStart <= 9007199254740991 ? Math.trunc(rawStart) : 0;
+  const end = rawEnd >= 0 && rawEnd <= 9007199254740991 ? Math.trunc(rawEnd) : 0;
+  return rangeNormalized({ start: start, end: end }, text.length);
 }
 
 interface TextReplaceResult {
@@ -322,7 +321,10 @@ function setTextComposition(
   return {
     text: result.text,
     selection: caretSelectionAt(absoluteCursor, absoluteCursor),
-    composition: { start: result.insertedStart, end: result.insertedEnd },
+    composition: {
+      start: result.insertedStart >= 0 && result.insertedStart <= 9007199254740991 ? Math.trunc(result.insertedStart) : 0,
+      end: result.insertedEnd >= 0 && result.insertedEnd <= 9007199254740991 ? Math.trunc(result.insertedEnd) : 0,
+    },
   };
 }
 
@@ -350,9 +352,13 @@ function deleteBackwardTextEdit(state: TextEditState, capacity: number): TextEdi
   if (caret === 0) {
     return { text: state.text, selection: { anchor: 0, focus: 0 }, composition: null };
   }
+  const rawStart = previousTextCaretOffset(state.text, caret);
   return replaceTextEditRange(
     state,
-    { start: previousTextCaretOffset(state.text, caret), end: caret },
+    {
+      start: rawStart >= 0 && rawStart <= 9007199254740991 ? Math.trunc(rawStart) : 0,
+      end: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0,
+    },
     new Uint8Array(0),
     capacity,
     null,
@@ -370,9 +376,13 @@ function deleteForwardTextEdit(state: TextEditState, capacity: number): TextEdit
     const len = state.text.length;
     return { text: state.text, selection: caretSelectionAt(len, len), composition: null };
   }
+  const rawEnd = nextTextCaretOffset(state.text, caret);
   return replaceTextEditRange(
     state,
-    { start: caret, end: nextTextCaretOffset(state.text, caret) },
+    {
+      start: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0,
+      end: rawEnd >= 0 && rawEnd <= 9007199254740991 ? Math.trunc(rawEnd) : 0,
+    },
     new Uint8Array(0),
     capacity,
     null,
@@ -389,9 +399,13 @@ function deleteWordBackwardTextEdit(state: TextEditState, capacity: number): Tex
   if (caret === 0) {
     return { text: state.text, selection: { anchor: 0, focus: 0 }, composition: null };
   }
+  const rawStart = previousTextWordOffset(state.text, caret);
   return replaceTextEditRange(
     state,
-    { start: previousTextWordOffset(state.text, caret), end: caret },
+    {
+      start: rawStart >= 0 && rawStart <= 9007199254740991 ? Math.trunc(rawStart) : 0,
+      end: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0,
+    },
     new Uint8Array(0),
     capacity,
     null,
@@ -409,9 +423,13 @@ function deleteWordForwardTextEdit(state: TextEditState, capacity: number): Text
     const len = state.text.length;
     return { text: state.text, selection: caretSelectionAt(len, len), composition: null };
   }
+  const rawEnd = nextTextWordOffset(state.text, caret);
   return replaceTextEditRange(
     state,
-    { start: caret, end: nextTextWordOffset(state.text, caret) },
+    {
+      start: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0,
+      end: rawEnd >= 0 && rawEnd <= 9007199254740991 ? Math.trunc(rawEnd) : 0,
+    },
     new Uint8Array(0),
     capacity,
     null,
@@ -436,7 +454,7 @@ function deleteToStartTextEdit(state: TextEditState, capacity: number): TextEdit
   }
   return replaceTextEditRange(
     state,
-    { start: 0, end: caret },
+    { start: 0, end: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0 },
     new Uint8Array(0),
     capacity,
     null,
@@ -456,7 +474,10 @@ function deleteToLineStartTextEdit(state: TextEditState, capacity: number): Text
   }
   return replaceTextEditRange(
     state,
-    { start: lineStart, end: caret },
+    {
+      start: lineStart >= 0 && lineStart <= 9007199254740991 ? Math.trunc(lineStart) : 0,
+      end: caret >= 0 && caret <= 9007199254740991 ? Math.trunc(caret) : 0,
+    },
     new Uint8Array(0),
     capacity,
     null,


### PR DESCRIPTION
## Problem

The shipped `packages/core/sdk/text.ts` (v0.9.5, unchanged on `main`) fails the **pinned** scriptc 0.0.33 integer-boundary checks — 19 × SC4022/SC4023 errors on every `TextRange`/`TextSelection` construction that isn't routed through `caretSelectionAt`:

```
sdk/text.ts:79:34 - error SC4023: integer slot 'TextRange.start' (i64) cannot be proven — range failed: the proven range [-Infinity, 9007199254740991] does not fit [-9007199254740991, 9007199254740991] — integrality is provable only within ±(2^53 − 1)
sdk/text.ts:79:63 - error SC4022: integer slot 'TextRange.start' (i64) cannot be proven — wholeness failed: the value may be NaN, which is not a whole number
…
```

Any TS-core app that imports `@native-sdk/core/text` — i.e. every app with a text field — fails `native build`. Note `native check` stays green: this refusal comes from the external core compiler's integer-boundary proofs, not the NS subset checker, and the repo's external-compiler tests stub scriptc with a fixture, so CI never compiles this module with the real pinned compiler.

## Fix

State each offset whole in place, using the module's own established idiom — `caretSelectionAt` already documents exactly this pattern:

> offsets are whole byte offsets by contract, proven in place — range-guarded (an ordered comparison excludes NaN) and stated whole with Math.trunc. A value outside the provable ±(2^53 − 1) window clamps to 0, the same floor every caller's snap already applies.

This extends that form to `rangeNormalized`, `snapTextRange`, `setTextComposition`, and the six delete-* edit paths. No behavior change on reachable values: every internal producer already returns whole, non-negative byte offsets ≤ text length.

## Verification

- Reproduced all 19 SC4022/SC4023 errors on an app importing `@native-sdk/core/text` with the unpatched module; with this patch the same app builds clean (`native build`, ReleaseFast).
- `node --test packages/core/test/text.test.ts` — 6/6 pass.
- Differential fuzz vs the unpatched module: 4000 rounds / ~23k applied `applyTextInputEvent` + `clampedInsertEvent` calls over random UTF-8 text (multibyte, CRLF, selections, compositions, capacity refusals) — byte-identical states.
- `tsc --noEmit --strict` clean on the patched module.

Possible follow-up (out of scope here): a CI lane that compiles `sdk/text.ts` / `sdk/events.ts` with the real pinned scriptc would catch this class of regression — the current external-compiler tests stub scriptc.
