### PR TITLE
chore(core): upgrade scriptc to 0.0.35

### DIFF
--- a/build/ts_run.mjs
+++ b/build/ts_run.mjs
@@ -13,7 +13,7 @@
 // relied on: it refuses node_modules-resident .ts by design
 // (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING), and outside node_modules
 // it only became DEFAULT in node 22.18. Hooking everything keeps both layouts
-// identical. scriptc 0.0.33 requires Node 24 for its published compile-cache
+// identical. scriptc 0.0.35 requires Node 24 for its published compile-cache
 // bootstrap, so this shared runner enforces the same floor before importing
 // any frontend module. Then it imports the requested module with argv
 // respliced so the target sees its usual shape (its own path at argv[1],

--- a/docs/src/app/docs/quick-start/page.mdx
+++ b/docs/src/app/docs/quick-start/page.mdx
@@ -7,7 +7,7 @@ Native SDK is the complete toolkit for building beautiful native desktop applica
 ## Prerequisites
 
 - macOS 11 or newer, Linux, or Windows
-- Node.js 24+ for the default TypeScript scaffold — the TypeScript frontend (the checker), scriptc compiler, and core dev loop run under it at build and dev time; scriptc 0.0.33 uses Node 24's compile cache to accelerate repeated invocations. The binary you ship carries no JS runtime. A Zig-core app (`--template zig-core`) needs Node only when it declares relational SQLite, whose schema checker and migration generator run at build time.
+- Node.js 24+ for the default TypeScript scaffold — the TypeScript frontend (the checker), scriptc compiler, and core dev loop run under it at build and dev time; scriptc 0.0.35 uses Node 24's compile cache to accelerate repeated invocations. The binary you ship carries no JS runtime. A Zig-core app (`--template zig-core`) needs Node only when it declares relational SQLite, whose schema checker and migration generator run at build time.
 
 ## Get the CLI
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@native-sdk/core",
       "version": "0.9.5",
       "dependencies": {
-        "scriptc": "0.0.33"
+        "scriptc": "0.0.35"
       },
       "devDependencies": {
         "@typescript/old": "npm:typescript@6.0.3"
@@ -18,18 +18,18 @@
       }
     },
     "node_modules/@scriptc/compiler": {
-      "version": "0.0.33",
-      "integrity": "sha512-Hkxo+Z0WwY/c/X9jR/EXVqQv4uHxRuVoE7THIdfYOgTbnshqVvW2z8k5womnSu33j4pAV8MCo4vDImgOpoAeUw==",
+      "version": "0.0.35",
+      "integrity": "sha512-OLTmyGpFPJAAVn0RfRBoXuCjpaTfpBC1wt6XdO/SzqMab/DaRjCIJY9vv5b1VspP6zLZP2WEYWZPgP8vHKAJPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scriptc/runtime": "0.0.33",
+        "@scriptc/runtime": "0.0.35",
         "typescript": "7.0.2",
         "typescript5": "npm:typescript@5.9.3"
       }
     },
     "node_modules/@scriptc/runtime": {
-      "version": "0.0.33",
-      "integrity": "sha512-dvmfPdS/Jz4l7rmvnHk76yC469il+zk317RTnTDzP3iW4PHjOhd+W8ZCDgQZEp1VSsNSBy2EQnh2+8Eyv+uVKA==",
+      "version": "0.0.35",
+      "integrity": "sha512-kjtKfneGr9YGxx631jOPJ1XVh0X6h5LM+rwQmhF6loI9oA+zW7rlYmoF+VkTXLdkre+bu9LptIIgdxKPdAquPA==",
       "license": "Apache-2.0"
     },
     "node_modules/@typescript/old": {
@@ -347,11 +347,12 @@
       }
     },
     "node_modules/scriptc": {
-      "version": "0.0.33",
-      "integrity": "sha512-GzNvPRl41xzPA+E9hifmhACoIWPHxx2gU0BT++2T1CatrkQLvt5QKrjPw+OZzRLQBtOD/xGr3Tt4lT5gV/ganA==",
+      "version": "0.0.35",
+      "integrity": "sha512-46Td/02HJZNLuosdYDiUSQ+auKwGmQ03+odD6Pg+J7D+eAV7sOYQvjZu9M+3ePyYfL3hFQa6wWiGexV/Bd0r+w==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@scriptc/compiler": "0.0.33"
+        "@scriptc/compiler": "0.0.35"
       },
       "bin": {
         "scriptc": "dist/bootstrap.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,6 @@
     "@typescript/old": "npm:typescript@6.0.3"
   },
   "dependencies": {
-    "scriptc": "0.0.33"
+    "scriptc": "0.0.35"
   }
 }

--- a/packages/core/pnpm-lock.yaml
+++ b/packages/core/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       scriptc:
-        specifier: 0.0.33
-        version: 0.0.33
+        specifier: 0.0.35
+        version: 0.0.35
     devDependencies:
       '@typescript/old':
         specifier: npm:typescript@6.0.3
@@ -18,11 +18,11 @@ importers:
 
 packages:
 
-  '@scriptc/compiler@0.0.33':
-    resolution: {integrity: sha512-Hkxo+Z0WwY/c/X9jR/EXVqQv4uHxRuVoE7THIdfYOgTbnshqVvW2z8k5womnSu33j4pAV8MCo4vDImgOpoAeUw==}
+  '@scriptc/compiler@0.0.35':
+    resolution: {integrity: sha512-OLTmyGpFPJAAVn0RfRBoXuCjpaTfpBC1wt6XdO/SzqMab/DaRjCIJY9vv5b1VspP6zLZP2WEYWZPgP8vHKAJPg==}
 
-  '@scriptc/runtime@0.0.33':
-    resolution: {integrity: sha512-dvmfPdS/Jz4l7rmvnHk76yC469il+zk317RTnTDzP3iW4PHjOhd+W8ZCDgQZEp1VSsNSBy2EQnh2+8Eyv+uVKA==}
+  '@scriptc/runtime@0.0.35':
+    resolution: {integrity: sha512-kjtKfneGr9YGxx631jOPJ1XVh0X6h5LM+rwQmhF6loI9oA+zW7rlYmoF+VkTXLdkre+bu9LptIIgdxKPdAquPA==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -144,8 +144,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  scriptc@0.0.33:
-    resolution: {integrity: sha512-GzNvPRl41xzPA+E9hifmhACoIWPHxx2gU0BT++2T1CatrkQLvt5QKrjPw+OZzRLQBtOD/xGr3Tt4lT5gV/ganA==}
+  scriptc@0.0.35:
+    resolution: {integrity: sha512-46Td/02HJZNLuosdYDiUSQ+auKwGmQ03+odD6Pg+J7D+eAV7sOYQvjZu9M+3ePyYfL3hFQa6wWiGexV/Bd0r+w==}
     engines: {node: '>=24'}
     hasBin: true
 
@@ -166,13 +166,13 @@ packages:
 
 snapshots:
 
-  '@scriptc/compiler@0.0.33':
+  '@scriptc/compiler@0.0.35':
     dependencies:
-      '@scriptc/runtime': 0.0.33
+      '@scriptc/runtime': 0.0.35
       typescript: 7.0.2
       typescript5: typescript@5.9.3
 
-  '@scriptc/runtime@0.0.33': {}
+  '@scriptc/runtime@0.0.35': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -234,9 +234,9 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  scriptc@0.0.33:
+  scriptc@0.0.35:
     dependencies:
-      '@scriptc/compiler': 0.0.33
+      '@scriptc/compiler': 0.0.35
 
   typescript@5.9.3: {}
 

--- a/packages/core/scripts/compiler_command.mjs
+++ b/packages/core/scripts/compiler_command.mjs
@@ -49,7 +49,7 @@ export function compilerArgv(command, options = {}) {
 }
 
 /// Resolve scriptc through its published package `bin` declaration. This is
-/// intentionally not `scriptc/dist/main.js`: 0.0.33's bin points at the Node
+/// intentionally not `scriptc/dist/main.js`: 0.0.35's bin points at the Node
 /// 24 compile-cache bootstrap, and future package entrypoint changes should
 /// reach every Native check/build invocation automatically.
 export function publishedScriptcArgv(origin, options = {}) {

--- a/packages/core/test/ts_run.test.ts
+++ b/packages/core/test/ts_run.test.ts
@@ -1,5 +1,5 @@
 // The layout-neutral runner (build/ts_run.mjs) under both node capability
-// tiers. Node 24 is the common floor because scriptc 0.0.33's published
+// tiers. Node 24 is the common floor because scriptc 0.0.35's published
 // bootstrap uses Node 24's compile cache; module.registerHooks then strips
 // the runner strips EVERY .ts target with the transpiler's own toolchain
 // — node's native stripping is never relied on (it refuses node_modules

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@typescript/old": "npm:typescript@6.0.3",
-    "scriptc": "0.0.33"
+    "scriptc": "0.0.35"
   },
   "optionalDependencies": {
     "@native-sdk/cli-darwin-arm64": "0.9.5",

--- a/skill-data/ts-services/references/service-surface.md
+++ b/skill-data/ts-services/references/service-surface.md
@@ -6,7 +6,7 @@
      Verify without writing:
        node packages/core/scripts/gen_service_surface.mjs --check -->
 
-# Service compile surface — scriptc 0.0.33
+# Service compile surface — scriptc 0.0.35
 
 What TypeScript under `src/services/` can use, as stated by the pinned
 compiler itself (surface manifest schema 1, 527 entries:

--- a/tests/ts-services/npm-static-spike.json
+++ b/tests/ts-services/npm-static-spike.json
@@ -1,6 +1,6 @@
 {
-  "date": "2026-08-17",
-  "compiler": "scriptc 0.0.33",
+  "date": "2026-08-22",
+  "compiler": "scriptc 0.0.35",
   "policy": "explicit --npm-static; no auto or dynamic fallback",
   "method": "packages/core/scripts/npm_static_spike.mjs against exact package bytes in the locked docs workspace",
   "summary": "3 of 5 deliberately small candidates cleared 100% static coverage; nanoid and micromark were refused, so package support is selective",


### PR DESCRIPTION
- Upgrade the Native SDK core and CLI compiler dependency to scriptc 0.0.35.
- Refresh npm/pnpm locks and generated service-surface calibration metadata.
- Synchronize compiler references across tooling, tests, and documentation.