### PR TITLE
Prepare Native SDK v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,30 @@
 
 All notable changes to the Native SDK (formerly zero-native) will be documented in this file.
 
-## 0.9.5
+## 0.10.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Native macOS app updates**: Apps can publish Ed25519-signed update feeds that verify downloads, atomically replace and relaunch the installed bundle, roll back safely on failure, and integrate with new manifest settings plus CLI key-generation, feed-signing, and updater-package commands (#398).
+
+### Bug Fixes
+
+- **Accurate macOS text baselines**: AppKit text rendering now aligns each resolved font by its ascent, preserves fallback ink headroom, and keeps measured and rect-based layouts consistent (#396).
+
+### Improvements
+
+- **Updated compiler integration**: ScriptC advances to 0.0.35 with refreshed compiler-surface calibration, generated contracts, and synchronized package metadata (#395).
+
+### Contributors
+
+- @ctate
+- @sepehr-safari
+
+<!-- release:end -->
+
+## 0.9.5
 
 ### New Features
 
@@ -22,8 +43,6 @@ All notable changes to the Native SDK (formerly zero-native) will be documented 
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.9.4
 

--- a/examples/gpu-components/package.json
+++ b/examples/gpu-components/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/menu-bar/package.json
+++ b/examples/menu-bar/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "TypeScript + Native markup menu-bar lifecycle example.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/record-store/package.json
+++ b/examples/record-store/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor surface for the TypeScript core; the native CLI builds without node_modules.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/relational-notes/package.json
+++ b/examples/relational-notes/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/soundboard-ts/package.json
+++ b/examples/soundboard-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/system-monitor-ts/package.json
+++ b/examples/system-monitor-ts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/examples/voice-memo/package.json
+++ b/examples/voice-memo/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Editor and versioning surface only: stock TypeScript tooling resolves @native-sdk/core from here. The native CLI never reads it and builds with node_modules absent.",
   "dependencies": {
-    "@native-sdk/core": "0.9.5"
+    "@native-sdk/core": "0.10.0"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@native-sdk/core",
-      "version": "0.9.5",
+      "version": "0.10.0",
       "dependencies": {
         "scriptc": "0.0.35"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/core",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The TypeScript authoring tier: the app-core subset, its checker and contract frontend, the exact-pinned core compiler dependency, and the SDK module cores import",
   "repository": {
     "type": "git",

--- a/packages/native-sdk/npm/darwin-arm64/package.json
+++ b/packages/native-sdk/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-arm64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for macOS on Apple silicon (arm64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/darwin-x64/package.json
+++ b/packages/native-sdk/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-darwin-x64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for macOS on Intel (x64)",
   "os": [
     "darwin"

--- a/packages/native-sdk/npm/linux-arm64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-gnu",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Linux arm64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-arm64-musl/package.json
+++ b/packages/native-sdk/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-arm64-musl",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Linux arm64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-gnu/package.json
+++ b/packages/native-sdk/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-gnu",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/linux-x64-musl/package.json
+++ b/packages/native-sdk/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-linux-x64-musl",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Linux x64 (musl)",
   "os": [
     "linux"

--- a/packages/native-sdk/npm/win32-arm64/package.json
+++ b/packages/native-sdk/npm/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-arm64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Windows on ARM (arm64)",
   "os": [
     "win32"

--- a/packages/native-sdk/npm/win32-x64/package.json
+++ b/packages/native-sdk/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli-win32-x64",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The native CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/native-sdk/package.json
+++ b/packages/native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@native-sdk/cli",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "The Native SDK: the complete toolkit for building native desktop applications — declarative markup, native rendering, WebView surfaces, and OS capabilities",
   "type": "module",
   "engines": {
@@ -39,14 +39,14 @@
     "scriptc": "0.0.35"
   },
   "optionalDependencies": {
-    "@native-sdk/cli-darwin-arm64": "0.9.5",
-    "@native-sdk/cli-darwin-x64": "0.9.5",
-    "@native-sdk/cli-linux-arm64-gnu": "0.9.5",
-    "@native-sdk/cli-linux-arm64-musl": "0.9.5",
-    "@native-sdk/cli-linux-x64-gnu": "0.9.5",
-    "@native-sdk/cli-linux-x64-musl": "0.9.5",
-    "@native-sdk/cli-win32-arm64": "0.9.5",
-    "@native-sdk/cli-win32-x64": "0.9.5"
+    "@native-sdk/cli-darwin-arm64": "0.10.0",
+    "@native-sdk/cli-darwin-x64": "0.10.0",
+    "@native-sdk/cli-linux-arm64-gnu": "0.10.0",
+    "@native-sdk/cli-linux-arm64-musl": "0.10.0",
+    "@native-sdk/cli-linux-x64-gnu": "0.10.0",
+    "@native-sdk/cli-linux-x64-musl": "0.10.0",
+    "@native-sdk/cli-win32-arm64": "0.10.0",
+    "@native-sdk/cli-win32-x64": "0.10.0"
   },
   "repository": {
     "type": "git",

--- a/tools/native-sdk/main.zig
+++ b/tools/native-sdk/main.zig
@@ -6,7 +6,7 @@ const tooling = @import("tooling");
 const automation_protocol = @import("automation_protocol");
 const cli_build_info = @import("cli_build_info");
 
-const version = "0.9.5";
+const version = "0.10.0";
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();


### PR DESCRIPTION
## Summary

- Bump the Native SDK CLI, platform packages, TypeScript core package, lockfile, CLI-reported version, and TypeScript example dependency pins to `0.10.0`.
- Add the v0.10.0 changelog entry covering signed native macOS app updates, corrected AppKit text baselines, and the ScriptC 0.0.35 integration.
- Move the release markers to v0.10.0 so release automation selects only the newest entry.

## Why

This prepares a consistent minor release across every published package and dependent example while documenting the user-facing changes included since v0.9.5.

## Verification

- `scripts/gate.sh fast main`
- `node packages/native-sdk/scripts/check-version-sync.js`
- `git diff --check main...HEAD`