### PR TITLE
Raise retained widget layout budget 1024 -> 2048 nodes per view

### DIFF
--- a/src/automation/snapshot.zig
+++ b/src/automation/snapshot.zig
@@ -10,7 +10,7 @@ pub const max_views: usize = platform.max_windows + platform.max_views + platfor
 // cannot import the runtime); a lockstep test in
 // canvas_widget_layout_tests.zig fails if they drift, so snapshots never
 // silently truncate widget enumeration below the node budget.
-pub const max_widgets_per_view: usize = 1024;
+pub const max_widgets_per_view: usize = 2048;
 pub const max_widgets: usize = platform.max_views * max_widgets_per_view;
 
 pub const Window = struct {

--- a/src/runtime/canvas_limits.zig
+++ b/src/runtime/canvas_limits.zig
@@ -8,9 +8,13 @@ const canvas = @import("canvas");
 // markdown detail pane + run surface): it spent more design effort
 // budgeting nodes than building UI at the old 256-node cap. The
 // widget-node budget quadrupled (256 -> 1024: the measured worst realistic
-// three-pane view is ~500 nodes, so 1024 leaves comfortable headroom), and
-// the frame-content budgets doubled (commands 1024 -> 2048, glyphs
-// 4096 -> 8192, text 16 KiB -> 32 KiB: visible content per frame grows with
+// three-pane view is ~500 nodes, so 1024 leaves comfortable headroom), later
+// doubled (1024 -> 2048) after a production three-pane app — a ~50-row
+// session sidebar, a streaming detail timeline, and a dialog enumerating
+// ~60 model rows — measured 1036 nodes on its dialog frame; at the 1024
+// cap the adoption failure discarded whole frames, leaving controls
+// visibly dead. The frame-content budgets doubled (commands 1024 -> 2048,
+// glyphs 4096 -> 8192, text 16 KiB -> 32 KiB: visible content per frame grows with
 // surface density, not with the retained-node cap — a full-height monospace
 // diff pane is ~7200 glyphs). Memory cost is fixed-capacity address space
 // in the Runtime (in-place constructed, large fields left uninitialized),
@@ -174,13 +178,13 @@ pub const max_media_surface_pixel_bytes: usize = 8 * 1024 * 1024;
 pub const max_registered_canvas_fonts: usize = 8;
 pub const max_registered_canvas_font_bytes: usize = 24 * 1024 * 1024;
 
-// The retained widget-tree budgets (raised 256 -> 1024; see the header
+// The retained widget-tree budgets (raised 256 -> 1024 -> 2048; see the
 // comment). `automation.snapshot.max_widgets_per_view`
 // mirrors the node cap so snapshots never silently truncate widget
 // enumeration; a test in canvas_widget_layout_tests.zig keeps them in
 // lockstep.
-pub const max_canvas_widget_nodes_per_view: usize = 1024;
-pub const max_canvas_widget_semantics_per_view: usize = 1024;
+pub const max_canvas_widget_nodes_per_view: usize = 2048;
+pub const max_canvas_widget_semantics_per_view: usize = 2048;
 // Raised from 2048 with the inline-span/markdown work, then from 64 KiB for
 // editable code surfaces: a simple editor must retain a practical source
 // file (roughly 10k ordinary code lines) plus the surrounding view chrome.
@@ -210,7 +214,7 @@ pub const max_canvas_widget_spans_per_view: usize = 1024;
 // fast — a 24-row sidebar with 4 items + separator per row, a detail-pane
 // menu, and per-step ledger menus measured 124/128 before the app was
 // finished. Quadrupled (128 -> 512)
-// so declared menus scale with the 1024-node budget instead of becoming
+// so declared menus scale with the 2048-node budget instead of becoming
 // the next design-effort cliff. Memory cost is one 24-byte entry (a
 // 16-byte label slice + enabled/separator flags) per slot: 24 B x 512 =
 // 12 KiB per view (was 3 KiB at 128), x 32 view slots = 384 KiB total


### PR DESCRIPTION
Fixes #408.

## What

Doubles the retained per-view widget budgets:

- `canvas_limits.max_canvas_widget_nodes_per_view` 1024 → 2048
- `canvas_limits.max_canvas_widget_semantics_per_view` 1024 → 2048
- `automation.snapshot.max_widgets_per_view` in lockstep (the existing lockstep test in `canvas_widget_layout_tests.zig` enforces the mirror)

## Why

The 1024 cap was sized against "the measured worst realistic three-pane view is ~500 nodes". Real list-dense views blow past that: our production app (session rail enumerating ~50 rows, streaming detail timeline, model-picker dialog listing ~60 models with provider-group headers) measures **1036/1024 nodes** on its dialog frame — 12 nodes over.

The failure mode is much worse than "fail loudly": `adoptWidgetLayout` → `WidgetLayoutListFull` discards the whole rebuild, so the interaction that pushed the view over budget (opening a dialog) appears to do nothing — controls look dead — and any view that sits over budget drops every subsequent frame, wedging its interactions entirely.

2048 covers the measured view with ~2x headroom. These are validation bounds over fixed-capacity address space (pages touched only as used), so the raise costs address space, not committed memory.

## Why not 4096

Tried it first. The session record/replay tests (`session_tests`, `media_surface_tests`, `effects_video_tests`, …) inline record+replay harnesses and UiApp constructions into a single test function; on macOS those frames already run ~11 MiB of stack at 1024, and 4096 pushes them to ~17 MiB — past the main-thread stack limit: 53 tests crash with SIGSEGV at frame entry. At 2048 `zig build test` is green.

Longer term, apps retaining unbounded collections will outgrow any fixed cap; windowed retention for list widgets would remove the cliff. (Happy to open a separate issue for that.)

## Test

`zig build test` (zig 0.16.0, macOS arm64): 3366/3381 pass, 14 skipped, 1 failed — the one failure (`ui_app_tests.test.a failed build keeps the still-matching pair live`) reproduces identically on unmodified `main` when the shard runs in isolation (markup-build cache-state flake), so it is not caused by this change.
