### PR TITLE
Preserve digit-only text literals in markup attributes

### DIFF
--- a/src/primitives/canvas/ui_markup_compiled.zig
+++ b/src/primitives/canvas/ui_markup_compiled.zig
@@ -505,7 +505,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                         return built;
                     },
                     .app => |spelled| options.icon = spelled,
-                    .binding => options.icon = stringAttr(node, entries, comptime node.attr("name").?, ui, model, scope, markup.icon_name_message),
+                    .binding => options.icon = stringAttr(node, entries, "name", comptime node.attr("name").?, ui, model, scope, markup.icon_name_message),
                     .invalid => unreachable,
                 }
                 return ui.el(kind, options, .{});
@@ -804,8 +804,8 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                     const expression = markup.parseAttrExpression(raw) orelse fail(node, markup.markdown_issue_link_base_message);
                     if (expression == .equals) fail(node, markup.markdown_issue_link_base_message);
                 }
-                comptime requireVariant(exprVariant(node, entries, raw), &.{.string}, node, markup.markdown_issue_link_base_message);
-                const base = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                comptime requireVariant(attrExprVariant(node, entries, "issue-link-base", raw), &.{.string}, node, markup.markdown_issue_link_base_message);
+                const base = switch (attrExprValue(node, entries, "issue-link-base", raw, ui, model, scope)) {
                     .string => |text| text,
                     else => runtimeFail([]const u8, ui),
                 };
@@ -905,7 +905,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 options.grow = floatAttr(node, entries, comptime node.attr("grow").?, ui, model, scope);
             }
             if (comptime (node.attr("label") != null)) {
-                options.semantics.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.semantics.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             if (comptime (node.attr("key") != null)) {
                 options.key = attrKey(node, entries, comptime node.attr("key").?, ui, model, scope, "keys must be integers or strings");
@@ -1049,7 +1049,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 options.global_key = attrKey(node, entries, comptime node.attr("global-key").?, ui, model, scope, "keys must be integers or strings");
             }
             if (comptime (node.attr("label") != null)) {
-                options.semantics.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.semantics.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             const slot_index: ?usize = comptime if (node.children.len == 1 and node.children[0].kind == .slot_block) innermostSlotIndex(entries) else null;
             if (comptime (node.children.len == 1 and node.children[0].kind == .slot_block and slot_index == null)) {
@@ -1121,7 +1121,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
             }
             var options: Ui.InputGroupOptions = .{};
             if (comptime (node.attr("label") != null)) {
-                options.semantics.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.semantics.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             if (comptime (node.attr("width") != null)) {
                 options.width = floatAttr(node, entries, comptime node.attr("width").?, ui, model, scope);
@@ -1205,7 +1205,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 options.global_key = attrKey(node, entries, comptime node.attr("global-key").?, ui, model, scope, "keys must be integers or strings");
             }
             if (comptime (node.attr("label") != null)) {
-                options.semantics.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.semantics.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             var children: std.ArrayListUnmanaged(Ui.Node) = .empty;
             buildChildren(node, entries, ui, model, scope, &children);
@@ -1235,22 +1235,22 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 }
             }
             var options: Ui.TimelineItemOptions = .{ .title = "" };
-            options.title = stringAttr(node, entries, comptime node.attr("title").?, ui, model, scope, markup.timeline_item_text_attr_message);
+            options.title = stringAttr(node, entries, "title", comptime node.attr("title").?, ui, model, scope, markup.timeline_item_text_attr_message);
             if (comptime (node.attr("description") != null)) {
-                options.description = stringAttr(node, entries, comptime node.attr("description").?, ui, model, scope, markup.timeline_item_text_attr_message);
+                options.description = stringAttr(node, entries, "description", comptime node.attr("description").?, ui, model, scope, markup.timeline_item_text_attr_message);
             }
             if (comptime (node.attr("meta") != null)) {
-                options.meta = stringAttr(node, entries, comptime node.attr("meta").?, ui, model, scope, markup.timeline_item_text_attr_message);
+                options.meta = stringAttr(node, entries, "meta", comptime node.attr("meta").?, ui, model, scope, markup.timeline_item_text_attr_message);
             }
             if (comptime (node.attr("indicator") != null)) {
-                options.indicator = stringAttr(node, entries, comptime node.attr("indicator").?, ui, model, scope, markup.timeline_item_text_attr_message);
+                options.indicator = stringAttr(node, entries, "indicator", comptime node.attr("indicator").?, ui, model, scope, markup.timeline_item_text_attr_message);
             }
             if (comptime (node.attr("icon") != null)) {
                 // Vector icon indicator: the shared icon value grammar,
                 // resolved at comptime like every icon attribute.
                 switch (comptime iconValueChecked(node, node.attr("icon").?, markup.button_icon_message)) {
                     .builtin, .app => |name| options.icon = name,
-                    .binding => options.icon = stringAttr(node, entries, comptime node.attr("icon").?, ui, model, scope, markup.button_icon_message),
+                    .binding => options.icon = stringAttr(node, entries, "icon", comptime node.attr("icon").?, ui, model, scope, markup.button_icon_message),
                     .invalid => unreachable,
                 }
             }
@@ -1384,7 +1384,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 options.global_key = attrKey(node, entries, comptime node.attr("global-key").?, ui, model, scope, "keys must be integers or strings");
             }
             if (comptime (node.attr("label") != null)) {
-                options.semantics.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.semantics.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             const series = ui.arena.alloc(canvas.ChartSeries, node.children.len) catch {
                 ui.failed = true;
@@ -1440,7 +1440,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 };
             }
             if (comptime (node.attr("label") != null)) {
-                series.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, markup.series_label_message);
+                series.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, markup.series_label_message);
             }
             return series;
         }
@@ -1469,7 +1469,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
             }
             var options: Ui.VideoOptions = .{};
             if (comptime (node.attr("src") != null)) {
-                options.src = stringAttr(node, entries, comptime node.attr("src").?, ui, model, scope, markup.video_src_message);
+                options.src = stringAttr(node, entries, "src", comptime node.attr("src").?, ui, model, scope, markup.video_src_message);
             }
             if (comptime (node.attr("controls") != null)) {
                 options.controls = videoFlagValue(node, entries, comptime node.attr("controls").?, ui, model, scope);
@@ -1493,7 +1493,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 options.grow = floatAttr(node, entries, comptime node.attr("grow").?, ui, model, scope);
             }
             if (comptime (node.attr("label") != null)) {
-                options.label = stringAttr(node, entries, comptime node.attr("label").?, ui, model, scope, "label expects text");
+                options.label = stringAttr(node, entries, "label", comptime node.attr("label").?, ui, model, scope, "label expects text");
             }
             if (comptime (node.attr("key") != null)) {
                 options.key = attrKey(node, entries, comptime node.attr("key").?, ui, model, scope, "keys must be integers or strings");
@@ -1594,9 +1594,9 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
             }
         }
 
-        fn stringAttr(comptime node: markup.MarkupNode, comptime entries: []const ScopeEntry, comptime raw: []const u8, ui: *Ui, model: *const ModelT, scope: anytype, comptime message: []const u8) []const u8 {
-            comptime requireVariant(exprVariant(node, entries, raw), &.{.string}, node, message);
-            return switch (evalExpr(node, entries, raw, ui, model, scope)) {
+        fn stringAttr(comptime node: markup.MarkupNode, comptime entries: []const ScopeEntry, comptime attribute_name: []const u8, comptime raw: []const u8, ui: *Ui, model: *const ModelT, scope: anytype, comptime message: []const u8) []const u8 {
+            comptime requireVariant(attrExprVariant(node, entries, attribute_name, raw), &.{.string}, node, message);
+            return switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                 .string => |text| text,
                 else => runtimeFail([]const u8, ui),
             };
@@ -1887,8 +1887,8 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 } else if (comptime std.mem.eql(u8, attribute.name, "role")) {
                     options.semantics.role = roleValue(node, entries, attribute.value, ui, model, scope);
                 } else if (comptime std.mem.eql(u8, attribute.name, "label")) {
-                    comptime requireVariant(exprVariant(node, entries, attribute.value), &.{.string}, node, "label expects text");
-                    options.semantics.label = switch (evalExpr(node, entries, attribute.value, ui, model, scope)) {
+                    comptime requireVariant(attrExprVariant(node, entries, attribute.name, attribute.value), &.{.string}, node, "label expects text");
+                    options.semantics.label = switch (attrExprValue(node, entries, attribute.name, attribute.value, ui, model, scope)) {
                         .string => |text| text,
                         else => runtimeFail([]const u8, ui),
                     };
@@ -1929,7 +1929,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                     comptime if (!markup.iconAttrElement(node.name)) fail(node, markup.button_icon_element_message);
                     switch (comptime iconValueChecked(node, attribute.value, markup.button_icon_message)) {
                         .builtin, .app => |name| options.icon = name,
-                        .binding => options.icon = stringAttr(node, entries, attribute.value, ui, model, scope, markup.button_icon_message),
+                        .binding => options.icon = stringAttr(node, entries, attribute.name, attribute.value, ui, model, scope, markup.button_icon_message),
                         .invalid => unreachable,
                     }
                 } else if (comptime std.mem.eql(u8, attribute.name, "anchor")) {
@@ -1972,7 +1972,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 } else if (comptime std.mem.eql(u8, attribute.name, "radius")) {
                     options.style_tokens.radius = comptime radiusTokenRef(node, attribute.value);
                 } else {
-                    setOption(node, comptime optionFieldName(node, attribute.name), attribute.value, entries, ui, model, scope, options);
+                    setOption(node, comptime optionFieldName(node, attribute.name), attribute.name, attribute.value, entries, ui, model, scope, options);
                 }
             }
         }
@@ -2117,24 +2117,24 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
             }
         }
 
-        fn setOption(comptime node: markup.MarkupNode, comptime zig_field: []const u8, comptime raw: []const u8, comptime entries: []const ScopeEntry, ui: *Ui, model: *const ModelT, scope: anytype, options: *Ui.ElementOptions) void {
+        fn setOption(comptime node: markup.MarkupNode, comptime zig_field: []const u8, comptime attribute_name: []const u8, comptime raw: []const u8, comptime entries: []const ScopeEntry, ui: *Ui, model: *const ModelT, scope: anytype, options: *Ui.ElementOptions) void {
             const FieldType = @FieldType(Ui.ElementOptions, zig_field);
-            const variant = comptime exprVariant(node, entries, raw);
+            const variant = comptime attrExprVariant(node, entries, attribute_name, raw);
             switch (comptime @typeInfo(FieldType)) {
                 .float => {
                     comptime requireVariant(variant, &.{ .float, .integer }, node, "expected a number");
-                    @field(options, zig_field) = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                    @field(options, zig_field) = switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                         .float => |float| float,
                         .integer => |int| @floatFromInt(int),
                         else => runtimeFail(FieldType, ui),
                     };
                 },
-                .bool => @field(options, zig_field) = evalExpr(node, entries, raw, ui, model, scope).truthy(),
+                .bool => @field(options, zig_field) = attrExprValue(node, entries, attribute_name, raw, ui, model, scope).truthy(),
                 .optional => |optional| switch (@typeInfo(optional.child)) {
-                    .bool => @field(options, zig_field) = evalExpr(node, entries, raw, ui, model, scope).truthy(),
+                    .bool => @field(options, zig_field) = attrExprValue(node, entries, attribute_name, raw, ui, model, scope).truthy(),
                     .float => {
                         comptime requireVariant(variant, &.{ .float, .integer }, node, "expected a number");
-                        @field(options, zig_field) = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                        @field(options, zig_field) = switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                             .float => |float| float,
                             .integer => |int| @floatFromInt(int),
                             else => runtimeFail(optional.child, ui),
@@ -2152,7 +2152,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                     // @intCast TRAPPED on it instead of failing the
                     // build. The field type is the honest upper bound;
                     // no semantic cap is invented on top of it.
-                    @field(options, zig_field) = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                    @field(options, zig_field) = switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                         .integer => |int| if (int < 0 or int > std.math.maxInt(FieldType)) runtimeFail(FieldType, ui) else @intCast(int),
                         else => runtimeFail(FieldType, ui),
                     };
@@ -2165,7 +2165,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                         // is a compile error, not a failed rebuild.
                         @field(options, zig_field) = comptime (std.meta.stringToEnum(FieldType, expression.literal) orelse fail(node, "unknown option value"));
                     } else {
-                        const text = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                        const text = switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                             .string => |text| text,
                             else => runtimeFail([]const u8, ui),
                         };
@@ -2174,7 +2174,7 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                 },
                 .pointer => {
                     comptime requireVariant(variant, &.{.string}, node, "expected text");
-                    @field(options, zig_field) = switch (evalExpr(node, entries, raw, ui, model, scope)) {
+                    @field(options, zig_field) = switch (attrExprValue(node, entries, attribute_name, raw, ui, model, scope)) {
                         .string => |text| text,
                         else => runtimeFail(FieldType, ui),
                     };
@@ -2527,6 +2527,14 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
 
         const invalid_expression_message = markup.invalid_expression_message;
 
+        fn attrExprValue(comptime node: markup.MarkupNode, comptime entries: []const ScopeEntry, comptime attribute_name: []const u8, comptime raw: []const u8, ui: *Ui, model: *const ModelT, scope: anytype) Value {
+            const expression = comptime (markup.parseAttrExpression(raw) orelse fail(node, invalid_expression_message));
+            if (comptime (expression == .literal)) {
+                return comptime interpreter.literalValueForAttribute(expression.literal, attribute_name);
+            }
+            return evalExpr(node, entries, raw, ui, model, scope);
+        }
+
         fn evalExpr(comptime node: markup.MarkupNode, comptime entries: []const ScopeEntry, comptime raw: []const u8, ui: *Ui, model: *const ModelT, scope: anytype) Value {
             const expression = comptime (markup.parseAttrExpression(raw) orelse fail(node, invalid_expression_message));
             if (comptime (expression == .literal)) {
@@ -2651,6 +2659,21 @@ fn CompiledMarkupEngine(comptime ModelT: type, comptime MsgT: type, comptime res
                     .equals => .boolean,
                     .expression => |inner| expressionTreeVariant(node, entries, inner),
                 };
+            }
+        }
+
+        fn attrExprVariant(comptime node: markup.MarkupNode, comptime entries: []const ScopeEntry, comptime attribute_name: []const u8, comptime raw: []const u8) ?ValueVariant {
+            comptime {
+                const expression = markup.parseAttrExpression(raw) orelse fail(node, invalid_expression_message);
+                if (expression == .literal) {
+                    return switch (interpreter.literalValueForAttribute(expression.literal, attribute_name)) {
+                        .string => .string,
+                        .integer => .integer,
+                        .float => .float,
+                        .boolean => .boolean,
+                    };
+                }
+                return exprVariant(node, entries, raw);
             }
         }
 

--- a/src/primitives/canvas/ui_markup_compiled_tests.zig
+++ b/src/primitives/canvas/ui_markup_compiled_tests.zig
@@ -170,6 +170,32 @@ const selection_label_content_markup =
 ;
 const SelectionLabelContentCompiled = canvas.CompiledMarkupView(fixture.Model, fixture.Msg, selection_label_content_markup);
 
+const digit_text_attribute_markup =
+    \\<column padding="8">
+    \\  <text-field placeholder="123" label="456" />
+    \\</column>
+;
+const DigitTextAttributeCompiled = canvas.CompiledMarkupView(fixture.Model, fixture.Msg, digit_text_attribute_markup);
+
+test "compiled digit-only text attributes stay text while numeric attributes stay numeric" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const model = fixture.Model{};
+
+    var interpreter = try InboxInterpreter.init(arena, digit_text_attribute_markup);
+    var interpreter_ui = InboxUi.init(arena);
+    const interpreted = try interpreter_ui.finalize(try interpreter.build(&interpreter_ui, &model));
+    var compiled_ui = InboxUi.init(arena);
+    const compiled = try compiled_ui.finalize(DigitTextAttributeCompiled.build(&compiled_ui, &model));
+
+    try expectSameTree(fixture.Msg, interpreted, compiled);
+    const field = fixture.findByKind(compiled.root, .text_field).?;
+    try testing.expectEqualStrings("123", field.placeholder);
+    try testing.expectEqualStrings("456", field.semantics.label);
+    try testing.expectEqual(@as(f32, 8), compiled.root.layout.padding.top);
+}
+
 test "checkbox and radio element content builds identically in both markup engines" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/src/primitives/canvas/ui_markup_contract.zig
+++ b/src/primitives/canvas/ui_markup_contract.zig
@@ -774,12 +774,15 @@ const Checker = struct {
     /// against the contract and the whole expression run through the
     /// shared type checker with those kinds — `{count > 'a'}` fails here
     /// with the evaluator's teaching message and the model field's type.
-    fn attrKind(self: *Checker, node: markup.MarkupNode, attribute: markup.MarkupAttr, raw: []const u8) CheckErr!?ValueKind {
+    fn expressionKind(self: *Checker, node: markup.MarkupNode, attribute: markup.MarkupAttr, raw: []const u8, attribute_aware: bool) CheckErr!?ValueKind {
         const expression = markup.parseAttrExpression(raw) orelse {
             return self.failAttr(node, attribute, markup.invalid_expression_message);
         };
         return switch (expression) {
-            .literal => |text| expr.kindOf(reflect.literalValue(text)),
+            .literal => |text| expr.kindOf(if (attribute_aware)
+                reflect.literalValueForAttribute(text, attribute.name)
+            else
+                reflect.literalValue(text)),
             .binding => |path| (try self.resolveBinding(node, path, true)).kind,
             .equals => |sides| blk: {
                 // Arena-computed bindings are excluded from equality on
@@ -791,6 +794,14 @@ const Checker = struct {
             },
             .expression => |inner| try self.exprTreeKind(node, inner),
         };
+    }
+
+    fn attrKind(self: *Checker, node: markup.MarkupNode, attribute: markup.MarkupAttr, raw: []const u8) CheckErr!?ValueKind {
+        return self.expressionKind(node, attribute, raw, true);
+    }
+
+    fn unclassifiedKind(self: *Checker, node: markup.MarkupNode, attribute: markup.MarkupAttr, raw: []const u8) CheckErr!?ValueKind {
+        return self.expressionKind(node, attribute, raw, false);
     }
 
     fn exprTreeKind(self: *Checker, node: markup.MarkupNode, inner: []const u8) CheckErr!?ValueKind {
@@ -1120,7 +1131,7 @@ const Checker = struct {
                 }
             }
         }
-        return .{ .value = try self.attrKind(node, attribute, attribute.value) };
+        return .{ .value = try self.unclassifiedKind(node, attribute, attribute.value) };
     }
 
     fn checkSlot(self: *Checker, node: markup.MarkupNode) CheckErr!void {

--- a/src/primitives/canvas/ui_markup_contract_tests.zig
+++ b/src/primitives/canvas/ui_markup_contract_tests.zig
@@ -203,6 +203,15 @@ const fixtures = [_]Fixture{
         .expect = null,
     },
     .{
+        .name = "digit-only text attributes remain text",
+        .source =
+        \\<column padding="8">
+        \\  <text-field placeholder="123" label="456" />
+        \\</column>
+        ,
+        .expect = null,
+    },
+    .{
         .name = "a missing model field rejects",
         .source =
         \\<column>

--- a/src/primitives/canvas/ui_markup_reflect.zig
+++ b/src/primitives/canvas/ui_markup_reflect.zig
@@ -12,6 +12,7 @@
 
 const std = @import("std");
 const expr = @import("ui_markup_expr.zig");
+const schema = @import("ui_schema.zig");
 
 /// Comptime walks over an app's Model and Msg scale with the type's
 /// field/decl count, and the default 1000-backwards-branch quota dies at
@@ -448,4 +449,16 @@ pub fn literalValue(text: []const u8) expr.Value {
     if (std.fmt.parseInt(i64, text, 10)) |int| return .{ .integer = int } else |_| {}
     if (std.fmt.parseFloat(f32, text)) |float| return .{ .float = float } else |_| {}
     return .{ .string = text };
+}
+
+/// A bare attribute literal keeps the schema's declared text shape. Text
+/// attributes are the one exception to the general literal inference above:
+/// `placeholder="123"` is text, while numeric, whole-number, flag, option,
+/// and key attributes retain their existing inference and truthiness rules.
+/// Expression literals and template defaults intentionally continue to use
+/// `literalValue` directly.
+pub fn literalValueForAttribute(text: []const u8, attribute_name: []const u8) expr.Value {
+    const info = schema.attrByName(attribute_name) orelse return literalValue(text);
+    if (info.class == .text) return .{ .string = text };
+    return literalValue(text);
 }

--- a/src/primitives/canvas/ui_markup_view.zig
+++ b/src/primitives/canvas/ui_markup_view.zig
@@ -1741,7 +1741,7 @@ pub fn MarkupView(comptime ModelT: type, comptime MsgT: type) type {
                     }
                 }
             }
-            return .{ .value = try self.evalAttrExpression(scope, node, attribute) };
+            return .{ .value = try self.evalUnclassifiedExpression(scope, node, attribute) };
         }
 
         fn failPayload(self: *Self, node: markup.MarkupNode, message: []const u8) BuildError {
@@ -2443,9 +2443,12 @@ pub fn MarkupView(comptime ModelT: type, comptime MsgT: type) type {
         /// classified (and its expression tree parsed) once at document
         /// level, not per frame per use — the typed-document pass's whole
         /// point for the interpreter.
-        fn evalAttrExpression(self: *Self, scope: *Scope, node: markup.MarkupNode, attribute: markup.MarkupAttr) BuildError!Value {
+        fn evalAttributeExpression(self: *Self, scope: *Scope, node: markup.MarkupNode, attribute: markup.MarkupAttr, attribute_aware: bool) BuildError!Value {
             return switch (markup.attrTyped(attribute)) {
-                .literal => |text| literalValue(text),
+                .literal => |text| if (attribute_aware)
+                    literalValueForAttribute(text, attribute.name)
+                else
+                    literalValue(text),
                 .binding => |path| try self.evalBinding(scope, node, path, true),
                 // Arena-computed bindings are excluded from equality on
                 // purpose: comparing freshly formatted strings is a smell —
@@ -2457,6 +2460,14 @@ pub fn MarkupView(comptime ModelT: type, comptime MsgT: type) type {
                 .expression => |form| try self.evalExpressionForm(scope, node, form),
                 .message, .invalid => self.failValue(node, markup.invalid_expression_message),
             };
+        }
+
+        fn evalAttrExpression(self: *Self, scope: *Scope, node: markup.MarkupNode, attribute: markup.MarkupAttr) BuildError!Value {
+            return self.evalAttributeExpression(scope, node, attribute, true);
+        }
+
+        fn evalUnclassifiedExpression(self: *Self, scope: *Scope, node: markup.MarkupNode, attribute: markup.MarkupAttr) BuildError!Value {
+            return self.evalAttributeExpression(scope, node, attribute, false);
         }
 
         /// A typed expression: use the pre-parsed tree when the pass
@@ -2893,6 +2904,7 @@ pub fn valueOf(comptime T: type, value: T) ?Value {
 }
 
 pub const literalValue = reflect.literalValue;
+pub const literalValueForAttribute = reflect.literalValueForAttribute;
 
 /// Display-text formatting for interpolation and `++` concatenation:
 /// defined once in the expression core so both engines (and the evaluator

--- a/src/primitives/canvas/ui_markup_view_tests.zig
+++ b/src/primitives/canvas/ui_markup_view_tests.zig
@@ -216,6 +216,24 @@ test "markup view builds the same tree as the hand-written view" {
     );
 }
 
+test "digit-only text attributes stay text while numeric attributes stay numeric" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var view = try InboxMarkup.init(
+        arena,
+        "<column padding=\"8\">\n  <text-field placeholder=\"123\" label=\"456\" />\n</column>",
+    );
+    var ui = InboxUi.init(arena);
+    const tree = try ui.finalize(try view.build(&ui, &Model{}));
+    const field = findByKind(tree.root, .text_field).?;
+
+    try testing.expectEqualStrings("123", field.placeholder);
+    try testing.expectEqualStrings("456", field.semantics.label);
+    try testing.expectEqual(@as(f32, 8), tree.root.layout.padding.top);
+}
+
 test "markup keyed rows keep ids across model changes and filters dispatch" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
Markup inferred every bare literal numerically before applying attribute types, so values like `placeholder="123"` or `label="456"` could reject the view and leave a blank window.

This change adds schema-aware literal classification shared by the interpreter, compiled engine, and contract checker. Text attributes remain strings while numeric, flag, option, and key attributes retain their existing behavior, with parity coverage for all three paths.